### PR TITLE
Enable hotkeys and add cheat sheet

### DIFF
--- a/app/assets/javascripts/mapping.js
+++ b/app/assets/javascripts/mapping.js
@@ -641,6 +641,7 @@ var MRManager = (function() {
             searchInFocus = false;
         });
         registerHotKeys();
+        setupHotKeysCheatSheet();
     };
 
     var updateMapOptions = function(mapElement, point, options) {
@@ -1055,49 +1056,88 @@ var MRManager = (function() {
     };
 
     // registers a series of hotkeys for quick access to functions
+    var hotkeys = {
+      81: { // Get next task, set current task to false positive
+        key: 'q',
+        description: Messages("mapping.js.control.falsepositive"),
+        action: function() {
+          if (!debugMode && !currentTask.getChallenge().isSurvey()) {
+              setTaskStatus(TaskStatus.FALSEPOSITIVE);
+          }
+        }
+      },
+      87: { // Get next task, skip current task
+        key: 'w',
+        description: Messages("mapping.js.control.skip"),
+        action: function() {
+          MRManager.getNextTask();
+        }
+      },
+      69: { // open task in ID
+        key: 'e',
+        description: Messages("mapping.js.control.edit.id"),
+        action: function() {
+          if (!debugMode && !currentTask.getChallenge().isSurvey()) {
+              openTaskInId();
+          }
+        }
+      },
+      82: { // open task in JOSM in current layer
+        key: 'r',
+        description: Messages("mapping.js.control.edit.josm"),
+        action: function() {
+          if (!debugMode && !currentTask.getChallenge().isSurvey()) {
+              openTaskInJosm(false);
+          }
+        }
+      },
+      84: { // Get next task, skip current task
+        key: 't',
+        description: Messages("mapping.js.control.edit.josm.layer"),
+        action: function() {
+          if (!debugMode && !currentTask.getChallenge().isSurvey()) {
+              openTaskInJosm(true);
+          }
+        }
+      },
+      27: { // remove open dialog
+        key: 'ESC',
+        description: Messages("mapping.js.control.edit.cancel"),
+        action: function() {
+          resetEditControls();
+        }
+      }
+    };
+
     var registerHotKeys = function() {
         $(document).keydown(function(e) {
-            if (disableKeys) {
-                return;
-            }
-            e.preventDefault();
-            switch(e.keyCode) {
-                case 81: //q
-                    // Get next task, set current task to false positive
-                    if (!debugMode && !currentTask.getChallenge().isSurvey()) {
-                        setTaskStatus(TaskStatus.FALSEPOSITIVE);
-                    }
-                    break;
-                case 87: //w
-                    // Get next task, skip current task
-                    MRManager.getNextTask();
-                    break;
-                case 69: //e
-                    // open task in ID
-                    if (!debugMode && !currentTask.getChallenge().isSurvey()) {
-                        openTaskInId();
-                    }
-                    break;
-                case 82: //r
-                    // open task in JOSM in current layer
-                    if (!debugMode && !currentTask.getChallenge().isSurvey()) {
-                        openTaskInJosm(false);
-                    }
-                    break;
-                case 84: //t
-                    // open task in JOSM in new layer
-                    if (!debugMode && !currentTask.getChallenge().isSurvey()) {
-                        openTaskInJosm(true);
-                    }
-                    break;
-                case 27: //esc
-                    // remove open dialog
-                    resetEditControls();
-                    break;
-                default:
-                    break;
-            }
+          e.preventDefault();
+
+          if (hotkeys[e.keyCode]) {
+            hotkeys[e.keyCode].action();
+          }
         });
+    };
+
+    var setupHotKeysCheatSheet = function() {
+      var cheatSheet = "<table id='cheat-sheet'>";
+      for (var shortcut in hotkeys) {
+          if (hotkeys.hasOwnProperty(shortcut)) {
+            cheatSheet += "<tr><td class='key'>" +
+                            hotkeys[shortcut].key +
+                          "</td><td class='description'>" +
+                            hotkeys[shortcut].description +
+                          "</td></tr>";
+          }
+      }
+      cheatSheet += "</table>";
+
+      $("#show-hotkeys").popover({
+        title: "Keyboard Shortcuts <span class='pull-right'><i class='fa fa-times'></i></span>",
+        content: cheatSheet,
+        html: true,
+        placement: 'top',
+      });
     };
 
     var constructIdUri = function () {

--- a/app/assets/javascripts/mapping.js
+++ b/app/assets/javascripts/mapping.js
@@ -1138,6 +1138,7 @@ var MRManager = (function() {
         html: true,
         placement: 'top',
       });
+      $("#hotkey-cheatsheet-link").show();
     };
 
     var constructIdUri = function () {

--- a/app/assets/stylesheets/mapping.less
+++ b/app/assets/stylesheets/mapping.less
@@ -101,3 +101,22 @@
   background-color:#00a;
   color:#fff;
 }
+
+#cheat-sheet {
+  min-width: 300px;
+
+  .key {
+    font-weight: bold;
+    padding-right: 20px;
+  }
+}
+
+#hotkey-cheatsheet-link {
+  position: absolute;
+  z-index: 800;
+  bottom: 52px;
+  left: 50%;
+  background-color: rgba(255, 255, 255, 0.7);
+  padding: 0 4px;
+  border-radius: 5px;
+}

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -61,13 +61,20 @@
 
             <!-- Main Footer -->
             <footer id="footer" class="main-footer">
+                <div id="hotkey-cheatsheet-link" class="hidden-xs">
+                  <a href="#" id="show-hotkeys" data-toggle="popover" data-trigger="focus" role="button" tabindex="0">View keyboard shortcuts</a>
+                </div>
+
                     <!-- To the right -->
                 <div class="pull-right hidden-xs">
                     <a href="#" id="pi" data-toggle="modal" data-target="#geoJsonViewer" onclick='MRManager.updateGeoJsonViewer();'>&pi;</a>
                 </div>
+
                     <!-- Default to the left -->
                 <strong>@Html(messages("general.copyright")) <a href="#">MapRoulette Version @{config.getSemanticVersion}</a>.</strong> @messages("general.rights")
-            </footer>
+
+                <div class="clearfix" />
+              </footer>
 
                 <!-- Control Sidebar -->
             <aside class="control-sidebar control-sidebar-dark">

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -61,7 +61,7 @@
 
             <!-- Main Footer -->
             <footer id="footer" class="main-footer">
-                <div id="hotkey-cheatsheet-link" class="hidden-xs">
+                <div id="hotkey-cheatsheet-link" class="hidden-xs" style="display: none;">
                   <a href="#" id="show-hotkeys" data-toggle="popover" data-trigger="focus" role="button" tabindex="0">View keyboard shortcuts</a>
                 </div>
 

--- a/conf/messages
+++ b/conf/messages
@@ -354,6 +354,7 @@ mapping.js.control.edit.id=Edit in iD
 mapping.js.control.edit.josm=Edit in JOSM
 mapping.js.control.edit.josm.layer=Edit in new JOSM Layer
 mapping.js.control.edit.nevermind=Nevermind close this
+mapping.js.control.edit.cancel=Cancel
 mapping.js.control.results.title=The area is now loaded in your OSM editor. See if you can fix it, and then return to MapRoulette.<br/><i>Please make sure you save (iD) or upload (JOSM) your work after each fix!<i/>
 mapping.js.control.results.fixed=I fixed it!
 mapping.js.control.results.difficult=Too difficult/Couldn't see


### PR DESCRIPTION
- Enable hotkeys.
- Add cheat sheet popover that displays available keyboard shortcuts.

<img width="916" alt="mr2_hotkeys" src="https://cloud.githubusercontent.com/assets/445970/23573879/24eb205e-002e-11e7-85b0-9b650f1676c3.png">
