### PR TITLE
Handling exceptions for points around the poles.

### DIFF
--- a/conf/evolutions/default/11.sql
+++ b/conf/evolutions/default/11.sql
@@ -110,10 +110,14 @@ DECLARE
   rec RECORD;;
 BEGIN
   FOR rec IN SELECT id FROM challenges LOOP
-    UPDATE challenges SET bounding = (SELECT ST_Envelope(ST_Buffer((ST_SetSRID(ST_Extent(location), 4326))::geography,2)::geometry)
-            FROM tasks
-            WHERE parent_id = rec.id)
-    WHERE id = rec.id;;
+    BEGIN
+      UPDATE challenges SET bounding = (SELECT ST_Envelope(ST_Buffer((ST_SetSRID(ST_Extent(location), 4326))::geography,2)::geometry)
+        FROM tasks
+        WHERE parent_id = rec.id)
+      WHERE id = rec.id;;
+    EXCEPTION WHEN SQLSTATE 'XX000' THEN
+      RAISE NOTICE 'Failed to create bounding for challenge %', rec.id;;
+    END;;
   END LOOP;;
 END$$;;
 


### PR DESCRIPTION
There seems to be a bug in Postgis that cannot handle transforming points close to the poles. This will happen very rarely, but in that particular case we will handle the exception and continue on. Otherwise we wouldn't be able to update all the other valid challenges.