### PR TITLE
Updated Cache for UserGroups cachsing. Fixed issue with splitting csv…

### DIFF
--- a/app/org/maproulette/cache/BasicCache.scala
+++ b/app/org/maproulette/cache/BasicCache.scala
@@ -1,0 +1,133 @@
+package org.maproulette.cache
+
+import org.joda.time.{LocalDateTime, Seconds}
+import scala.collection.mutable.Map
+
+case class BasicInnerValue[Key, Value](key:Key, value:Value, accessTime:LocalDateTime, localExpiry:Option[Int]=None)
+
+/**
+  * This is a very basic Cache Storage class that will store all items in memory. Ultimately this
+  * class should be extended to use the Play Cache API
+  *
+  * cacheLimit - The number of entries allowed in the cache until it starts kicking out the oldest entries
+  * cacheExpiry - The number of seconds allowed until a cache item is expired out the cache lazily
+  *
+  * @author cuthbertm
+  */
+class BasicCache[Key, Value] (cacheLimit:Int=CacheManager.DEFAULT_CACHE_LIMIT, cacheExpiry:Int=CacheManager.DEFAULT_CACHE_EXPIRY) {
+  val cache:Map[Key, BasicInnerValue[Key, Value]] = Map.empty
+
+  /**
+    * Gets an object from the cache
+    *
+    * @param id The id of the object you are looking for
+    * @return The object from the cache, None if not found
+    */
+  def get(id:Key) : Option[Value] = synchronized {
+    this.cache.get(id) match {
+      case Some(value) =>
+        if (isExpired(value)) {
+          None
+        } else {
+          // because it has been touched, we need to update the accesstime
+          add(id, value.value)
+          Some(value.value)
+        }
+      case None => None
+    }
+  }
+
+  /**
+    * Adds an object to the cache, if cache limit has been reached, then will remove the oldest
+    * accessed item in the cache
+    *
+    * @param obj The object to add to the cache
+    * @param localExpiry You can add a custom expiry to a specific element in seconds
+    * @return The object put in the cache, or None if it could not be placed in the cache
+    */
+  def add(key:Key, obj:Value, localExpiry:Option[Int]=None) : Option[Value] = synchronized {
+    if (this.cache.size == cacheLimit) {
+      val oldestEntry = this.cache.valuesIterator.reduceLeft((x, y) => if (x.accessTime.isBefore(y.accessTime)) x else y)
+      remove(oldestEntry.key)
+    } else if (this.cache.size > cacheLimit) {
+      // something has gone very wrong if the cacheLimit has already been exceeded, this really shouldn't ever happen
+      // in this case we go for the nuclear option, basically blow away the whole cache
+      this.cache.clear()
+    }
+    this.cache.put(key, BasicInnerValue(key, obj, new LocalDateTime(), localExpiry)) match {
+      case Some(value) => Some(value.value)
+      case None => None
+    }
+  }
+
+  /**
+    * Removes an object from the cache based on the id
+    *
+    * @param id the id of the object to be removed
+    * @return The object removed from the cache, or None if it could not be removed from the cache,
+    *         or was not originally in the cache
+    */
+  def remove(id:Key) : Option[Value] = synchronized {
+    this.cache.remove(id) match {
+      case Some(value) => Some(value.value)
+      case None => None
+    }
+  }
+
+  /**
+    * Fully clears the cache, this may not be applicable for non basic in memory caches
+    */
+  def clear() : Unit = this.cache.clear()
+
+  /**
+    * The current size of the cache
+    *
+    * @return
+    */
+  def size : Int = this.cache.size
+
+  /**
+    * True size is a little bit more accurate than size, however the performance will be a bit slower
+    * as this size will loop through all the objects in the cache and expire out any items that have
+    * expired. Thereby giving the true size at the end.
+    *
+    * @return
+    */
+  def trueSize : Int = this.cache.keysIterator.count(!isExpiredByKey(_))
+
+  /**
+    * Checks if an item is cached or not
+    *
+    * @param id The id of the object to check to see if it is in the cache
+    * @return true if the item is found in the cache
+    */
+  def isCached(id:Key) : Boolean = this.cache.contains(id)
+
+  private def isExpiredByKey(key:Key) : Boolean = synchronized {
+    this.cache.get(key) match {
+      case Some(value) => isExpired(value)
+      case None => true
+    }
+  }
+
+  /**
+    * Checks to see if the item has expired and should be removed from the cache. If it finds the
+    * item and it has expired it will automatically remove it from the cache.
+    *
+    * @param value The value to check in the cache
+    * @return true if it doesn't exist or has expired
+    */
+  protected def isExpired(value:BasicInnerValue[Key, Value]) : Boolean = synchronized {
+    val currentTime = new LocalDateTime()
+    val itemExpiry = value.localExpiry match {
+      case Some(v) => v
+      case None => cacheExpiry
+    }
+    if (currentTime.isAfter(value.accessTime.plus(Seconds.seconds(itemExpiry)))) {
+      remove(value.key)
+      true
+    } else {
+      false
+    }
+  }
+}

--- a/app/org/maproulette/cache/CacheManager.scala
+++ b/app/org/maproulette/cache/CacheManager.scala
@@ -42,7 +42,7 @@ class CacheManager[Key, A<:BaseObject[Key]](cacheLimit:Int=CacheManager.DEFAULT_
           case Some(obj) => Some(obj.id)
           case None => block(name) match {
             case Some(obj) =>
-              this.cache.add(obj)
+              this.cache.addObject(obj)
               this.nameCache.put(name, obj.id)
               Some(obj.id)
             case None => None
@@ -94,7 +94,7 @@ class CacheManager[Key, A<:BaseObject[Key]](cacheLimit:Int=CacheManager.DEFAULT_
           case None =>
             block() match {
               case Some(result) =>
-                this.cache.add(result)
+                this.cache.addObject(result)
                 Some(result)
               case None => None
             }
@@ -141,7 +141,7 @@ class CacheManager[Key, A<:BaseObject[Key]](cacheLimit:Int=CacheManager.DEFAULT_
             if (delete) {
               this.cache.remove(updatedItem.id)
             } else {
-              this.cache.add(updatedItem)
+              this.cache.addObject(updatedItem)
             }
             Some(updatedItem)
           case None => None
@@ -180,12 +180,12 @@ class CacheManager[Key, A<:BaseObject[Key]](cacheLimit:Int=CacheManager.DEFAULT_
         // we execute the block if there are uncachedID's or if the original ids passed in is empty
         val cachedItems = if (unCachedIDs.nonEmpty || ids.isEmpty) {
           val uncachedList = block(unCachedIDs)
-          (unCachedIDs zip uncachedList).foreach(obj => this.cache.add(obj._2))
+          (unCachedIDs zip uncachedList).foreach(obj => this.cache.addObject(obj._2))
           uncachedList ++ connected.flatMap(_._2)
         } else {
           connected.flatMap(_._2)
         }
-        cachedItems.filter(entry => ids.isEmpty || unCachedIDs.contains(entry.id)).foreach(this.cache.add(_))
+        cachedItems.filter(entry => ids.isEmpty || unCachedIDs.contains(entry.id)).foreach(this.cache.addObject(_))
         cachedItems
       case false => block(ids)
     }
@@ -244,7 +244,7 @@ class CacheManager[Key, A<:BaseObject[Key]](cacheLimit:Int=CacheManager.DEFAULT_
         val unCachedIDs = connected.filter(value => value._2.isEmpty).map(_._1)
         if (unCachedIDs.nonEmpty) {
           val list = block(unCachedIDs)
-          list.foreach(this.cache.add(_))
+          list.foreach(this.cache.addObject(_))
           list ++ connected.flatMap(_._2)
         } else {
           connected.flatMap(_._2)
@@ -287,7 +287,7 @@ class CacheManager[Key, A<:BaseObject[Key]](cacheLimit:Int=CacheManager.DEFAULT_
       case Some(a) => a
       case None =>
         val created = create(item)
-        if (caching) this.cache.add(created)
+        if (caching) this.cache.addObject(created)
         created
     }
   }

--- a/app/org/maproulette/cache/TagCacheManager.scala
+++ b/app/org/maproulette/cache/TagCacheManager.scala
@@ -29,7 +29,7 @@ class TagCacheManager @Inject() (tagDAL: Provider[TagDAL], db:Database) extends 
     try {
       db.withConnection { implicit c =>
         this.cache.clear()
-        SQL"""SELECT * FROM tags""".as(tagDAL.get.parser.*).foreach(tag => cache.add(tag))
+        SQL"""SELECT * FROM tags""".as(tagDAL.get.parser.*).foreach(tag => cache.addObject(tag))
       }
     } finally {
       this.loadingLock.writeLock().unlock()

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -140,7 +140,7 @@ class ChallengeController @Inject()(override val childController: TaskController
           val filter = if (StringUtils.isEmpty(statusFilter)) {
             None
           } else {
-            Some(statusFilter.split(",").map(_.toInt).toList)
+            Some(Utils.split(statusFilter).map(_.toInt))
           }
           Ok(Json.parse(this.dal.getChallengeGeometry(challengeId, filter)))
         case None => throw new NotFoundException(s"No challenge with id $challengeId found.")
@@ -154,7 +154,7 @@ class ChallengeController @Inject()(override val childController: TaskController
       val filter = if (StringUtils.isEmpty(statusFilter)) {
         None
       } else {
-        Some(statusFilter.split(",").map(_.toInt).toList)
+        Some(Utils.split(statusFilter).map(_.toInt))
       }
       Ok(Json.toJson(this.dal.getClusteredPoints(challengeId, filter)))
     }
@@ -175,7 +175,7 @@ class ChallengeController @Inject()(override val childController: TaskController
         val params = p.copy(
           challengeId = Some(challengeId),
           taskSearch = Some(taskSearch),
-          taskTags = Some(tags.split(",").toList)
+          taskTags = Some(Utils.split(tags))
         )
         val result = this.dalManager.task.getRandomTasksWithPriority(User.userOrMocked(user), params, limit)
         result.foreach(task => this.actionManager.setAction(user, this.itemType.convertToItem(task.id), TaskViewed(), ""))
@@ -200,7 +200,7 @@ class ChallengeController @Inject()(override val childController: TaskController
         val params = p.copy(
           challengeId = Some(challengeId),
           taskSearch = Some(taskSearch),
-          taskTags = Some(tags.split(",").toList)
+          taskTags = Some(Utils.split(tags))
         )
         val result = this.dalManager.task.getRandomTasks(User.userOrMocked(user), params, limit, None, Utils.negativeToOption(proximityId))
         result.foreach(task => this.actionManager.setAction(user, this.itemType.convertToItem(task.id), TaskViewed(), ""))
@@ -262,7 +262,7 @@ class ChallengeController @Inject()(override val childController: TaskController
     */
   def deleteTasks(challengeId:Long, statusFilters:String="") : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.dal.deleteTasks(user, challengeId, statusFilters.split(",").map(_.toInt).toList)
+      this.dal.deleteTasks(user, challengeId, Utils.split(statusFilters).map(_.toInt))
       Ok
     }
   }

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -52,6 +52,7 @@ class ProjectController @Inject() (override val childController:ChallengeControl
   override def updateCreateBody(body: JsValue, user:User): JsValue = {
     var jsonBody = super.updateCreateBody(body, user)
     jsonBody = Utils.insertIntoJson(jsonBody, "groups", Array.emptyShortArray)(arrayWrites[Short])
+    jsonBody = Utils.insertIntoJson(jsonBody, "owner", user.osmProfile.id, true)(LongWrites)
     Utils.insertIntoJson(jsonBody, "enabled", true)(BooleanWrites)
   }
 
@@ -94,9 +95,9 @@ class ProjectController @Inject() (override val childController:ChallengeControl
       val params = SearchParameters(
         projectId = Some(projectId),
         challengeSearch = Some(challengeSearch),
-        challengeTags = Some(challengeTags.split(",").toList),
+        challengeTags = Some(Utils.split(challengeTags)),
         taskSearch = Some(taskSearch),
-        taskTags = Some(tags.split(",").toList)
+        taskTags = Some(Utils.split(tags))
       )
 
       val result = this.taskDAL.getRandomTasks(User.userOrMocked(user), params, limit, None, Utils.negativeToOption(proximityId))
@@ -123,7 +124,7 @@ class ProjectController @Inject() (override val childController:ChallengeControl
       val cids = if (StringUtils.isEmpty(challengeIds)) {
         List.empty
       } else {
-        challengeIds.split(",").map(_.toLong).toList
+        Utils.split(challengeIds).map(_.toLong)
       }
       Ok(Json.toJson(this.dal.getClusteredPoints(pid, cids)))
     }

--- a/app/org/maproulette/controllers/api/TagsMixin.scala
+++ b/app/org/maproulette/controllers/api/TagsMixin.scala
@@ -89,7 +89,7 @@ trait TagsMixin[T<:BaseObject[Long]] {
             case e: NumberFormatException =>
               // this is the case where a name is supplied, so we will either search for a tag with
               // the same name or create a new tag with the current name
-              this.dal.retrieveByName(tag) match {
+              this.tagDAL.retrieveByName(tag) match {
                 case Some(t) => t.asInstanceOf[Tag]
                 case None => Tag(-1, tag)
               }
@@ -108,7 +108,7 @@ trait TagsMixin[T<:BaseObject[Long]] {
         }
       case _ => List.empty
     }
-    val tagIds = tagDAL.updateTagList(tags, user).map(_.id)
+    val tagIds = this.tagDAL.updateTagList(tags, user).map(_.id)
 
     if (tagIds.nonEmpty) {
       // now we have the ids for the supplied tags, then lets map them to the item created

--- a/app/org/maproulette/models/ClusteredPoint.scala
+++ b/app/org/maproulette/models/ClusteredPoint.scala
@@ -3,7 +3,7 @@
 package org.maproulette.models
 
 import org.joda.time.DateTime
-import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.{JsValue, Json, Reads, Writes}
 
 /**
   * @author cuthbertm
@@ -26,7 +26,7 @@ case class Point(lat:Double, lng:Double)
   * @param type The type of this ClusteredPoint
   * @param status The status of the task, only used for task points, ie. not challenge points
   */
-case class ClusteredPoint(id:Long, owner:Long, ownerName:String, title:String, point:Point,
+case class ClusteredPoint(id:Long, owner:Long, ownerName:String, title:String, point:Point, bounding:JsValue,
                           blurb:String, modified:DateTime, difficulty:Int, `type`:Int, status:Int = -1)
 
 object ClusteredPoint {

--- a/app/org/maproulette/models/Project.scala
+++ b/app/org/maproulette/models/Project.scala
@@ -17,7 +17,7 @@ import play.api.libs.json.{Json, Reads, Writes}
   * @author cuthbertm
   */
 case class Project(override val id: Long,
-                   ownerId: Long,
+                   owner: Long,
                    override val name: String,
                    override val created:DateTime,
                    override val modified:DateTime,
@@ -40,7 +40,7 @@ object Project {
   val projectForm = Form(
     mapping(
       "id" -> default(longNumber,-1L),
-      "ownerId" -> default(longNumber, User.DEFAULT_SUPER_USER_ID.toLong),
+      "owner" -> default(longNumber, User.DEFAULT_SUPER_USER_ID.toLong),
       "name" -> nonEmptyText,
       "created" -> default(jodaDate, DateTime.now()),
       "modified" -> default(jodaDate, DateTime.now()),

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -17,7 +17,7 @@ import org.maproulette.models._
 import org.maproulette.permissions.Permission
 import org.maproulette.session.{SearchParameters, User}
 import play.api.db.Database
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsString, JsValue, Json}
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
@@ -161,7 +161,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
                       ${challenge.priority.defaultPriority}, ${challenge.priority.highPriorityRule}, ${challenge.priority.mediumPriorityRule},
                       ${challenge.priority.lowPriorityRule}, ${challenge.extra.defaultZoom}, ${challenge.extra.minZoom},
                       ${challenge.extra.maxZoom}, ${challenge.extra.defaultBasemap}, ${challenge.extra.customBasemap}, ${challenge.extra.updateTasks}
-                      ) ON CONFLICT(parent_id, LOWER(name)) DO NOTHING RETURNING *""".as(this.parser.*).headOption
+                      ) ON CONFLICT(parent_id, LOWER(name)) DO NOTHING RETURNING #${this.retrieveColumns}""".as(this.parser.*).headOption
       }
     } match {
       case Some(value) => value
@@ -234,7 +234,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
                 low_priority_rule = ${if (StringUtils.isEmpty(lowPriorityRule)) { Option.empty[String] } else { Some(lowPriorityRule) }},
                 default_zoom = $defaultZoom, min_zoom = $minZoom, max_zoom = $maxZoom, default_basemap = $defaultBasemap,
                 custom_basemap = $customBasemap, updatetasks = $updateTasks, challenge_type = $challengeType
-              WHERE id = $id RETURNING *""".as(parser.*).headOption
+              WHERE id = $id RETURNING #${this.retrieveColumns}""".as(parser.*).headOption
       }
     }
     // update the task priorities in the background
@@ -391,7 +391,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
           val locationJSON = Json.parse(location)
           val coordinates = (locationJSON \ "coordinates").as[List[Double]]
           val point = Point(coordinates(1), coordinates.head)
-          ClusteredPoint(id, -1, "", name, point, instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status)
+          ClusteredPoint(id, -1, "", name, point, JsString(""), instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status)
       }
         SQL"""SELECT id, name, instruction, status,
                       ST_AsGeoJSON(location) AS location

--- a/app/org/maproulette/models/dal/TagDAL.scala
+++ b/app/org/maproulette/models/dal/TagDAL.scala
@@ -74,7 +74,7 @@ class TagDAL @Inject() (override val db:Database,
       this.permission.hasObjectWriteAccess(cachedItem, user)
       this.withMRTransaction { implicit c =>
         val name = (tag \ "name").asOpt[String].getOrElse(cachedItem.name)
-        if (name.nonEmpty) {
+        if (name.isEmpty) {
           // do not allow empty tags
           throw new InvalidException(s"Tags cannot be empty strings")
         }

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -82,6 +82,11 @@ object Utils extends DefaultWrites {
     }
   }
 
+  def split(value:String, splitCharacter:String=",") : List[String] = value match {
+    case "" => List[String]()
+    case _ => value.split(splitCharacter).toList
+  }
+
   def optionStringToOptionInt(value:Option[String]) : Option[Int] = value match {
     case Some(v) => Some(v.toInt)
     case None => None

--- a/test/org/maproulette/cache/CacheSpec.scala
+++ b/test/org/maproulette/cache/CacheSpec.scala
@@ -170,7 +170,7 @@ class CacheSpec extends Specification {
     "cache must expire values correctly" in {
       theCache.clear()
       cacheObject(1L, "test1")
-      theCache.add(TestBaseObject(2L, "test2"), Some(1))
+      theCache.addObject(TestBaseObject(2L, "test2"), Some(1))
       Thread.sleep(2000)
       theCache.trueSize mustEqual 1
       Thread.sleep(5000)


### PR DESCRIPTION
… strings in the query string

Bug fixes include:

- Fixed bug that would cause the API to fail on empty csv list. Various API requests used csv lists in the query string and when it was split on an empty string it would return a list of 1 element which was an empty string and that caused some downstream functions to fail.
- Updated cache for UserGroup objects, to improve performance on some requests.
Fixed bug that was throwing an invalid exception with correct data with tags.