### PR TITLE
Fixed SQL generation bug for the extendedFind function. Inserting pro…

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -291,8 +291,11 @@ class ChallengeController @Inject()(override val childController: TaskController
           NotFound
         } else {
           val tags = this.tagDAL.listByChallenges(challenges.map(c => c.id))
+          val projects = Some(this.dalManager.project.retrieveListById(-1, 0)(challenges.map(c => c.general.parent)).map(p => p.id -> p).toMap)
           val jsonList = challenges.map { c =>
-            Utils.insertIntoJson(Json.toJson(c), Tag.KEY, Json.toJson(tags.getOrElse(c.id, List.empty).map(_.name)))
+            val updated = Utils.insertIntoJson(Json.toJson(c), Tag.KEY, Json.toJson(tags.getOrElse(c.id, List.empty).map(_.name)))
+            val projectJson = Json.toJson(projects.get(c.general.parent)).as[JsObject] - Project.KEY_GROUPS
+            Utils.insertIntoJson(updated, Challenge.KEY_PARENT, projectJson, true)
           }
           Ok(Json.toJson(jsonList))
         }

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -90,8 +90,9 @@ class ProjectController @Inject() (override val childController:ChallengeControl
 
   def getSearchedClusteredPoints(searchCookie:String) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      val searchParams = SearchParameters.convert(searchCookie)
-      Ok(Json.toJson(this.dal.getSearchedClusteredPoints(searchParams)))
+      SearchParameters.withSearch { params =>
+        Ok(Json.toJson(this.dal.getSearchedClusteredPoints(params)))
+      }
     }
   }
 

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -120,6 +120,7 @@ object Challenge {
   val MAX_ZOOM = 19
 
   val KEY_ANSWER = "answers"
+  val KEY_PARENT = "parent"
   val defaultAnswerValid = Answer(-1, "Valid")
   val defaultAnswerInvalid = Answer(-2, "Invalid")
 

--- a/app/org/maproulette/models/Project.scala
+++ b/app/org/maproulette/models/Project.scala
@@ -33,6 +33,8 @@ object Project {
   implicit val projectWrites: Writes[Project] = Json.writes[Project]
   implicit val projectReads: Reads[Project] = Json.reads[Project]
 
+  val KEY_GROUPS = "groups"
+
   val projectForm = Form(
     mapping(
       "id" -> default(longNumber,-1L),
@@ -40,7 +42,7 @@ object Project {
       "created" -> default(jodaDate, DateTime.now()),
       "modified" -> default(jodaDate, DateTime.now()),
       "description" -> optional(text),
-      "groups" -> list(
+      KEY_GROUPS -> list(
         mapping(
           "id" -> longNumber,
           "name" -> nonEmptyText,

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -584,8 +584,8 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
       val joinClause = new StringBuilder()
 
       searchParameters.projectId match {
-        case Some(pid) => whereClause ++= s"c.parent_id = $pid"
-        case None =>
+        case Some(pid) if pid > -1 => whereClause ++= s"c.parent_id = $pid"
+        case _ =>
           joinClause ++= "INNER JOIN projects p ON p.id = c.parent_id"
           searchParameters.projectSearch match {
             case Some(ps) if ps.nonEmpty =>
@@ -606,7 +606,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
         case Some(cs) if cs.nonEmpty =>
           searchParameters.fuzzySearch match {
             case Some(x) =>
-              whereClause ++= this.fuzzySearch("c.name", "cs", x)(None)
+              this.appendInWhereClause(whereClause, this.fuzzySearch("c.name", "cs", x)(None))
               parameters += ('cs -> cs)
             case None =>
               this.appendInWhereClause(whereClause, this.searchField("c.name", "cs")(None))

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -155,37 +155,4 @@ object SearchParameters {
     case Some(v) => Some(v)
     case None => default
   }
-
-  def withQSSearch[T](block:SearchParameters => T)(implicit request:Request[AnyContent]) : T = {
-    val qsParams = SearchParameters(
-      Utils.optionStringToOptionLong(request.getQueryString("pid")),
-      request.getQueryString("ps"),
-      Utils.optionStringToOptionBoolean(request.getQueryString("pe")),
-      Utils.optionStringToOptionLong(request.getQueryString("cid")),
-      Utils.optionStringToOptionStringList(request.getQueryString("ct")),
-      Some(request.getQueryString("ctc").getOrElse("false").toBoolean),
-      request.getQueryString("cs"),
-      Utils.optionStringToOptionBoolean(request.getQueryString("ce")),
-      Utils.optionStringToOptionStringList(request.getQueryString("tt")),
-      Some(request.getQueryString("ttc").getOrElse("false").toBoolean),
-      request.getQueryString("ts"),
-      request.getQueryString("tStatus") match {
-        case Some(v) => Utils.toIntList(v)
-        case None => None
-      },
-      None,
-      Utils.optionStringToOptionInt(request.getQueryString("tp")),
-      request.getQueryString("tbb") match {
-        case Some(v) if v.nonEmpty =>
-          v.split(",") match {
-            case x if x.size == 4 => Some(SearchLocation(x(0).toDouble, x(1).toDouble, x(2).toDouble, x(3).toDouble))
-            case _ => None
-          }
-        case _ => None
-      },
-      Utils.optionStringToOptionInt(request.getQueryString("fuzzy")),
-      request.getQueryString("o")
-    )
-    block(qsParams)
-  }
 }


### PR DESCRIPTION
…ject json into response for each Challenge in the extendedFind function.

This SQL generation was only invalid in a certain circumstances where the project ID was purposefully set to -1. This is stored in a cookie and then will be kept around for longer than expected and can caused confusion. The update will now make sure that the project ID is at the very least within the valid range.

Inserting the project JSON into the Challenge will alleviate any need to retrieve project information with another API call.