### PR TITLE
Removing task location update which was causing a deadlock situation …

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -334,7 +334,6 @@ class TaskDAL @Inject()(override val db: Database,
         .execute()
       c.commit()
     }
-    this.updateTaskLocation(taskId)
   }
 
   def updateTaskLocation(taskId: Long): Int = {


### PR DESCRIPTION
…in the database.

The problem with that particular line of code is the transaction that it was contained within. It would get into a deadlock scenario because it was trying to update the task, then it updated the geometries of the task and then it tried to update the task again with a new location, but because the transaction hadn't closed it was now waiting on the original update of the task, causing the deadlock.

We can simply remove this altogether as there is a scheduled job that runs twice a day that will update it.