### PR TITLE
Fixing some permissions bugs.

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -114,7 +114,8 @@ class ChallengeController @Inject()(override val childController: TaskController
     if (!this.challengeService.buildChallengeTasks(user, createdObject, localJson)) {
       super.extractAndCreate(body, createdObject, user)
     }
-    this.extractTags(body, createdObject, user)
+    // we need to elevate the user permissions to super users to extract and create the tags
+    this.extractTags(body, createdObject, User.superUser)
   }
 
   /**

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -111,7 +111,8 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
     * @param user          The user that is executing the function
     */
   override def extractAndCreate(body: JsValue, createdObject: Task, user: User)
-                               (implicit c:Option[Connection]=None): Unit = this.extractTags(body, createdObject, user)
+                               (implicit c:Option[Connection]=None): Unit =
+    this.extractTags(body, createdObject, User.superUser)
 
   /**
     * Gets a json list of tags of the task

--- a/app/org/maproulette/jobs/Bootstrap.scala
+++ b/app/org/maproulette/jobs/Bootstrap.scala
@@ -1,0 +1,31 @@
+package org.maproulette.jobs
+
+import javax.inject.{Inject, Singleton}
+
+import anorm._
+import play.api.db.Database
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.Future
+
+/**
+  * @author mcuthbert
+  */
+@Singleton
+class Bootstrap @Inject()(appLifeCycle:ApplicationLifecycle, db:Database) {
+
+  def start(): Unit = {
+    // for startup we make sure that all the super users are set correctly
+    db.withConnection { implicit c =>
+      SQL"""DELETE FROM user_groups
+            WHERE group_id = -999 AND NOT osm_user_id = -999
+        """.executeUpdate()
+    }
+  }
+
+  appLifeCycle.addStopHook { () =>
+    Future.successful(())
+  }
+
+  start()
+}

--- a/app/org/maproulette/jobs/JobModule.scala
+++ b/app/org/maproulette/jobs/JobModule.scala
@@ -12,5 +12,6 @@ class JobModule extends AbstractModule with AkkaGuiceSupport {
   def configure() : Unit = {
     bindActor[SchedulerActor]("scheduler-actor")
     bind(classOf[Scheduler]).asEagerSingleton()
+    bind(classOf[Bootstrap]).asEagerSingleton()
   }
 }

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -336,8 +336,8 @@ class TaskDAL @Inject()(override val db: Database,
     }
   }
 
-  def updateTaskLocation(taskId: Long): Int = {
-    this.db.withTransaction { implicit c =>
+  def updateTaskLocation(taskId: Long)(implicit c: Option[Connection] = None): Int = {
+    this.withMRTransaction { implicit c =>
       // Update the location of the particular task
       SQL"""UPDATE tasks
             SET location = (SELECT ST_Centroid(ST_Collect(ST_Makevalid(geom)))
@@ -347,8 +347,8 @@ class TaskDAL @Inject()(override val db: Database,
     }
   }
 
-  def updateTaskLocations(challengeId: Long): Int = {
-    this.db.withTransaction { implicit c =>
+  def updateTaskLocations(challengeId: Long)(implicit c: Option[Connection] = None): Int = {
+    this.withMRTransaction { implicit c =>
       // update all the tasks of a particular challenge
       SQL"""DO $$
             DECLARE

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,8 +86,8 @@ maproulette {
     updateLocations.interval="12 hours"
     cleanOldTasks {
       interval="24 hours"
-      olderThan="7 days"
-      statusFilter=[0,3]
+      olderThan="31 days"
+      statusFilter=[0, 3]
     }
   }
 }


### PR DESCRIPTION
Adding job on startup of server that will check that will remove any user except the default super user from the super user group. This makes sure that if the super user accounts are modified between restarts that it will respect the list and not allow users who previously were super users to continue to be super users even when there osm user id was removed from the super user list.

Elevated access to super user when creating tags. Although you don't need the elevated access to associate the tags with the challenges, if you are creating new tags in the process you will need the elevated access.