### PR TITLE
Performance Improvements

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -206,7 +206,7 @@ class Application @Inject() (val messagesApi: MessagesApi,
             "name" -> task.name,
             "instruction" -> task.instruction,
             "location" -> task.location.toString,
-            "status" -> task.status.getOrElse(0).toString,
+            "status" -> Task.getStatusName(task.status.getOrElse(0)).getOrElse("Unknown"),
             "actions" -> task.id.toString
           ))
 

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -63,6 +63,10 @@ class Config @Inject() (implicit val application:Application) {
 
   lazy val getSemanticVersion : String =
     this.config.getString(Config.KEY_SEMANTIC_VERSION).getOrElse("N/A")
+
+  lazy val sessionTimeout : Long = this.config.getLong(Config.KEY_SESSION_TIMEOUT).getOrElse(Config.DEFAULT_SESSION_TIMEOUT)
+
+  lazy val taskReset : Int = this.config.getInt(Config.KEY_TASK_RESET).getOrElse(Config.DEFAULT_TASK_RESET)
 }
 
 object Config {
@@ -75,6 +79,8 @@ object Config {
   val KEY_NUM_OF_CHALLENGES = s"$GROUP_MAPROULETTE.limits.challenges"
   val KEY_RECENT_ACTIVITY = s"$GROUP_MAPROULETTE.limits.activities"
   val KEY_SEMANTIC_VERSION = s"$GROUP_MAPROULETTE.version"
+  val KEY_SESSION_TIMEOUT = s"$GROUP_MAPROULETTE.session.timeout"
+  val KEY_TASK_RESET = s"$GROUP_MAPROULETTE.task.reset"
 
   val GROUP_OSM = "osm"
   val KEY_OSM_SERVER = s"$GROUP_OSM.server"
@@ -88,6 +94,8 @@ object Config {
   val KEY_OSM_QL_PROVIDER = s"$GROUP_OSM.ql.provider"
   val KEY_OSM_QL_TIMEOUT = s"$GROUP_OSM.ql.timeout"
 
+  val DEFAULT_SESSION_TIMEOUT = 3600000L
+  val DEFAULT_TASK_RESET= 7
   val DEFAULT_OSM_QL_TIMEOUT = 25
   val DEFAULT_NUM_OF_CHALLENGES = 3
   val DEFAULT_RECENT_ACTIVITY = 5

--- a/app/org/maproulette/models/dal/BaseDAL.scala
+++ b/app/org/maproulette/models/dal/BaseDAL.scala
@@ -96,7 +96,8 @@ trait BaseDAL[Key, T<:BaseObject[Key]] extends DALHelper with TransactionManager
 
   /**
     * This is a merge update function that will update the function if it exists otherwise it will
-    * insert a new item.
+    * insert a new item. By default unless the implementing class overrides this function, the
+    * mergeUpdate will simply attempt an insert
     *
     * @param element The element that needs to be inserted or updated. Although it could be updated,
     *                it requires the element itself in case it needs to be inserted
@@ -105,11 +106,15 @@ trait BaseDAL[Key, T<:BaseObject[Key]] extends DALHelper with TransactionManager
     * @param c A connection to execute against
     * @return
     */
-  def mergeUpdate(element: T, user:User)(implicit id:Key, c:Connection=null) : Option[T]
+  def mergeUpdate(element: T, user:User)(implicit id:Key, c:Connection=null) : Option[T] =
+    Some(insert(element, user))
 
   /**
     * Update function that must be implemented by the class that mixes in this trait. This update
-    * function updates based on the name instead of the id
+    * function updates based on the name instead of the id. This is the default update function,
+    * the downside of this function is that it will first retrieve the item from cache and then
+    * attempt to update it. For a more efficient method, the implementing class would need to
+    * override this and then execute the update function filtering on the name and parentId.
     *
     * @param updates The updates in json form
     * @param user The user executing the update

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -122,24 +122,6 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL, overri
   }
 
   /**
-    * This is a merge update function that will update the function if it exists otherwise it will
-    * insert a new item.
-    *
-    * @param element The element that needs to be inserted or updated. Although it could be updated,
-    *                it requires the element itself in case it needs to be inserted
-    * @param user    The user that is executing the function
-    * @param id      The id of the element that is being updated/inserted
-    * @param c       A connection to execute against
-    * @return
-    */
-  override def mergeUpdate(element: Challenge, user: User)(implicit id: Long, c: Connection): Option[Challenge] = {
-    element.hasWriteAccess(user)
-    withMRTransaction { implicit c =>
-      None
-    }
-  }
-
-  /**
     * Gets the featured challenges
     *
     * @param limit The number of challenges to retrieve

--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -96,25 +96,6 @@ class ProjectDAL @Inject() (override val db:Database,
     }
   }
 
-
-  /**
-    * This is a merge update function that will update the function if it exists otherwise it will
-    * insert a new item.
-    *
-    * @param element The element that needs to be inserted or updated. Although it could be updated,
-    *                it requires the element itself in case it needs to be inserted
-    * @param user    The user that is executing the function
-    * @param id      The id of the element that is being updated/inserted
-    * @param c       A connection to execute against
-    * @return
-    */
-  override def mergeUpdate(element: Project, user: User)(implicit id: Long, c: Connection): Option[Project] = {
-    element.hasWriteAccess(user)
-    withMRTransaction { implicit c =>
-      None
-    }
-  }
-
   /**
     * Gets a list of all projects that are specific managed by the supplied user
     *

--- a/app/org/maproulette/models/dal/SurveyDAL.scala
+++ b/app/org/maproulette/models/dal/SurveyDAL.scala
@@ -126,24 +126,6 @@ class SurveyDAL @Inject() (override val db:Database,
   }
 
   /**
-    * This is a merge update function that will update the function if it exists otherwise it will
-    * insert a new item.
-    *
-    * @param element The element that needs to be inserted or updated. Although it could be updated,
-    *                it requires the element itself in case it needs to be inserted
-    * @param user    The user that is executing the function
-    * @param id      The id of the element that is being updated/inserted
-    * @param c       A connection to execute against
-    * @return
-    */
-  override def mergeUpdate(element: Survey, user: User)(implicit id: Long, c: Connection): Option[Survey] = {
-    element.hasWriteAccess(user)
-    withMRTransaction { implicit c =>
-      None
-    }
-  }
-
-  /**
     * Answers a question by inserting a record in the survey_answers table. This will allow users
     * to answer the question for the same task multiple times. This way you will get an idea of the
     * answers based on multiple users feedback

--- a/app/org/maproulette/models/dal/TagDAL.scala
+++ b/app/org/maproulette/models/dal/TagDAL.scala
@@ -72,24 +72,6 @@ class TagDAL @Inject() (override val db:Database, tagCacheProvider: Provider[Tag
   }
 
   /**
-    * This is a merge update function that will update the function if it exists otherwise it will
-    * insert a new item.
-    *
-    * @param element The element that needs to be inserted or updated. Although it could be updated,
-    *                it requires the element itself in case it needs to be inserted
-    * @param user    The user that is executing the function
-    * @param id      The id of the element that is being updated/inserted
-    * @param c       A connection to execute against
-    * @return
-    */
-  override def mergeUpdate(element: Tag, user: User)(implicit id: Long, c: Connection=null): Option[Tag] = {
-    element.hasWriteAccess(user)
-    withMRTransaction { implicit c =>
-      None
-    }
-  }
-
-  /**
     * Get all the tags for a specific task
     *
     * @param id The id fo the task

--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -102,7 +102,7 @@ class SessionManager @Inject() (ws:WSClient, dalManager: DALManager, config:Conf
       token <- request.session.get(SessionManager.KEY_TOKEN)
       secret <- request.session.get(SessionManager.KEY_SECRET)
       tick <- request.session.get(SessionManager.KEY_USER_TICK)
-      if tick.toLong >= DateTime.now().getMillis - 1800000
+      if tick.toLong >= DateTime.now().getMillis - config.sessionTimeout
     } yield {
       RequestToken(token, secret)
     }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,6 +52,10 @@ play {
 maproulette {
   version="2.0.0"
   action.level=3
+  #session timeout in milliseconds, default 3600000
+  session.timeout=3600000
+  # number of days till we reset the status if it has not been fixed
+  task.reset=7
   #logo="/assets/images/companylogo.png"
   debug=true
   limits {

--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -319,6 +319,48 @@ CREATE TABLE IF NOT EXISTS locked
 
 SELECT create_index_if_not_exists('locked', 'item_type_item_id', '(item_type, item_id)', true);
 
+-- Creates or updates and task. Will also check if task status needs to be updated
+CREATE OR REPLACE FUNCTION create_update_task(task_name text, task_parent_id bigint, task_instruction text, task_status integer, task_id bigint DEFAULT -1, reset_interval INTERVAL DEFAULT '7 days') RETURNS integer as $$
+DECLARE
+  return_id integer;;
+BEGIN
+  return_id := task_id;;
+  IF (SELECT task_id) = -1 THEN
+    BEGIN
+      INSERT INTO tasks (name, parent_id, instruction) VALUES (task_name, task_parent_id, task_instruction) RETURNING id INTO return_id;;
+      EXCEPTION WHEN UNIQUE_VIOLATION THEN
+      SELECT INTO return_id update_task(task_name, task_parent_id, task_instruction, task_status, task_id, reset_interval);;
+    END;;
+  ELSE
+    SELECT update_task(task_name, task_parent_id, task_instruction, task_status, task_id, reset_interval);;
+  END IF;;
+  RETURN return_id;;
+END
+$$
+LANGUAGE plpgsql VOLATILE;;
+
+CREATE OR REPLACE FUNCTION update_task(task_name text, task_parent_id bigint, task_instruction text, task_status integer, task_id bigint DEFAULT -1, reset_interval INTERVAL DEFAULT '7 days') RETURNS integer as $$
+DECLARE
+  update_id integer;;
+  update_modified timestamp without time zone;;
+  update_status integer;;
+  new_status integer;;
+BEGIN
+  IF (SELECT task_id) = -1 THEN
+    SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+  ELSE
+    SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+  END IF;;
+  new_status := task_status;;
+  IF update_status = task_status AND (SELECT AGE(NOW(), update_modified)) > reset_interval THEN
+    new_status := 0;;
+  END IF;;
+  UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status WHERE id = update_id;;
+  RETURN update_id;;
+END
+$$
+LANGUAGE plpgsql VOLATILE;;
+
 -- Insert the default root, used for migration and those using the old API
 INSERT INTO projects (id, name, description) VALUES (0, 'SuperRootProject', 'Root Project for super users.');
 INSERT INTO groups(id, project_id, name, group_type)  VALUES (-999, 0, 'SUPERUSERS', -1);


### PR DESCRIPTION
Primarily performance improvements, on initial tests will import 2000 tasks in 2 seconds, which is down from 2000 tasks in roughly 15 seconds. 

Added some configuration for task reset and session timeout.

Added a task reset functionality that will reset the task status (back to created) if a task is uploaded (with currently the same status) after a set period.

