### PR TITLE
Update dev setup instructions in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ For more details on the app registration process, see the [OSM OAuth wiki page](
 * Navigate into the newly created `maproulette2` directory and run the local development server: `activator run`. This will take some time the first run as dependencies are downloaded.
 * Head to [http://localhost:9000/](http://localhost:9000/) and confirm you can see the New MapRoulette front end. This also may take a while as artifacts are compiled.
 
+If you are having issues getting the activator to run, you can configure your instance with [dev.conf](#using-devconf)
+
 #### Linux
 
 > These instructions were written for Ubuntu 16.04
@@ -83,6 +85,23 @@ A work-in-progress setup guide for Windows lives [here](https://gist.github.com/
 #### Using dev.conf
 
 Another way to handle dev related configuration variables is to use the [dev.conf](conf/dev.conf) file which has a couple of prepopulated variables that would be beneficial for a test/development environment. To use this file you simply need to add the file as a jvm parameter, eg. -Dconfig.resource=dev.conf
+
+```
+activator run -Dconfig.resource=dev.conf
+```
+
+Your conf/dev.conf file should have the following:
+
+```
+include "application.conf"
+
+db.default.url="jdbc:postgresql://localhost:5432/mp_dev?user=osm&password=osm"
+maproulette.super.key="test"
+maproulette.super.accounts="*"
+osm.server="http://api06.dev.openstreetmap.org"
+osm.consumerKey=<APPLICATION_CONSUMER_KEY>
+osm.consumerSecret=<APPLICATION_CONSUMER_SECRET>
+```
 
 ## Creating new Challenges
 

--- a/README.md
+++ b/README.md
@@ -29,22 +29,36 @@ It uses the following core technologies:
 
 ### Local for test and development
 
+#### Register Dev App with OpenStreetMap
+
+Before beginning, you'll need to register an app with OpenStreetMap to get a consumer key and secret key. For development and testing, you may wish to do this on the [OSM dev server](http://master.apis.dev.openstreetmap.org) (you will need to setup a new user account if you have't used the dev server before).
+
+To register your app, login to your account, go to "My Settings", click on "oauth settings", and then click "Register your Application" near the bottom. Give your app a name and application URL (you can simply use http://localhost:9000 if desired) and leave the other URL fields blank. In the permissions section, check "read their user preferences" and then click the "Register" button at the bottom to get your consumer and secret keys. Be sure to take note of them.
+
+For more details on the app registration process, see the [OSM OAuth wiki page](http://wiki.openstreetmap.org/wiki/OAuth).
+
+
 #### Mac OSX
 
-* These instructions assume you have at least Mac OS 10.10 (Mavericks) and [Homebrew](http://brew.sh/) installed. We also assume that you have PostgreSQL 9.5 and PostGIS 2.2.1 installed. Homebrew provides packages for both, which we recommend.
+> These instructions assume you have at least Mac OS 10.10 (Mavericks) and [Homebrew](http://brew.sh/) installed. We also assume that you have at least PostgreSQL 9.5 and PostGIS 2.2.1 installed. Homebrew provides packages for both (`brew install postgresql` and `brew install postgis`), which we recommend.
+
 * Make sure you have a Java 8 JDK. Check with `java -version` which should mention an 1.8.x version number. [Get](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and install a Java 8 JDK if necessary.
 * Install the [Play Framework activator](https://www.playframework.com/documentation/2.5.x/Installing): `brew install typesafe-activator`.
 * Create a PostgreSQL superuser `osm`: `createuser -sW osm`. Use `osm` as the password.
 * Create a new PostgreSQL database `mp_dev` owned by `osm`: `createdb -O osm mp_dev`.
-* Set the database connection JDBC string as environment variable `DATABASE_URL`: `export DATABASE_URL='jdbc:postgresql://localhost:5432/mp_dev?user=osm&password=osm'`
-* Set the consumer_key and consumer_secret variables `CONSUMER_KEY`: `export CONSUMER_KEY=<APPLICATION_CONSUMER_KEY>`, `CONSUMER_SECRET`: `export CONSUMER_SECRET=<APPLICATION_CONSUMER_SECRET>`. This is the key and secret that is generated when you build your application in maproulette.org.
+* Setup your environment variables:
+    - Database connection JDBC string as `MR_DATABASE_URL`: `export MR_DATABASE_URL='jdbc:postgresql://localhost:5432/mp_dev?user=osm&password=osm'`
+    - Consumer key from [app registration](#register-dev-app-with-openstreetmap) as `MR_OAUTH_CONSUMER_KEY`: `export MR_OAUTH_CONSUMER_KEY=<APPLICATION_CONSUMER_KEY>`
+    - Consumer secret from [app registration](#register-dev-app-with-openstreetmap) as `MR_OAUTH_CONSUMER_SECRET`: `export MR_OAUTH_CONSUMER_SECRET=<APPLICATION_CONSUMER_SECRET>`
+    - OSM server URL as `MR_OSM_SERVER` if you wish to use the dev server (defaults to production): `export MR_OSM_SERVER='http://master.dev.openstreetmap.org'`
 * Clone New MapRoulette: `git clone https://github.com/maproulette/maproulette2.git`.
 * Navigate into the newly created `maproulette2` directory and run the local development server: `activator run`. This will take some time the first run as dependencies are downloaded.
 * Head to [http://localhost:9000/](http://localhost:9000/) and confirm you can see the New MapRoulette front end. This also may take a while as artifacts are compiled.
 
 #### Linux
 
-* These instructions were written for Ubuntu 16.04
+> These instructions were written for Ubuntu 16.04
+
 * Make sure you have a Java 8 JDK. Check with `java -version` which should mention a 1.8.x version number. 
 * If you don't have Java 8 JDK you can get it with the following command `sudo apt install openjdk-8-jdk`
 * Install the [Play Framework activator](https://www.playframework.com/documentation/2.5.x/Installing)
@@ -53,8 +67,11 @@ It uses the following core technologies:
 * Install PostgreSQL and PostGIS: `sudo apt install postgresql postgis`
 * Create a PostgreSQL superuser: `osm`: `sudo -u postgres createuser -sP osm`. Use `osm` as the password
 * Create a new PostgreSQL database `mp_dev` owned by `osm`: `sudo -u postgres createdb -O osm mp_dev`
-* Set the database connection JDBC string as an environment variable: `DATABASE_URL='jdbc:postgresql://localhost:5432/mp_dev?user=osm&password=osm'`
-* Set the consumer_key and consumer_secret variables `CONSUMER_KEY`: `export CONSUMER_KEY=<APPLICATION_CONSUMER_KEY>`, `CONSUMER_SECRET`: `export CONSUMER_SECRET=<APPLICATION_CONSUMER_SECRET>`. This is the key and secret that is generated when you build your application in maproulette.org.
+* Setup your environment variables:
+    - Database connection JDBC string as `MR_DATABASE_URL`: `export MR_DATABASE_URL='jdbc:postgresql://localhost:5432/mp_dev?user=osm&password=osm'`
+    - Consumer key from [app registration](#register-dev-app-with-openstreetmap) as `MR_OAUTH_CONSUMER_KEY`: `export MR_OAUTH_CONSUMER_KEY=<APPLICATION_CONSUMER_KEY>`
+    - Consumer secret from [app registration](#register-dev-app-with-openstreetmap) as `MR_OAUTH_CONSUMER_SECRET`: `export MR_OAUTH_CONSUMER_SECRET=<APPLICATION_CONSUMER_SECRET>`
+    - OpenStreetMap server URL as `MR_OSM_SERVER` if you wish to use the dev server (defaults to production): `export MR_OSM_SERVER=http://master.dev.openstreetmap.org`
 * Clone New MapRoulette: `git clone https://github.com/maproulette/maproulette2.git`.
 * Navigate into the newly created `maproulette2` directory and run the local development server: `activator run`. This will take some time the first run as dependencies are downloaded.
 * Head to [http://localhost:9000/](http://localhost:9000/) and confirm you can see the New MapRoulette front end. This also may take a while as artifacts are compiled.


### PR DESCRIPTION
- Add instructions for registering app with OSM to get consumer and secret keys.

- Update the documented environment variable names (which now start with MR_) in Mac and Linux sections, and mention the MR_OSM_SERVER variable for those who wish to connect to a development OSM server. However, there is a `start.sh` script that already exports the appropriate environment variables and runs the server, so I wonder if it'd be better to provide an example script and suggest devs copy it to a (gitignored) file that they customize?

- Include the commands for installing postgresql and postgis via homebrew in Mac section, just for completeness.

- Include sample dev.conf configuration in Using dev.conf section.