### PR TITLE
Integrated Swagger into MapRoulette. Now the endpoint /api/v2/docs wi…

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,20 +2,23 @@ package controllers
 
 import javax.inject.Inject
 
+import io.swagger.annotations.{Api, ApiOperation}
 import org.maproulette.Config
 import org.maproulette.actions._
 import org.maproulette.controllers.ControllerHelper
+import org.maproulette.exception.{StatusMessage, StatusMessages}
 import org.maproulette.models.{Survey, Task}
 import org.maproulette.models.dal._
 import org.maproulette.permissions.Permission
 import org.maproulette.session.{SessionManager, User}
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.libs.json.{JsNumber, Json}
+import play.api.libs.json.{JsNumber, JsString, Json}
 import play.api.mvc._
 import play.api.routing._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Promise
+import scala.util.parsing.json.JSONObject
 import scala.util.{Failure, Success}
 
 class Application @Inject() (val messagesApi: MessagesApi,
@@ -23,7 +26,7 @@ class Application @Inject() (val messagesApi: MessagesApi,
                              sessionManager:SessionManager,
                              override val dalManager: DALManager,
                              permission: Permission,
-                             val config:Config) extends Controller with I18nSupport with ControllerHelper {
+                             val config:Config) extends Controller with I18nSupport with ControllerHelper with StatusMessages {
 
   def clearCaches = Action.async { implicit request =>
     implicit val requireSuperUser = true
@@ -34,7 +37,7 @@ class Application @Inject() (val messagesApi: MessagesApi,
       dalManager.survey.clearCaches
       dalManager.task.clearCaches
       dalManager.tag.clearCaches
-      Ok(Json.obj("status" -> "OK", "message" -> "All caches cleared"))
+      Ok(Json.toJson(StatusMessage("OK", JsString("All caches cleared."))))
     }
   }
 

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -5,11 +5,11 @@ import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.controllers.ControllerHelper
-import org.maproulette.exception.{InvalidException, MPExceptionUtil, NotFoundException}
+import org.maproulette.exception._
 import org.maproulette.models.dal.DALManager
 import org.maproulette.session.{SessionManager, User}
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsString, Json}
 import play.api.mvc.{Action, Controller, Result}
 
 import scala.concurrent.Promise
@@ -24,7 +24,7 @@ class AuthController @Inject() (val messagesApi: MessagesApi,
                                 override val webJarAssets: WebJarAssets,
                                 sessionManager:SessionManager,
                                 override val dalManager:DALManager,
-                                val config:Config) extends Controller with I18nSupport with ControllerHelper {
+                                val config:Config) extends Controller with I18nSupport with ControllerHelper with StatusMessages {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -89,7 +89,7 @@ class AuthController @Inject() (val messagesApi: MessagesApi,
   def deleteUser(userId:Long) = Action.async { implicit request =>
     implicit val requireSuperUser = true
     sessionManager.authenticatedRequest { implicit user =>
-      Ok(Json.obj("message" -> s"${dalManager.user.delete(userId, user)} User deleted by super user ${user.name} [${user.id}]."))
+      Ok(Json.toJson(StatusMessage("OK", JsString(s"${dalManager.user.delete(userId, user)} User deleted by super user ${user.name} [${user.id}]."))))
     }
   }
 
@@ -133,7 +133,7 @@ class AuthController @Inject() (val messagesApi: MessagesApi,
             throw new InvalidException(s"User ${addUser.name} is already part of project $projectId")
           }
           dalManager.user.addUserToProject(addUser.osmProfile.id, projectId, user)
-          Ok(Json.obj("status" -> "Ok", "message" -> s"User ${addUser.name} added to project $projectId"))
+          Ok(Json.toJson(StatusMessage("OK", JsString(s"User ${addUser.name} added to project $projectId"))))
         case None => throw new NotFoundException(s"Could not find user with ID $userId")
       }
     }

--- a/app/org/maproulette/controllers/ParentController.scala
+++ b/app/org/maproulette/controllers/ParentController.scala
@@ -2,10 +2,10 @@ package org.maproulette.controllers
 
 import java.sql.Connection
 
+import org.maproulette.exception.StatusMessage
 import org.maproulette.models.BaseObject
 import org.maproulette.models.dal.ParentDAL
 import org.maproulette.session.User
-import org.maproulette.utils.Utils
 import play.api.Logger
 import play.api.libs.json._
 import play.api.mvc.{Action, BodyParsers}
@@ -119,7 +119,7 @@ trait ParentController[T<:BaseObject[Long], C<:BaseObject[Long]] extends CRUDCon
         case None =>
           val message = s"Bad id, no parent found with supplied id [$id]"
           Logger.error(message)
-          BadRequest(Json.obj("status" -> "KO", "message" -> message))
+          BadRequest(Json.toJson(StatusMessage("KO", JsString(message))))
       }
     }
   }
@@ -169,7 +169,7 @@ trait ParentController[T<:BaseObject[Long], C<:BaseObject[Long]] extends CRUDCon
         case JsSuccess(value, _) => Ok(value)
         case JsError(errors) =>
           Logger.error(JsError.toJson(errors).toString)
-          InternalServerError(Json.obj("status" -> "KO", "message" -> JsError.toJson(errors)))
+          InternalServerError(Json.toJson(StatusMessage("KO", JsError.toJson(errors))))
       }
     }
   }

--- a/app/org/maproulette/controllers/api/APIController.scala
+++ b/app/org/maproulette/controllers/api/APIController.scala
@@ -1,7 +1,9 @@
 package org.maproulette.controllers.api
 
 import javax.inject.Inject
-import play.api.libs.json.Json
+
+import org.maproulette.exception.{StatusMessage, StatusMessages}
+import play.api.libs.json.{JsString, Json}
 import play.api.mvc.{Action, Controller}
 
 /**
@@ -9,7 +11,7 @@ import play.api.mvc.{Action, Controller}
   *
   * @author cuthbertm
   */
-class APIController @Inject() extends Controller {
+class APIController @Inject() extends Controller with StatusMessages {
 
   /**
     * In the routes file this will be mapped to any /api/v2/ paths. It is the last mapping to take
@@ -19,7 +21,6 @@ class APIController @Inject() extends Controller {
     * @return A json object returned with a 400 BadRequest
     */
   def invalidAPIPath(path:String) = Action {
-    val message = s"Invalid Path [$path] for API"
-    BadRequest(Json.obj("status" -> "KO", "message" -> message))
+    BadRequest(Json.toJson(StatusMessage("KO", JsString(s"Invalid Path [$path] for API"))))
   }
 }

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -3,6 +3,7 @@ package org.maproulette.controllers.api
 import java.sql.Connection
 import javax.inject.Inject
 
+import io.swagger.annotations.Api
 import org.maproulette.actions.{ActionManager, Actions, ChallengeType, TaskViewed}
 import org.maproulette.controllers.ParentController
 import org.maproulette.models.dal.{ChallengeDAL, SurveyDAL, TagDAL, TaskDAL}
@@ -20,6 +21,7 @@ import play.api.mvc.Action
   *
   * @author cuthbertm
   */
+@Api(value = "/Challenge", description = "Operations for Challenges", protocols = "http")
 class ChallengeController @Inject() (override val childController:TaskController,
                                      override val sessionManager: SessionManager,
                                      override val actionManager: ActionManager,

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -2,6 +2,7 @@ package org.maproulette.controllers.api
 
 import javax.inject.Inject
 
+import io.swagger.annotations.Api
 import org.maproulette.actions.{ActionManager, ProjectType, TaskViewed}
 import org.maproulette.controllers.ParentController
 import org.maproulette.models.dal.{ProjectDAL, TaskDAL}
@@ -19,6 +20,7 @@ import play.api.mvc.{Action, AnyContent}
   *
   * @author cuthbertm
   */
+@Api(value = "/Project", description = "Operations for Projects", protocols = "http")
 class ProjectController @Inject() (override val childController:ChallengeController,
                                    override val sessionManager:SessionManager,
                                    override val actionManager: ActionManager,

--- a/app/org/maproulette/controllers/api/SurveyController.scala
+++ b/app/org/maproulette/controllers/api/SurveyController.scala
@@ -3,6 +3,7 @@ package org.maproulette.controllers.api
 import java.sql.Connection
 import javax.inject.Inject
 
+import io.swagger.annotations.Api
 import org.maproulette.actions._
 import org.maproulette.controllers.ParentController
 import org.maproulette.exception.NotFoundException
@@ -21,6 +22,7 @@ import play.api.mvc.Action
   *
   * @author cuthbertm
   */
+@Api(value = "/Survey", description = "Operations for Surveys", protocols = "http")
 class SurveyController @Inject() (override val childController:TaskController,
                                   override val sessionManager: SessionManager,
                                   override val actionManager: ActionManager,

--- a/app/org/maproulette/controllers/api/TagController.scala
+++ b/app/org/maproulette/controllers/api/TagController.scala
@@ -2,11 +2,12 @@ package org.maproulette.controllers.api
 
 import javax.inject.Inject
 
+import io.swagger.annotations.Api
 import org.maproulette.actions.{ActionManager, TagType}
 import org.maproulette.controllers.CRUDController
-import org.maproulette.models.Tag
+import org.maproulette.models.{Tag}
 import org.maproulette.models.dal.TagDAL
-import org.maproulette.session.{User, SessionManager}
+import org.maproulette.session.{SessionManager, User}
 import org.maproulette.utils.Utils
 import play.api.libs.json._
 import play.api.mvc.Action
@@ -18,6 +19,7 @@ import play.api.mvc.Action
   *
   * @author cuthbertm
   */
+@Api(value = "/Tag", description = "Operations for Tags", protocols = "http")
 class TagController @Inject() (override val sessionManager: SessionManager,
                                override val actionManager: ActionManager,
                                override val dal:TagDAL)

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -3,6 +3,7 @@ package org.maproulette.controllers.api
 import java.sql.Connection
 import javax.inject.Inject
 
+import io.swagger.annotations.{Api, ApiOperation}
 import org.maproulette.actions._
 import org.maproulette.controllers.CRUDController
 import org.maproulette.models.dal.{TagDAL, TaskDAL}
@@ -20,6 +21,7 @@ import play.api.mvc.Action
   *
   * @author cuthbertm
   */
+@Api(value = "/Task", description = "Operations for Tasks", protocols = "http")
 class TaskController @Inject() (override val sessionManager: SessionManager,
                                 override val actionManager: ActionManager,
                                 override val dal:TaskDAL,
@@ -103,6 +105,7 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
     * @param id The id of the task containing the tags
     * @return The html Result containing json array of tags
     */
+  @ApiOperation(value = "Gets the tags for ta task", nickname = "getTagsForTask", httpMethod = "GET")
   def getTagsForTask(implicit id: Long) = Action.async { implicit request =>
     sessionManager.userAwareRequest { implicit user =>
       Ok(Json.toJson(getTags(id)))

--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -3,12 +3,11 @@ package org.maproulette.exception
 import controllers.WebJarAssets
 import oauth.signpost.exception.OAuthNotAuthorizedException
 import org.maproulette.Config
-import org.maproulette.actions.ActionManager
-import org.maproulette.models.dal.{ChallengeDAL, DALManager}
+import org.maproulette.models.dal.DALManager
 import org.maproulette.session.User
 import play.api.Logger
 import play.api.i18n.Messages
-import play.api.libs.json.Json
+import play.api.libs.json.{JsString, Json}
 import play.api.mvc.{Request, Result}
 import play.api.mvc.Results._
 
@@ -35,16 +34,16 @@ object MPExceptionUtil {
     } catch {
       case e:InvalidException =>
         Logger.error(e.getMessage, e)
-        BadRequest(Json.obj("status" -> "KO", "message" -> e.getMessage))
+        BadRequest(Json.toJson(StatusMessage("KO", JsString(e.getMessage))))
       case e:IllegalAccessException =>
         Logger.error(e.getMessage, e)
-        Forbidden(Json.obj("status" -> "Forbidden", "Message" -> e.getMessage))
+        Forbidden(Json.toJson(StatusMessage("Forbidden", JsString(e.getMessage))))
       case e:NotFoundException =>
         Logger.error(e.getMessage, e)
-        NotFound(Json.obj("status" -> "NotFound", "message" -> e.getMessage))
+        NotFound(Json.toJson(StatusMessage("NotFound", JsString(e.getMessage))))
       case e:Exception =>
         Logger.error(e.getMessage, e)
-        InternalServerError(Json.obj("status" -> "KO", "message" -> e.getMessage))
+        InternalServerError(Json.toJson(StatusMessage("KO", JsString(e.getMessage))))
     }
   }
 
@@ -112,19 +111,19 @@ object MPExceptionUtil {
     e match {
       case e:InvalidException =>
         Logger.error(e.getMessage, e)
-        BadRequest(Json.obj("status" -> "KO", "message" -> e.getMessage))
+        BadRequest(Json.toJson(StatusMessage("KO", JsString(e.getMessage))))
       case e:OAuthNotAuthorizedException =>
         Logger.error(e.getMessage, e)
-        Unauthorized(Json.obj("status" -> "NotAuthorized", "message" -> e.getMessage)).withNewSession
+        Unauthorized(Json.toJson(StatusMessage("NotAuthorized", JsString(e.getMessage)))).withNewSession
       case e:IllegalAccessException =>
         Logger.error(e.getMessage, e)
-        Forbidden(Json.obj("status" -> "Forbidden", "message" -> e.getMessage))
+        Forbidden(Json.toJson(StatusMessage("Forbidden", JsString(e.getMessage))))
       case e:NotFoundException =>
         Logger.error(e.getMessage, e)
-        NotFound(Json.obj("status" -> "NotFound", "message" -> e.getMessage))
+        NotFound(Json.toJson(StatusMessage("NotFound", JsString(e.getMessage))))
       case e:Throwable =>
         Logger.error(e.getMessage, e)
-        InternalServerError(Json.obj("status" -> "KO", "message" -> e.getMessage))
+        InternalServerError(Json.toJson(StatusMessage("KO", JsString(e.getMessage))))
     }
   }
 

--- a/app/org/maproulette/exception/StatusMessage.scala
+++ b/app/org/maproulette/exception/StatusMessage.scala
@@ -1,0 +1,18 @@
+package org.maproulette.exception
+
+import play.api.libs.json.{JsValue, Json, Reads, Writes}
+
+/**
+  * @author cuthbertm
+  */
+trait StatusMessages {
+  implicit val statusMessageWrites = StatusMessage.statusMessageWrites
+  implicit val statusMessageReads = StatusMessage.statusMessageReads
+}
+
+case class StatusMessage(status:String, message:JsValue)
+
+object StatusMessage {
+  implicit val statusMessageWrites: Writes[StatusMessage] = Json.writes[StatusMessage]
+  implicit val statusMessageReads: Reads[StatusMessage] = Json.reads[StatusMessage]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,10 @@ version := "1.0"
 scalaVersion := "2.11.8"
 
 lazy val `MapRouletteV2` = (project in file("."))
-  .enablePlugins(PlayScala)
+  .enablePlugins(PlayScala).dependsOn(swagger)
   .enablePlugins(SbtWeb)
+
+lazy val swagger = RootProject(uri("ssh://git@github.com/CreditCardsCom/swagger-play.git"))
 
 pipelineStages := Seq(rjs, digest, gzip)
 
@@ -23,6 +25,7 @@ libraryDependencies ++= Seq(
   "net.postgis" % "postgis-jdbc" % "2.2.0",
   "joda-time" % "joda-time" % "2.9.2",
   "com.vividsolutions" % "jts" % "1.13",
+  "io.swagger" %% "swagger-play2" % "1.5.2-SNAPSHOT",
   "org.webjars" %% "webjars-play" % "2.5.0",
   "org.webjars" % "bootstrap" % "3.3.6",
   "org.webjars" % "font-awesome" % "4.5.0",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -115,6 +115,19 @@ play.http.parser.maxMemoryBuffer=150000K
 parsers.MultipartFormData.maxLength=150000K
 
 play.modules.enabled += "org.maproulette.jobs.JobModule"
+play.modules.enabled += "play.modules.swagger.SwaggerModule"
+
+api.version="2.0"
+swagger {
+  api.basepath="http://www.maproulette.org:8080/api/v2"
+  api.info {
+    contact="maproulette@maproulette.org"
+    description="API for MapRoulette enabling the creation and maintenance of MapRoulette challenges"
+    title="MapRoulette API"
+    license="Apache License version 2.0"
+    licenseUrl="http://www.apache.org/licenses/"
+  }
+}
 
 # Assets configuration
 # ~~~~~

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,8 @@ GET     /mapping/previousTask/:parentId/:id                             @control
 GET     /mapping/randomTask                                             @controllers.MappingController.getRandomNextTask(pid:Long ?= -1, ps:String ?= "", cid:Long ?= -1, ct:String ?= "", cs:String ?= "", tags:String ?= "", s:String ?= "")
 # DATA ROUTES
 
+# Swagger route
+GET     /api/v2/docs                                                    @controllers.ApiHelpController.getResources
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file                                                   @controllers.Assets.versioned(path="/public", file)
 GET     /webjars/*file                                                  @controllers.WebJarAssets.at(file)


### PR DESCRIPTION
…ll return a swagger json that can be used to in something like swagger-ui to get information about the Map Roulette API. The endpoints have not all been tagged correctly, so currently it is all the default information that is retrieved from the code. It also relies on a github repo that fixes an issue in swagger-play2, which will be removed as soon as the issue is merged into the master branch of https://github.com/swagger-api/swagger-play.