### PR TITLE
Adding unsave API for users saved challenges

### DIFF
--- a/app/org/maproulette/controllers/api/APIController.scala
+++ b/app/org/maproulette/controllers/api/APIController.scala
@@ -33,6 +33,13 @@ class APIController @Inject() (dalManager: DALManager, sessionManager: SessionMa
     }
   }
 
+  def unsaveChallenge(userId:Long, challengeId:Long) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      dalManager.user.unsaveChallenge(userId, challengeId, user)
+      Ok(Json.toJson(StatusMessage("OK", JsString(s"Challenge $challengeId unsaved from user $userId"))))
+    }
+  }
+
   /**
     * In the routes file this will be mapped to any /api/v2/ paths. It is the last mapping to take
     * place so if it doesn't match any of the other routes it will fall into this invalid path.

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -513,6 +513,21 @@ class UserDAL @Inject() (override val db:Database,
   }
 
   /**
+    * Unsaves a challenge from the users profile
+    *
+    * @param userId The id of the user that has previously saved the challenge
+    * @param challengeId The id of the challenge to remove from the user profile
+    * @param user The user executing the unsave function
+    * @param c The existing connection if any
+    */
+  def unsaveChallenge(userId:Long, challengeId:Long, user:User)(implicit c:Option[Connection]=None) : Unit = {
+    this.permission.hasWriteAccess(UserType(), user)(userId)
+    withMRConnection { implicit c =>
+      SQL(s"""DELETE FROM saved_challenges WHERE user_id = $userId AND challenge_id = $challengeId""").execute()
+    }
+  }
+
+  /**
     * Retrieves the user's home project
     *
     * @param user The user to search for the home project

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2009,7 +2009,7 @@ GET     /user/:userId                               @org.maproulette.controllers
 #   - name: username
 #     description: The OSM username of the user to retrieve
 ###
-GET     /osmuser/:username                               @org.maproulette.controllers.api.UserController.getUserByOSMUsername(username:String)
+GET     /osmuser/:username                          @org.maproulette.controllers.api.UserController.getUserByOSMUsername(username:String)
 ###
 # tags: [ User ]
 # summary: Retrieves Users Saved Challenged
@@ -2024,6 +2024,11 @@ GET     /osmuser/:username                               @org.maproulette.contro
 # parameters:
 #   - name: userId
 #     description: The id of the user to retrieve the challenges for
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
 ###
 GET     /user/:userId/saved                         @org.maproulette.controllers.api.APIController.getSavedChallenges(userId:Long)
 ###
@@ -2049,6 +2054,29 @@ GET     /user/:userId/saved                         @org.maproulette.controllers
 #     type: string
 ###
 POST    /user/:userId/save/:challengeId             @org.maproulette.controllers.api.APIController.saveChallenge(userId:Long, challengeId:Long)
+###
+# tags: [ User ]
+# summary: Unsaves Challenge for a User
+# description: Unsaves a Challenge to a user account
+# responses:
+#   '200':
+#     description: A simple OK status message
+#     schema:
+#       $ref: '#/definitions/org.maproulette.exception.StatusMessage'
+#   '404':
+#     description: If User or Challenge for provided ID's is not found.
+# parameters:
+#   - name: userId
+#     description: The id of the user to unsave the challenges for
+#   - name: challengeId
+#     description: The id of the challenge to unsave
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+POST   /user/:userId/unsave/:challengeId            @org.maproulette.controllers.api.APIController.unsaveChallenge(userId:Long, challengeId:Long)
 ###
 # tags: [ User ]
 # summary: Updates UserSettings


### PR DESCRIPTION
There is currently an API option to save challenges to a user's profile. However there was no unsave option, so a user could only add more and more challenges to it's challenge list. This new API will allow the user to remove challenges from it's saved challenge list. This will not delete any challenges or any data, just remove the reference to that user.