### PR TITLE
Updates in preparation for handling new MR3 frontend

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -4,6 +4,7 @@ package org.maproulette
 
 import javax.inject.{Inject, Singleton}
 
+import org.apache.commons.lang3.StringUtils
 import org.maproulette.actions.Actions
 import play.api.Application
 import play.api.libs.oauth.ConsumerKey
@@ -77,8 +78,24 @@ class Config @Inject() (implicit val application:Application) {
 
   lazy val signIn : Boolean = this.config.getBoolean(Config.KEY_SIGNIN).getOrElse(Config.DEFAULT_SIGNIN)
 
-  lazy val mr3JSSource : String = this.config.getString(Config.KEY_MR3_JS_SOURCE).get
-  lazy val mr3CSSSource : String = this.config.getString(Config.KEY_MR3_CSS_SOURCE).get
+  lazy val mr3JSManifest : String = this.config.getString(Config.KEY_MR3_MANIFEST).get
+  lazy val mr3StaticPath : Option[String] = {
+    val static = this.config.getString(Config.KEY_MR3_STATIC_PATH).getOrElse("")
+    if (StringUtils.isEmpty(static)) {
+      None
+    } else {
+      Some(static)
+    }
+  }
+  lazy val mr3DevMode : Boolean = this.config.getBoolean(Config.KEY_MR3_DEV_MODE).getOrElse(Config.DEFAULT_MR3_DEV_MODE)
+  lazy val mr3Host : String = {
+    val host = this.config.getString(Config.KEY_MR3_HOST).getOrElse(Config.DEFAULT_MR3_HOST)
+    if (StringUtils.isEmpty(host)) {
+      Config.DEFAULT_MR3_HOST
+    } else {
+      host
+    }
+  }
 
   /**
     * Retrieves a FiniteDuration config value from the configuration and executes the
@@ -129,8 +146,10 @@ object Config {
   val KEY_OSM_CONSUMER_SECRET = s"$GROUP_OSM.consumerSecret"
 
   val GROUP_MR3 = "mr3"
-  val KEY_MR3_JS_SOURCE = s"$GROUP_MR3.jsSource"
-  val KEY_MR3_CSS_SOURCE = s"$GROUP_MR3.cssSource"
+  val KEY_MR3_MANIFEST = s"$GROUP_MR3.manifest"
+  val KEY_MR3_STATIC_PATH = s"$GROUP_MR3.staticPath"
+  val KEY_MR3_DEV_MODE = s"$GROUP_MR3.devMode"
+  val KEY_MR3_HOST = s"$GROUP_MR3.host"
 
   val KEY_OSM_QL_PROVIDER = s"$GROUP_OSM.ql.provider"
   val KEY_OSM_QL_TIMEOUT = s"$GROUP_OSM.ql.timeout"
@@ -142,4 +161,6 @@ object Config {
   val DEFAULT_RECENT_ACTIVITY = 5
   val DEFAULT_LIST_SIZE = 10
   val DEFAULT_SIGNIN = false
+  val DEFAULT_MR3_DEV_MODE = false
+  val DEFAULT_MR3_HOST = "/external"
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,10 +110,12 @@ osm {
 }
 
 mr3 {
-  jsSource="http://localhost:3000/static/js/bundle.js"
-  jsSource=${?MR3_JS_ASSET_URI}
-  cssSource="http://localhost:3000/static/css/bundle.css"
-  cssSource=${?MR3_CSS_ASSET_URI}
+  devMode=false
+  host=""
+  manifest="asset-manifest.json"
+  manifest=${?MR3_MANIFEST_URI}
+  staticPath=""
+  staticPath=${?MR3_STATIC_PATH}
 }
 
 # Evolutions

--- a/conf/dev.conf
+++ b/conf/dev.conf
@@ -14,3 +14,5 @@ osm.consumerSecret="BRTrSbdy96enzaMr9JteXcvUZQi49Q2Aaf3n6Hse"
 play.http.parser.maxDiskBuffer=100M
 play.http.parser.maxMemoryBuffer=100M
 parsers.MultipartFormData.maxLength=100M
+#mr3.host="http://localhost:3000"
+mr3.staticPath="/maproulette-frontend/build"

--- a/conf/routes
+++ b/conf/routes
@@ -52,6 +52,8 @@ GET     /docs/swagger-ui/*file                                          @control
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file                                                   @controllers.Assets.versioned(path="/public", file)
 GET     /webjars/*file                                                  @controllers.WebJarAssets.at(file)
+# Map external resources
+GET     /external/*file                                                 @controllers.Application.externalResources(file)
 
 ->  /api/v2     apiv2.Routes
 


### PR DESCRIPTION
This update will allow for handling the new MR3 frontend. The new frontend can be served in a multitude of ways. Firstly the new frontend is completely separated from the backend and as such can be served to users in a couple of ways. These updates attempt to make it easy to handle it.

The new configuration gives you the following options:

```
mr3 {
    devMode=false
    host=""
    manifest="asset-manifest.json"
    manifest=${?MR3_MANIFEST_URI}
    staticPath=""
    staticPath=${?MR3_STATIC_PATH}
}
```

- devMode - This mode is used when you are developing the frontend and have not packaged the frontend at all.
- host - If you are serving the new frontend outside of the Play framework you would input the host here. You can use this in conjunction with devMode to and set the value to `localhost:3000` which will then point to the version served by the command `yarn run start`
- manifest - The path to the manifest file. If using a hosted version, this would be the path that comes after the host. Ie. "/static/asset-manifest.json"
- staticPath - This would be the default deployment option, and if using the standard deployment the only option you would need to set. After running "yarn run build" the static path would simply point to the build location. This would need to be on the same server as the MapRoulette backend but can be placed anywhere. The backend would then parse the manifest file and get the location of the js and css files and serve all the content directly from there.