### PR TITLE
#161 url-encode the # in getCommentHashtags

### DIFF
--- a/app/assets/javascripts/mapping.js
+++ b/app/assets/javascripts/mapping.js
@@ -1099,7 +1099,7 @@ var MRManager = (function() {
 
     var getCommentHashtags = function() {
         // add comment specific to challenge, make sure the name has no whitespace
-        return "#maproulette%20" + currentTask.getChallenge().getData().name.replace(/ /g, "_");
+        return "%23maproulette%20" + currentTask.getChallenge().getData().name.replace(/ /g, "_");
     };
 
     var openTaskInId = function () {


### PR DESCRIPTION
This works in both iD and JOSM from in-browser testing. It's possible that it'd be better to urlencode the whole return value instead, but I'm not sure about the particular edge cases there.