### PR TITLE
Add missed comma in settings file. Fixes #324

### DIFF
--- a/app/views/user/settings.scala.html
+++ b/app/views/user/settings.scala.html
@@ -40,7 +40,7 @@
                 (messages("user.profile.settings.select"), "-1"),
                 ("en-US (US English)", "en-US"),
                 ("af (Afrikaans)", "af"),
-                ("de (Deutsch)", "de")
+                ("de (Deutsch)", "de"),
                 ("fr (Français)", "fr")
             ),
             isMultiple = false,


### PR DESCRIPTION
Fixes compilation error resulting from missed comma in settings
file when the fr translation was added.