### PR TITLE
add german to locale settings select

### DIFF
--- a/app/views/user/settings.scala.html
+++ b/app/views/user/settings.scala.html
@@ -39,7 +39,8 @@
             optionList = List(
                 (messages("user.profile.settings.select"), "-1"),
                 ("en-US (US English)", "en-US"),
-                ("af (Afrikaans)", "af")
+                ("af (Afrikaans)", "af"),
+                ("de (Deutsch)", "de")
             ),
             isMultiple = false,
             help = messages("user.profile.settings.locale.help"),


### PR DESCRIPTION
It seems that the German translation cannot be selected in the user settings. Probably this settings entry was missing. Please note that I have not tested this addition, but it seems easy enough.