### PR TITLE
Disable hotkeys in input/textarea/select fields.

### DIFF
--- a/app/assets/javascripts/mapping.js
+++ b/app/assets/javascripts/mapping.js
@@ -1111,11 +1111,13 @@ var MRManager = (function() {
 
     var registerHotKeys = function() {
         $(document).keydown(function(e) {
-          e.preventDefault();
-
-          if (hotkeys[e.keyCode]) {
-            hotkeys[e.keyCode].action();
-          }
+            if (hotkeys[e.keyCode]) {
+                // Ignore typing in search boxes, etc.
+                if (!/textarea|input|select/i.test(e.target.nodeName)) {
+                    e.preventDefault();
+                    hotkeys[e.keyCode].action();
+                }
+            }
         });
     };
 


### PR DESCRIPTION
This should address the problem of hot keys interfering with search box input.