### PR TITLE
Changed name of distribution package

### DIFF
--- a/app/views/controls/rightSidebar.scala.html
+++ b/app/views/controls/rightSidebar.scala.html
@@ -6,7 +6,7 @@
 <ul class="nav nav-tabs nav-justified control-sidebar-tabs">
   <li class="active" id="control-sidebar-home-upper-tab"><a href="#control-sidebar-home-tab" data-toggle="tab"><i class="fa fa-wrench"></i></a></li>
   <li><a href="#control-sidebar-activity-tab" data-toggle="tab"><i class="fa fa-bars"></i></a></li>
-  <li><a href="#control-sidebar-settings-tab" data-toggle="tab"><i class="fa fa-gears"></i></a></li>
+  <!--li><a href="#control-sidebar-settings-tab" data-toggle="tab"><i class="fa fa-gears"></i></a></li-->
 </ul>
   <!-- Tab panes -->
 <div class="tab-content">
@@ -136,7 +136,7 @@
     </ul><!-- /.control-sidebar-menu -->
   </div>
     <!-- Settings tab content -->
-  <div class="tab-pane" id="control-sidebar-settings-tab">
+  <!--div class="tab-pane" id="control-sidebar-settings-tab">
     <form method="post">
       <h3 class="control-sidebar-heading">@messages("rightsidebar.general.header")</h3>
       <div class="form-group">
@@ -147,7 +147,7 @@
         <p>@messages("rightsidebar.general.info")</p>
       </div>
     </form>
-  </div>
+  </div-->
 </div>
 <script type="application/javascript">
   if (typeof MRManager === 'undefined') {

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "2.0.2"
 
 scalaVersion := "2.11.8"
 
+packageName in Universal := "MapRouletteV2"
+
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 
 compileScalastyle := org.scalastyle.sbt.ScalastylePlugin.scalastyle.in(Compile).toTask("").value

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -37,6 +37,7 @@ GET     /challenge/:cid/tasks/random                @org.maproulette.controllers
 GET     /challenge/:cid/tasks/randomTasks           @org.maproulette.controllers.api.ChallengeController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1)
 GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, filter:String ?= "")
 GET     /challenge/clustered/:id                    @org.maproulette.controllers.api.ChallengeController.getClusteredPoints(id:Long, filter:String ?= "")
+PUT     /challenge/:id/updateTaskPriorities         @org.maproulette.controllers.api.ChallengeController.updateTaskPriorities(id:Long)
 # Survey API
 POST    /survey                                     @org.maproulette.controllers.api.SurveyController.create
 POST    /surveys                                    @org.maproulette.controllers.api.SurveyController.batchUploadPost


### PR DESCRIPTION
There was an issue with deployment that was caused when the MapRouletteV2 distribution package's name was changed due to a version change. I updated the build file to always create the same distribution package name for consistency.

Also added an API call to update all the task priorities.