### PR TITLE
Adding a proximity API option, so that when retrieving the next task …

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -191,9 +191,10 @@ class ChallengeController @Inject()(override val childController: TaskController
     * @param taskSearch  Filter based on the name of the task
     * @param tags        A comma separated list of tags that optionally can be used to further filter the tasks
     * @param limit       Limit of how many tasks should be returned
+    * @param proximityId Id of task that you wish to find the next task based on the proximity of that task
     * @return A list of Tasks that match the supplied filters
     */
-  def getRandomTasks(challengeId: Long, taskSearch: String, tags: String, limit: Int): Action[AnyContent] = Action.async { implicit request =>
+  def getRandomTasks(challengeId: Long, taskSearch: String, tags: String, limit: Int, proximityId:Long): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { p =>
         val params = p.copy(
@@ -201,7 +202,7 @@ class ChallengeController @Inject()(override val childController: TaskController
           taskSearch = Some(taskSearch),
           taskTags = Some(tags.split(",").toList)
         )
-        val result = this.dalManager.task.getRandomTasks(User.userOrMocked(user), params, limit)
+        val result = this.dalManager.task.getRandomTasks(User.userOrMocked(user), params, limit, None, Utils.negativeToOption(proximityId))
         result.foreach(task => this.actionManager.setAction(user, this.itemType.convertToItem(task.id), TaskViewed(), ""))
         Ok(Json.toJson(result))
       }

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -70,10 +70,11 @@ class ProjectController @Inject() (override val childController:ChallengeControl
     * @param tags A comma separated list of tags that optionally can be used to further filter the tasks
     * @param taskSearch Filter based on the name of the task
     * @param limit Limit of how many tasks should be returned
+    * @param proximityId Id of task that you wish to find the next task based on the proximity of that task
     * @return A list of Tasks that match the supplied filters
     */
   def getRandomTasks(projectId: Long, challengeSearch:String, challengeTags:String,
-                     tags: String, taskSearch:String, limit:Int) : Action[AnyContent] = Action.async { implicit request =>
+                     tags: String, taskSearch:String, limit:Int, proximityId:Long) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       val params = SearchParameters(
         projectId = Some(projectId),
@@ -82,7 +83,8 @@ class ProjectController @Inject() (override val childController:ChallengeControl
         taskSearch = Some(taskSearch),
         taskTags = Some(tags.split(",").toList)
       )
-      val result = this.taskDAL.getRandomTasks(User.userOrMocked(user), params, limit)
+
+      val result = this.taskDAL.getRandomTasks(User.userOrMocked(user), params, limit, None, Utils.negativeToOption(proximityId))
       result.foreach(task => this.actionManager.setAction(user, this.itemType.convertToItem(task.id), TaskViewed(), ""))
       Ok(Json.toJson(result))
     }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -134,6 +134,7 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
     * @param tags A comma separated list of tags to match against
     * @param taskSearch Filter based on the name of the task
     * @param limit The number of tasks to return
+    * @param proximityId Id of task that you wish to find the next task based on the proximity of that task
     * @return
     */
   def getRandomTasks(projectSearch:String,
@@ -141,7 +142,8 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
                      challengeTags:String,
                      tags: String,
                      taskSearch: String,
-                     limit: Int) : Action[AnyContent] = Action.async { implicit request =>
+                     limit: Int,
+                     proximityId: Long) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       val params = SearchParameters(
         projectSearch = Some(projectSearch),
@@ -150,7 +152,7 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
         taskTags = Some(tags.split(",").toList),
         taskSearch = Some(taskSearch)
       )
-      val result = this.dal.getRandomTasks(User.userOrMocked(user), params, limit)
+      val result = this.dal.getRandomTasks(User.userOrMocked(user), params, limit, None, Utils.negativeToOption(proximityId))
       result.foreach(task => this.actionManager.setAction(user, this.itemType.convertToItem(task.id), TaskViewed(), ""))
       Ok(Json.toJson(result))
     }

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -119,4 +119,9 @@ object Utils extends DefaultWrites {
   } else {
     Some(DateTime.parse(date))
   }
+
+  def negativeToOption(value:Long) : Option[Long] = value match {
+    case v if v < 0 => None
+    case v => Some(v)
+  }
 }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -409,8 +409,11 @@ GET     /project/:id/children                       @org.maproulette.controllers
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
-GET     /project/:id/tasks                          @org.maproulette.controllers.api.ProjectController.getRandomTasks(id:Long, cs:String ?= "", ct:String ?= "", tags:String ?= "", s:String ?= "", limit:Int ?= 1)
+GET     /project/:id/tasks                          @org.maproulette.controllers.api.ProjectController.getRandomTasks(id:Long, cs:String ?= "", ct:String ?= "", tags:String ?= "", s:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Project ]
 # summary: Retrieves clustered challenge points
@@ -970,8 +973,11 @@ GET     /challenge/:id/children                     @org.maproulette.controllers
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
-GET     /challenge/:cid/tasks/random                @org.maproulette.controllers.api.ChallengeController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1)
+GET     /challenge/:cid/tasks/random                @org.maproulette.controllers.api.ChallengeController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Challenge ]
 # summary: Retrieves random Task
@@ -996,8 +1002,11 @@ GET     /challenge/:cid/tasks/random                @org.maproulette.controllers
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
-GET     /challenge/:cid/tasks/randomTasks           @org.maproulette.controllers.api.ChallengeController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1)
+GET     /challenge/:cid/tasks/randomTasks           @org.maproulette.controllers.api.ChallengeController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Challenge ]
 # summary: Retrieves Challenge GeoJSON
@@ -1294,8 +1303,11 @@ PUT     /surveys                                    @org.maproulette.controllers
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
-GET     /survey/:cid/tasks/random                   @org.maproulette.controllers.api.SurveyController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1)
+GET     /survey/:cid/tasks/random                   @org.maproulette.controllers.api.SurveyController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Survey ]
 # summary: Answers Survey Question
@@ -1650,8 +1662,11 @@ DELETE  /task/:id/tags                              @org.maproulette.controllers
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
-GET     /tasks/random                               @org.maproulette.controllers.api.TaskController.getRandomTasks(ps:String ?= "", cs:String ?= "", ct:String ?= "", tags:String ?= "", ts:String ?= "", limit:Int ?= 1)
+GET     /tasks/random                               @org.maproulette.controllers.api.TaskController.getRandomTasks(ps:String ?= "", cs:String ?= "", ct:String ?= "", tags:String ?= "", ts:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Task ]
 # summary: Update Task Status


### PR DESCRIPTION
…you can look for the next closest available task.

As the title says, when using the API you can include "?proximity=<TASK_ID>" in the query string and then the random next task retrieved will be the closest task to the provided task_id. If a task is locked by a user it will look for the next closest one after that.

Also updated the API so that if you don't use priority for the random next task it will ignore it completely. Previously it was using HIGH priority and so there were situations where it wouldn't return by default any tasks even though there would have been tasks in the medium and low priorities.