### PR TITLE
Virtual Challenges

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -63,10 +63,10 @@ class Application @Inject() (val messagesApi: MessagesApi,
     }
   }
 
-  def runJob(name:String) : Action[AnyContent] = Action.async { implicit request =>
+  def runJob(name:String, action:String) : Action[AnyContent] = Action.async { implicit request =>
     implicit val requireSuperUser = true
     sessionManager.authenticatedRequest { implicit user =>
-      schedulerActor ! RunJob(name)
+      schedulerActor ! RunJob(name, action)
       Ok
     }
   }

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -52,6 +52,15 @@ class Config @Inject() (implicit val application:Application) {
   lazy val numberOfActivities : Int =
     this.config.getInt(Config.KEY_RECENT_ACTIVITY).getOrElse(Config.DEFAULT_RECENT_ACTIVITY)
 
+  lazy val virtualChallengeLimit : Double =
+    this.config.getDouble(Config.KEY_VIRTUAL_CHALLENGE_LIMIT).getOrElse(Config.DEFAULT_VIRTUAL_CHALLENGE_LIMIT)
+
+  lazy val virtualChallengeBatchSize : Int =
+    this.config.getInt(Config.KEY_VIRTUAL_CHALLENGE_BATCH_SIZE).getOrElse(Config.DEFAULT_VIRTUAL_CHALLENGE_BATCH_SIZE)
+
+  lazy val virtualChallengeExpiry : Duration =
+    Duration(this.config.getString(Config.KEY_VIRTUAL_CHALLENGE_EXPIRY).getOrElse(Config.DEFAULT_VIRTUAL_CHALLENGE_EXPIRY))
+
   lazy val getOSMOauth : OSMOAuth = {
     val osmServer = this.config.getString(Config.KEY_OSM_SERVER).get
     OSMOAuth(
@@ -135,6 +144,7 @@ object Config {
   val KEY_SCHEDULER_CLEAN_TASKS_INTERVAL = s"$SUB_GROUP_SCHEDULER.cleanOldTasks.interval"
   val KEY_SCHEDULER_CLEAN_TASKS_STATUS_FILTER = s"$SUB_GROUP_SCHEDULER.cleanOldTasks.statusFilter"
   val KEY_SCHEDULER_CLEAN_TASKS_OLDER_THAN = s"$SUB_GROUP_SCHEDULER.cleanOldTasks.olderThan"
+  val KEY_SCHEDULER_CLEAN_VC_INTEVAL = s"$SUB_GROUP_SCHEDULER.cleanExpiredVCs.interval"
 
   val GROUP_OSM = "osm"
   val KEY_OSM_SERVER = s"$GROUP_OSM.server"
@@ -151,11 +161,16 @@ object Config {
   val KEY_MR3_DEV_MODE = s"$GROUP_MR3.devMode"
   val KEY_MR3_HOST = s"$GROUP_MR3.host"
 
+  val GROUP_CHALLENGES = "challenges"
+  val KEY_VIRTUAL_CHALLENGE_LIMIT = s"$GROUP_CHALLENGES.virtual.limit"
+  val KEY_VIRTUAL_CHALLENGE_BATCH_SIZE = s"$GROUP_CHALLENGES.virtual.batchSize"
+  val KEY_VIRTUAL_CHALLENGE_EXPIRY = s"$GROUP_CHALLENGES.virtual.expiry"
+
   val KEY_OSM_QL_PROVIDER = s"$GROUP_OSM.ql.provider"
   val KEY_OSM_QL_TIMEOUT = s"$GROUP_OSM.ql.timeout"
 
   val DEFAULT_SESSION_TIMEOUT = 3600000L
-  val DEFAULT_TASK_RESET= 7
+  val DEFAULT_TASK_RESET = 7
   val DEFAULT_OSM_QL_TIMEOUT = 25
   val DEFAULT_NUM_OF_CHALLENGES = 3
   val DEFAULT_RECENT_ACTIVITY = 5
@@ -163,4 +178,7 @@ object Config {
   val DEFAULT_SIGNIN = false
   val DEFAULT_MR3_DEV_MODE = false
   val DEFAULT_MR3_HOST = "/external"
+  val DEFAULT_VIRTUAL_CHALLENGE_LIMIT = 100
+  val DEFAULT_VIRTUAL_CHALLENGE_BATCH_SIZE = 500
+  val DEFAULT_VIRTUAL_CHALLENGE_EXPIRY ="6 hours"
 }

--- a/app/org/maproulette/actions/Actions.scala
+++ b/app/org/maproulette/actions/Actions.scala
@@ -37,6 +37,7 @@ class ItemType(id:Int) {
       case ta:TagType => new TagItem(itemId)
       case u:UserType => new UserItem(itemId)
       case s:SurveyType => new SurveyItem(itemId)
+      case vc:VirtualChallengeType => new VirtualChallengeItem(itemId)
     }
   }
 }
@@ -52,6 +53,7 @@ case class TaskType() extends ItemType(Actions.ITEM_TYPE_TASK)
 case class TagType() extends ItemType(Actions.ITEM_TYPE_TAG)
 case class UserType() extends ItemType(Actions.ITEM_TYPE_USER)
 case class GroupType() extends ItemType(Actions.ITEM_TYPE_GROUP)
+case class VirtualChallengeType() extends ItemType(Actions.ITEM_TYPE_VIRTUAL_CHALLENGE)
 
 class ProjectItem(override val itemId:Long) extends ProjectType with Item
 class ChallengeItem(override val itemId:Long) extends ChallengeType with Item
@@ -59,6 +61,7 @@ class TaskItem(override val itemId:Long) extends TaskType with Item
 class TagItem(override val itemId:Long) extends TagType with Item
 class UserItem(override val itemId:Long) extends UserType with Item
 class SurveyItem(override val itemId:Long) extends SurveyType with Item
+class VirtualChallengeItem(override val itemId:Long) extends VirtualChallengeType with Item
 
 case class Updated() extends ActionType(Actions.ACTION_TYPE_UPDATED, Actions.ACTION_LEVEL_2)
 case class Created() extends ActionType(Actions.ACTION_TYPE_CREATED, Actions.ACTION_LEVEL_2)
@@ -88,6 +91,8 @@ object Actions {
   val ITEM_TYPE_USER_NAME = "User"
   val ITEM_TYPE_GROUP = 6
   val ITEM_TYPE_GROUP_NAME = "Group"
+  val ITEM_TYPE_VIRTUAL_CHALLENGE = 7
+  val ITEM_TYPE_VIRTUAL_CHALLENGE_NAME = "VirtualChallenge"
   val itemIDMap = Map(
     ITEM_TYPE_PROJECT -> (ITEM_TYPE_PROJECT_NAME, ProjectType()),
     ITEM_TYPE_CHALLENGE -> (ITEM_TYPE_CHALLENGE_NAME, ChallengeType()),
@@ -95,7 +100,8 @@ object Actions {
     ITEM_TYPE_TAG -> (ITEM_TYPE_TAG_NAME, TagType()),
     ITEM_TYPE_SURVEY -> (ITEM_TYPE_SURVEY_NAME, SurveyType()),
     ITEM_TYPE_USER -> (ITEM_TYPE_USER_NAME, UserType()),
-    ITEM_TYPE_GROUP -> (ITEM_TYPE_GROUP_NAME, GroupType())
+    ITEM_TYPE_GROUP -> (ITEM_TYPE_GROUP_NAME, GroupType()),
+    ITEM_TYPE_VIRTUAL_CHALLENGE -> (ITEM_TYPE_VIRTUAL_CHALLENGE_NAME, VirtualChallengeType())
   )
 
   val ACTION_TYPE_UPDATED = 0

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -25,6 +25,7 @@ class Scheduler @Inject() (val system: ActorSystem,
   schedule("runChallengeSchedules", "Running challenge Schedules", 1.minute, Config.KEY_SCHEDULER_RUN_CHALLENGE_SCHEDULES_INTERVAL)
   schedule("updateLocations", "Updating locations", 1.minute, Config.KEY_SCHEDULER_UPDATE_LOCATIONS_INTERVAL)
   schedule("cleanOldTasks", "Cleaning old tasks", 1.minute, Config.KEY_SCHEDULER_CLEAN_TASKS_INTERVAL)
+  schedule("cleanExpiredVirtualChallenges", "Cleaning up expired Virtual Challenges", 1.minute, Config.KEY_SCHEDULER_CLEAN_VC_INTEVAL)
 
   /**
     * Conditionally schedules message event when configured with a valid duration

--- a/app/org/maproulette/models/VirtualChallenge.scala
+++ b/app/org/maproulette/models/VirtualChallenge.scala
@@ -1,0 +1,27 @@
+package org.maproulette.models
+
+import org.joda.time.DateTime
+import org.maproulette.actions.{ItemType, VirtualChallengeType}
+import org.maproulette.session.SearchParameters
+import play.api.libs.json.{DefaultWrites, Json, Reads, Writes}
+
+/**
+  * @author mcuthbert
+  */
+case class VirtualChallenge(override val id:Long,
+                            override val name:String,
+                            override val created:DateTime,
+                            override val modified:DateTime,
+                            override val description:Option[String]=None,
+                            searchParameters:SearchParameters,
+                            expiry:DateTime) extends BaseObject[Long] with DefaultWrites {
+
+  override val itemType: ItemType = VirtualChallengeType()
+
+  def isExpired = DateTime.now().isAfter(expiry)
+}
+
+object VirtualChallenge {
+  implicit val virtualChallengeWrites:Writes[VirtualChallenge] = Json.writes[VirtualChallenge]
+  implicit val virtualChallengeReads:Reads[VirtualChallenge] = Json.reads[VirtualChallenge]
+}

--- a/app/org/maproulette/models/dal/Locking.scala
+++ b/app/org/maproulette/models/dal/Locking.scala
@@ -1,0 +1,150 @@
+package org.maproulette.models.dal
+
+import java.sql.Connection
+
+import anorm._
+import org.maproulette.actions.ItemType
+import org.maproulette.exception.{LockedException, NotFoundException}
+import org.maproulette.models.BaseObject
+import org.maproulette.models.utils.TransactionManager
+import org.maproulette.session.User
+
+/**
+  * @author mcuthbert
+  */
+trait Locking[T<:BaseObject[_]] extends TransactionManager {
+  this:BaseDAL[_, _] =>
+
+  /**
+    * Locks an item in the database.
+    *
+    * @param user The user requesting the lock
+    * @param item The item wanting to be locked
+    * @param c A sql connection that is implicitly passed in from the calling function, this is an
+    *          implicit function because this will always be called from within the code and never
+    *          directly from an API call
+    * @return true if successful
+    */
+  def lockItem(user:User, item:T)(implicit c:Option[Connection]=None) : Int =
+    this.withMRTransaction { implicit c =>
+      // first check to see if the item is already locked
+      val checkQuery =
+        s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${item.itemType.typeId} FOR UPDATE"""
+      SQL(checkQuery).on('itemId -> ParameterValue.toParameterValue(item.id)(p = keyToStatement)).as(SqlParser.long("user_id").singleOpt) match {
+        case Some(id) =>
+          if (id == user.id) {
+            val query = s"UPDATE locked SET date = NOW() WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${item.itemType.typeId}"
+            SQL(query).on('itemId -> ParameterValue.toParameterValue(item.id)(p = keyToStatement)).executeUpdate()
+          } else {
+            0
+            //throw new LockedException(s"Could not acquire lock on object [${item.id}, already locked by user [$id]")
+          }
+        case None =>
+          val query = s"INSERT INTO locked (item_type, item_id, user_id) VALUES (${item.itemType.typeId}, {itemId}, ${user.id})"
+          SQL(query).on('itemId -> ParameterValue.toParameterValue(item.id)(p = keyToStatement)).executeUpdate()
+      }
+    }
+
+  /**
+    * Unlocks an item in the database
+    *
+    * @param user The user requesting to unlock the item
+    * @param item The item being unlocked
+    * @param c A sql connection that is implicitly passed in from the calling function, this is an
+    *          implicit function because this will always be called from within the code and never
+    *          directly from an API call
+    * @return true if successful
+    */
+  def unlockItem(user:User, item:T)(implicit c:Option[Connection]=None) : Int =
+    this.withMRTransaction { implicit c =>
+      val checkQuery = s"""SELECT user_id FROM locked WHERE item_id = {itemId} AND item_type = ${item.itemType.typeId} FOR UPDATE"""
+      SQL(checkQuery).on('itemId -> ParameterValue.toParameterValue(item.id)(p = keyToStatement)).as(SqlParser.long("user_id").singleOpt) match {
+        case Some(id) =>
+          if (id == user.id) {
+            val query = s"""DELETE FROM locked WHERE user_id = ${user.id} AND item_id = {itemId} AND item_type = ${item.itemType.typeId}"""
+            SQL(query).on('itemId -> ParameterValue.toParameterValue(item.id)(p = keyToStatement)).executeUpdate()
+          } else {
+            throw new LockedException(s"Item [${item.id}] currently locked by different user. [${user.id}")
+          }
+        case None => throw new LockedException(s"Item [${item.id}] trying to unlock does not exist.")
+      }
+    }
+
+  /**
+    * Unlocks all the items that are associated with the current user
+    *
+    * @param user The user
+    * @param c an implicit connection, this function should generally be executed in conjunction
+    *          with other requests
+    * @return Number of locks removed
+    */
+  def unlockAllItems(user:User, itemType:Option[ItemType]=None)(implicit c:Option[Connection]=None) : Int =
+    this.withMRTransaction { implicit c =>
+      itemType match {
+        case Some(it) =>
+          SQL"""DELETE FROM locked WHERE user_id = ${user.id} AND item_type = ${it.typeId}""".executeUpdate()
+        case None =>
+          SQL"""DELETE FROM locked WHERE user_id = ${user.id}""".executeUpdate()
+      }
+    }
+
+  /**
+    * Method to lock all items returned in the lambda block. It will first all unlock all items
+    * that have been locked by the user.
+    *
+    * @param user The user making the request
+    * @param itemType The type of item that will be locked
+    * @param block The block of code to execute inbetween unlocking and locking items
+    * @param c The connection
+    * @return List of objects
+    */
+  def withListLocking(user:User, itemType:Option[ItemType]=None)(block:() => List[T])
+                  (implicit c:Option[Connection]=None) : List[T] = {
+    this.withMRTransaction { implicit c =>
+      // if a user is requesting a task, then we can unlock all other tasks for that user, as only a single
+      // task can be locked at a time
+      this.unlockAllItems(user, itemType)
+      val results = block()
+      // once we have the tasks, we need to lock each one, if any fail to lock we just remove
+      // them from the list. A guest user will not lock any tasks, but when logged in will be
+      // required to refetch the current task, and if it is locked, then will have to get another
+      // task
+      if (!user.guest) {
+        val resultList = results.filter(lockItem(user, _) > 0)
+        if (resultList.isEmpty) {
+          throw new NotFoundException("No objects found.")
+        }
+        resultList
+      } else {
+        results
+      }
+    }
+  }
+
+  /**
+    * Method to lock a single optional item returned in a lambda block. It will first unlock all items
+    * that have been locked by the user
+    *
+    * @param user The user making the request
+    * @param itemType The type of item that will be locked
+    * @param block The block of code to execute inbetween unlocking and locking items
+    * @param c The connection
+    * @return Option object
+    */
+  def withSingleLocking(user:User, itemType:Option[ItemType]=None)(block:() => Option[T])
+                      (implicit c:Option[Connection]=None) : Option[T] = {
+    this.withMRTransaction { implicit c =>
+      // if a user is requesting a task, then we can unlock all other tasks for that user, as only a single
+      // task can be locked at a time
+      this.unlockAllItems(user, itemType)
+      val result = block()
+      if (!user.guest) {
+        result match {
+          case Some(r) => lockItem(user, r)
+          case None => // ignore
+        }
+      }
+      result
+    }
+  }
+}

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -1,0 +1,304 @@
+package org.maproulette.models.dal
+
+import java.sql.Connection
+import javax.inject.Inject
+
+import anorm.SqlParser._
+import anorm._
+import org.joda.time.DateTime
+import org.maproulette.Config
+import org.maproulette.actions.{Actions, TaskType, VirtualChallengeType}
+import org.maproulette.cache.CacheManager
+import org.maproulette.exception.InvalidException
+import org.maproulette.models.{ClusteredPoint, Point, Task, VirtualChallenge}
+import org.maproulette.models.utils.DALHelper
+import org.maproulette.permissions.Permission
+import org.maproulette.session.{SearchLocation, SearchParameters, User}
+import play.api.db.Database
+import play.api.libs.json.{JsString, JsValue, Json}
+
+/**
+  * @author mcuthbert
+  */
+class VirtualChallengeDAL @Inject() (override val db:Database,
+                                     override val permission:Permission,
+                                     val taskDAL:TaskDAL,
+                                     val config:Config)
+  extends BaseDAL[Long, VirtualChallenge] with DALHelper with Locking[Task] {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  override val cacheManager = new CacheManager[Long, VirtualChallenge]
+  override val tableName: String = "virtual_challenges"
+
+  implicit val locationWrites = Json.writes[SearchLocation]
+  implicit val locationReads = Json.reads[SearchLocation]
+  implicit val paramsWrites = Json.writes[SearchParameters]
+  implicit val paramsReads = Json.reads[SearchParameters]
+
+  override val parser: RowParser[VirtualChallenge] = {
+    get[Long]("virtual_challenges.id") ~
+      get[String]("virtual_challenges.name") ~
+      get[DateTime]("virtual_challenges.created") ~
+      get[DateTime]("virtual_challenges.modified") ~
+      get[Option[String]]("virtual_challenges.description") ~
+      get[String]("virtual_challenges.search_parameters") ~
+      get[DateTime]("virtual_challenges.expiry") map {
+      case id ~ name ~ created ~ modified ~ description ~ searchParameters ~ expiry =>
+        new VirtualChallenge(id, name, created, modified, description, Json.parse(searchParameters).as[SearchParameters], expiry)
+    }
+  }
+
+  /**
+    * The insert function for virtual challenges needs to create a new challenge and then find all the
+    * tasks based on the search parameters in the virtual challenge
+    *
+    * @param element The element that you are inserting to the database
+    * @param user    The user executing the task
+    * @return The object that was inserted into the database. This will include the newly created id
+    */
+  override def insert(element: VirtualChallenge, user: User)(implicit c: Option[Connection]=None): VirtualChallenge = {
+    permission.hasWriteAccess(VirtualChallengeType(), user)(-1)
+    this.cacheManager.withOptionCaching { () =>
+      withMRTransaction { implicit c =>
+        element.searchParameters.location match {
+          case Some(box) if ((box.right - box.left) * (box.top - box.bottom)) < config.virtualChallengeLimit =>
+              val query = """INSERT INTO virtual_challenges (owner_id, name, description, search_parameters, expiry)
+                             VALUES ({owner}, {name}, {description}, {parameters}, {expiry}::timestamp)
+                             RETURNING *"""
+              val newChallenge = SQL(query).on(
+                'owner -> user.osmProfile.id,
+                'name -> element.name,
+                'description -> element.description,
+                'parameters -> Json.toJson(element.searchParameters).toString(),
+                'expiry -> ParameterValue.toParameterValue(String.valueOf(element.expiry))
+              ).as(this.parser.single)
+            c.commit()
+            this.rebuildVirtualChallenge(newChallenge.id, element.searchParameters, user)
+            Some(newChallenge)
+          case _ =>
+            throw new InvalidException(s"Bounding Box that has an area smaller than ${config.virtualChallengeLimit} required to create virtual challenge.")
+        }
+      }
+    }.get
+  }
+
+  /**
+    * The update function is limited in that you can only update the superficial elements, name
+    * and description. The only value of consequence that you can update is expiry, which by default
+    * is set to a day but can be extended by the user.
+    *
+    * @param updates The updates in json form
+    * @param user The user executing the task
+    * @param id The id of the object that you are updating
+    * @param c
+    * @return An optional object, it will return None if no object found with a matching id that was supplied
+    */
+  override def update(updates: JsValue, user: User)(implicit id: Long, c: Option[Connection]=None): Option[VirtualChallenge] = {
+    permission.hasWriteAccess(VirtualChallengeType(), user)
+    this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit cachedItem =>
+      withMRTransaction { implicit c =>
+        // first if the virtual challenge has expired then just delete it
+        val expiry = (updates \ "expiry").asOpt[DateTime].getOrElse(cachedItem.expiry)
+        if (DateTime.now().isAfter(expiry)) {
+          this.delete(cachedItem.id, user)
+          throw new InvalidException("Could not update virtual challenge as it has already expired")
+        } else {
+          val name = (updates \ "name").asOpt[String].getOrElse(cachedItem.name)
+          val description = (updates \ "description").asOpt[String].getOrElse(cachedItem.description.getOrElse(""))
+          val query = """UPDATE virtual_challenges
+               SET name = {name}, description = {description}, expiry = {expiry}::timestamp
+               WHERE id = {id} RETURNING *"""
+          SQL(query)
+              .on(
+                'name -> name,
+                'description -> description,
+                'expiry -> ParameterValue.toParameterValue(String.valueOf(expiry)),
+                'id -> id
+              ).as(this.parser.*).headOption
+        }
+      }
+    }
+  }
+
+  /**
+    * This function will rebuild the virtual challenge based on the search parameters that have been stored with the object
+    *
+    * @param id The id of the virtual challenge
+    * @param user The user making the request
+    * @param c implicit connection
+    * @return
+    */
+  def rebuildVirtualChallenge(id:Long, params:SearchParameters, user:User)(implicit c:Option[Connection]=None) : Unit = {
+    permission.hasWriteAccess(VirtualChallengeType(), user)(id)
+    withMRTransaction { implicit c =>
+      this.taskDAL.getTasksInBoundingBox(params, -1, 0).grouped(config.virtualChallengeBatchSize).foreach(batch => {
+        val insertRows = batch.map(point => s"(${point.id}, $id)").mkString(",")
+        SQL"""
+           INSERT INTO virtual_challenge_tasks (task_id, virtual_challenge_id) VALUES #$insertRows
+         """.execute()
+        c.commit()
+      })
+    }
+  }
+
+  def listTasks(id:Long, user:User, limit:Int, offset:Int)(implicit c:Option[Connection]=None) : List[Task] = {
+    permission.hasReadAccess(VirtualChallengeType(), user)(id)
+    withMRTransaction { implicit c =>
+      SQL"""SELECT tasks.#${taskDAL.retrieveColumns} FROM tasks
+            INNER JOIN virtual_challenge_tasks vct ON vct.task_id = tasks.id
+            WHERE virtual_challenge_id = $id
+            LIMIT #${sqlLimit(limit)} OFFSET $offset""".as(taskDAL.parser.*)
+    }
+  }
+
+  /**
+    * Gets a random task from the list of tasks associated with the virtual challenge
+    *
+    * @param id The id of the virtual challenge
+    * @param params The search parameters, most of the parameters will not be used
+    * @param user The user making the request
+    * @param proximityId Id of the task to find the closest next task
+    * @param c
+    * @return An optional Task, None if no tasks available
+    */
+  def getRandomTask(id:Long, params:SearchParameters, user:User, proximityId:Option[Long] = None)
+                   (implicit c:Option[Connection]=None) : Option[Task] = {
+    permission.hasReadAccess(VirtualChallengeType(), user)(id)
+    // The default where clause will check to see if the parents are enabled, that the task is
+    // not locked (or if it is, it is locked by the current user) and that the status of the task
+    // is either Created or Skipped
+    val taskStatusList = params.taskStatus match {
+      case Some(l) if l.nonEmpty => l
+      case _ => List(Task.STATUS_CREATED, Task.STATUS_SKIPPED, Task.STATUS_TOO_HARD)
+    }
+
+    val whereClause = new StringBuilder(s"""
+      WHERE vct.virtual_challenge_id = $id AND
+      (l.id IS NULL OR l.user_id = ${user.id}) AND
+      tasks.status IN ({statusList})
+    """)
+
+    val proximityOrdering = proximityId match {
+      case Some(id) =>
+        appendInWhereClause(whereClause, s"tasks.id != $id")
+        s"ST_Distance(tasks.location, (SELECT location FROM tasks WHERE id = $id)),"
+      case None => ""
+    }
+
+    val query = s"""SELECT tasks.${taskDAL.retrieveColumns} FROM tasks
+            LEFT JOIN locked l ON l.item_id = tasks.id
+            INNER JOIN virtual_challenge_tasks vct ON vct.task_id = tasks.id
+            ${whereClause.toString}
+            ORDER BY $proximityOrdering tasks.status, RANDOM() LIMIT 1"""
+
+    this.withSingleLocking(user, Some(TaskType())) { () =>
+      withMRTransaction { implicit c =>
+        SQL(query)
+          .on(
+            'statusList -> ParameterValue.toParameterValue(taskStatusList)
+          ).as(taskDAL.parser.*).headOption
+      }
+    }
+  }
+
+  /**
+    * Gets the combined geometry of all the tasks that are associated with the virtual challenge
+    * NOTE* Due to the way this function finds the geometries, it could be quite slow.
+    *
+    * @param challengeId The id for the virtual challenge
+    * @param statusFilter To view the geojson for only tasks with a specific status
+    * @param c The implicit connection for the function
+    * @return A JSON string representing the geometry
+    */
+  def getChallengeGeometry(challengeId:Long, statusFilter:Option[List[Int]]=None)(implicit c:Option[Connection]=None) : String = {
+    this.withMRConnection { implicit c =>
+      val filter = statusFilter match {
+        case Some(s) => s"AND status IN (${s.mkString(",")}"
+        case None => ""
+      }
+      SQL"""SELECT row_to_json(fc)::text as geometries
+            FROM ( SELECT 'FeatureCollection' As type, array_to_json(array_agg(f)) As features
+                   FROM ( SELECT 'Feature' As type,
+                                  ST_AsGeoJSON(lg.geom)::json As geometry,
+                                  hstore_to_json(lg.properties) As properties
+                          FROM task_geometries As lg
+                          WHERE task_id IN
+                          (SELECT DISTINCT id FROM tasks WHERE id IN
+                            (SELECT task_id FROM virtual_challenge_tasks
+                              WHERE virtual_challenge_id = $challengeId)) #$filter
+                    ) As f
+            )  As fc""".as(str("geometries").single)
+    }
+  }
+
+  /**
+    * Retrieves the json that contains the central points for all the tasks in the virtual challenge
+    *
+    * @param challengeId The id of the virtual challenge
+    * @param statusFilter Filter the displayed task cluster points by their status
+    * @return A list of clustered point objects
+    */
+  def getClusteredPoints(challengeId:Long, statusFilter:Option[List[Int]]=None)
+                        (implicit c:Option[Connection]=None) : List[ClusteredPoint] = {
+    this.withMRConnection { implicit c =>
+      val filter = statusFilter match {
+        case Some(s) => s"AND status IN (${s.mkString(",")}"
+        case None => ""
+      }
+      val pointParser = long("id") ~ str("name") ~ str("instruction") ~ str("location") ~ int("status") map {
+        case id ~ name ~ instruction ~ location ~ status =>
+          val locationJSON = Json.parse(location)
+          val coordinates = (locationJSON \ "coordinates").as[List[Double]]
+          val point = Point(coordinates(1), coordinates.head)
+          ClusteredPoint(id, -1, "", name, point, JsString(""), instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status)
+      }
+      SQL"""SELECT id, name, instruction, status,
+                      ST_AsGeoJSON(location) AS location
+              FROM tasks WHERE id IN
+              (SELECT task_id FROM virtual_challenge_tasks
+                WHERE virtual_challenge_id = $challengeId) #$filter"""
+        .as(pointParser.*)
+    }
+  }
+
+  // --- FOLLOWING FUNCTION OVERRIDE BASE FUNCTION TO SIMPLY REMOVE ANY RETRIEVED VIRTUAL CHALLENGES
+  // --- THAT ARE EXPIRED
+  override def retrieveById(implicit id: Long, c: Option[Connection]=None): Option[VirtualChallenge] = {
+    super.retrieveById match {
+      case Some(vc) if vc.isExpired =>
+        this.delete(id, User.superUser)
+        None
+      case x => x
+    }
+  }
+
+  override def retrieveByName(implicit name: String, parentId: Long, c: Option[Connection]=None): Option[VirtualChallenge] = {
+    super.retrieveByName match {
+      case Some(vc) if vc.isExpired =>
+        this.delete(vc.id, User.superUser)
+        None
+      case x => x
+    }
+  }
+
+  override def retrieveListById(limit: Int, offset: Int)(implicit ids: List[Long], c: Option[Connection]=None): List[VirtualChallenge] =
+    super.retrieveListById(limit, offset).filter(!_.isExpired)
+
+  override def retrieveListByName(implicit names: List[String], parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
+    super.retrieveListByName.filter(!_.isExpired)
+
+  override def retrieveListByPrefix(prefix: String, limit: Int, offset: Int, onlyEnabled: Boolean, orderColumn: String, orderDirection: String)
+                                   (implicit parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
+    super.retrieveListByPrefix(prefix, limit, offset, onlyEnabled, orderColumn, orderDirection).filter(!_.isExpired)
+
+  override def find(searchString: String, limit: Int, offset: Int, onlyEnabled: Boolean, orderColumn: String, orderDirection: String)
+                   (implicit parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
+    super.find(searchString, limit, offset, onlyEnabled, orderColumn, orderDirection).filter(!_.isExpired)
+
+  override def list(limit: Int, offset: Int, onlyEnabled: Boolean, searchString: String, orderColumn: String, orderDirection: String)
+                   (implicit parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
+    super.list(limit, offset, onlyEnabled, searchString, orderColumn, orderDirection).filter(!_.isExpired)
+
+  // --- END OF OVERRIDDEN FUNCTIONS TO FILTER OUT ANY EXPIRED VIRTUAL CHALLENGES
+}

--- a/app/org/maproulette/services/ChallengeService.scala
+++ b/app/org/maproulette/services/ChallengeService.scala
@@ -64,7 +64,7 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
                 this.challengeDAL.update(Json.obj("overpassStatus" -> Challenge.STATUS_FAILED), user)(challenge.id)
             }
             true
-          case None => false
+          case _ => false
         }
       } else {
         false

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1194,6 +1194,238 @@ GET     /challenge/:id/comments                     @org.maproulette.controllers
 ###
 GET     /challenge/:id/comments/extract             @org.maproulette.controllers.api.ChallengeController.extractComments(id:Long, limit:Int ?= -1, page:Int ?= 0)
 ###
+# tags: [ Virtual Challenge ]
+# summary: Create a Virtual Challenge
+# consumes: [ application/json ]
+# produces: [ application/json ]
+# description: Will create a new Virtual Challenge from the supplied JSON in the body.
+#               When creating the Virtual Challenge, leave the ID field out of the body json,
+#               if updating (generally use the PUT method) include the ID field.
+# responses:
+#   '200':
+#     description: The newly created Virtual Challenge with a unique id.
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.VirtualChallenge'
+#   '304':
+#     description: Not updated responding with empty payload if Virtual Challenge already exists and nothing to update
+#   '400':
+#     description: Invalid json payload for Virtual Challenge
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: body
+#     in: body
+#     description: The JSON structure for the Virtual Challenge body.
+#     required: true
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.VirtualChallenge'
+###
+POST    /virtualchallenge                           @org.maproulette.controllers.api.VirtualChallengeController.create
+###
+# tags: [ Virtual Challenge ]
+# summary: Updates a Virtual Challenge
+# consumes: [ application/json ]
+# produces: [ application/json ]
+# description: Will update an already existing Virtual Challenge from the supplied JSON in the body.
+# responses:
+#   '200':
+#     description: The updated JSON Virtual Challenge
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.VirtualChallenge'
+#   '304':
+#     description: Not updated responding with empty payload if Virtual Challenge already exists and nothing to update
+#   '400':
+#     description: Invalid json payload for Virtual Challenge
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the Virtual Challenge that is being updated
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: body
+#     in: body
+#     description: The JSON structure for the Virtual Challenge body.
+#     required: true
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Challenge'
+###
+PUT     /virtualchallenge/:id                       @org.maproulette.controllers.api.VirtualChallengeController.update(id:Long)
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves an already existing Virtual Challenge
+# produces: [ application/json ]
+# description: Retrieves an already existing Virtual Challenge based on the supplied ID in the URL.
+# responses:
+#   '200':
+#     description: The retrieved Virtual Challenge
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.VirtualChallenge'
+#   '404':
+#     description: ID field supplied but no object found matching the id
+# parameters:
+#   - name: id
+#     description: The id of the Virtual Challenge to retrieve
+###
+GET     /virtualchallenge/:id                              @org.maproulette.controllers.api.VirtualChallengeController.read(id:Long)
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves an already existing Virtual Challenge
+# produces: [ application/json ]
+# description: Retrieves an already existing Virtual Challenge based on the name of the Virtual Challenge rather than an ID
+# responses:
+#   '200':
+#     description: The retrieved Virtual Challenge
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.VirtualChallenge'
+#   '404':
+#     description: No Virtual Challenge found matching the provided name
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the parent Project of the Virtual Challenge
+#   - name: name
+#     in: path
+#     description: The name of the Virtual Challenge being retrieved
+###
+GET     /virtualchallengebyname/:name                   @org.maproulette.controllers.api.VirtualChallengeController.readByName(id:Long ?= -1, name:String)
+###
+# tags: [ Virtual Challenge ]
+# summary: Deletes an existing Virtual Challenge
+# description: Deletes an existing Virtual Challenge based on the supplied ID. This will delete all associated Tasks of the Virtual Challenge.
+# responses:
+#   '200':
+#     description: A status message containing the ID of the Virtual Challenge that was just deleted
+#     schema:
+#       $ref: '#/definitions/org.maproulette.exception.StatusMessage'
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Virtual Challenge found matching the provided id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Virtual Challenge being deleted
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+DELETE  /virtualchallenge/:id                           @org.maproulette.controllers.api.VirtualChallengeController.delete(id:Long)
+###
+# tags: [ Virtual Challenge ]
+# summary: List all the Virtual Challenge.
+# produces: [ application/json ]
+# description: Lists all the Virtual Challenges in the system
+# responses:
+#   '200':
+#     description: A list of all the Virtual Challenges
+#     schema:
+#       type: array
+#       $ref: '#/definitions/org.maproulette.models.VirtualChallenge'
+# parameters:
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /virtualchallenges                              @org.maproulette.controllers.api.VirtualChallengeController.list(limit:Int ?= 10, page:Int ?= 0, onlyEnabled:Boolean ?= false)
+###
+# tags: [ Virtual Challenge ]
+# summary: List all the Virtual Challenges Tasks.
+# consumes: [ application/json ]
+# produces: [ application/json ]
+# description: Lists all the Tasks that are children of the supplied Virtual Challenge.
+# responses:
+#   '200':
+#     description: A list of all the Tasks
+#     schema:
+#       type: array
+#       $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: id
+#     in: path
+#     description: The project ID.
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /virtualchallenge/:id/tasks                     @org.maproulette.controllers.api.VirtualChallengeController.listTasks(id:Long, limit:Int ?= 10, page:Int ?= 0)
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves random Task
+# produces: [ application/json ]
+# description: Retrieves a random Task based on the search criteria and contained within the current Virtual Challenge
+# responses:
+#   '200':
+#     description: The task if any is found
+#     schema:
+#       type: array
+#       $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: cid
+#     in: path
+#     description: The id of the Virtual Challenge limiting the tasks to only a descendent of that Virtual Challenge.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
+###
+GET     /virtualchallenge/:cid/task                 @org.maproulette.controllers.api.VirtualChallengeController.getRandomTask(cid:Long, proximity:Long ?= -1)
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves Virtual Challenge GeoJSON
+# produces: [ application/json ]
+# description: Retrieves the GeoJSON for the Virtual Challenge that represents all the associated Tasks of the Virtual Challenge.
+#               WARNING* This API query can be quite slow due to retrieving all the points that is grouped in various different challenges
+# responses:
+#   '200':
+#     description: Standard GeoJSON Virtual Challenge Geometry
+#   '404':
+#     description: ID field supplied but no object found matching the id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the parent Virtual Challenge limiting the tasks to only a descendent of that Virtual Challenge.
+#   - name: filter
+#     in: query
+#     description: Can filter the Tasks returned by the status of the Task. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
+###
+GET     /virtualchallenge/view/:id                  @org.maproulette.controllers.api.VirtualChallengeController.getVirtualChallengeGeoJSON(id:Long, filter:String ?= "")
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves clustered Task points
+# produces: [ application/json ]
+# description: Retrieves all the Tasks for a specific Virtual Challenge as clustered points to potentially display on a map.
+# responses:
+#   '200':
+#     description: An array of clustered point representations for a Task. If none found will return an empty list
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.ClusteredPoint'
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the parent project.
+#   - name: filter
+#     in: query
+#     description: Can filter the Tasks returned by the status of the Task. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
+###
+GET     /virtualchallenge/clustered/:id             @org.maproulette.controllers.api.VirtualChallengeController.getClusteredPoints(id:Long, filter:String ?= "")
+###
 # tags: [ Survey ]
 # summary: Create a Survey
 # consumes: [ application/json ]

--- a/conf/evolutions/default/12.sql
+++ b/conf/evolutions/default/12.sql
@@ -1,0 +1,34 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- New table for virtual challenges
+CREATE TABLE IF NOT EXISTS virtual_challenges
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  owner_id integer NOT NULL,
+  name character varying NULL,
+  created timestamp without time zone DEFAULT NOW(),
+  modified timestamp without time zone DEFAULT NOW(),
+  description character varying NULL,
+  search_parameters character varying NOT NULL,
+  expiry timestamp with time zone DEFAULT NOW() + INTERVAL '1 day'
+);;
+
+SELECT create_index_if_not_exists('virtual_challenges', 'owner_id', '(owner_id)');;
+
+CREATE TABLE IF NOT EXISTS virtual_challenge_tasks
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  task_id integer NOT NULL,
+  virtual_challenge_id integer NOT NULL,
+  CONSTRAINT virtual_challenges_tasks_task_id_fkey FOREIGN KEY (task_id)
+    REFERENCES tasks(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT virtual_challenges_tasks_virtual_challenge_id_fkey FOREIGN KEY (virtual_challenge_id)
+    REFERENCES virtual_challenges(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE
+);;
+
+SELECT create_index_if_not_exists('virtual_challenge_tasks', 'virtual_challenge_id', '(virtual_challenge_id)');;
+
+# --- !Downs

--- a/conf/routes
+++ b/conf/routes
@@ -34,7 +34,7 @@ GET     /auth/addUser/:userId/toProject/:projectId                      @control
 GET     /refreshProfile                                                 @controllers.Application.refreshProfile
 GET     /clearCaches                                                    @controllers.Application.clearCaches
 GET     /javascriptRoutes                                               @controllers.Application.javascriptRoutes
-PUT     /runJob/:name                                                   @controllers.Application.runJob(name:String)
+PUT     /runJob/:name                                                   @controllers.Application.runJob(name:String, action:String ?= "")
 # MAPPING ROUTES
 GET     /map/:parentId/:taskId                                          @controllers.Application.mapTask(parentId:Long, taskId:Long)
 GET     /map/:parentId                                                  @controllers.Application.mapChallenge(parentId:Long)

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -18,6 +18,7 @@
   tags:
     - name: "Project"
     - name: "Challenge"
+    - name: "Virtual Challenge"
     - name: "Survey"
     - name: "Task"
     - name: "Keyword"

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -1,10 +1,9 @@
 {
-	"variables": [],
 	"info": {
 		"name": "maproulette2",
 		"_postman_id": "fc293308-9da6-f4cc-0e4e-a634dc3111e8",
 		"description": "",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -29,23 +28,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"SimpleProject\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
 						},
 						"description": "Creates a base project for all the other Map Roulette API Testing"
 					},
@@ -71,23 +80,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"SimpleChallenge\",\n    \"description\":\"A simple challenge containing only the basic elements for a challenge\",\n    \"parent\":{{SimpleProjectID}},\n    \"instruction\":\"Instruction for the simple challenge\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge"
+							]
 						},
 						"description": "Creates the most basic challenge with the least set of options in the body json"
 					},
@@ -109,23 +128,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{SimpleChallengeID}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{SimpleChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{SimpleChallengeID}}"
+							]
 						},
 						"description": "Deletes the challenge for the provided ID"
 					},
@@ -151,23 +181,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"TagsChallenge\",\n    \"description\":\"A simple challenge containing only the basic elements for a challenge and two tags\",\n    \"parent\":{{SimpleProjectID}},\n    \"instruction\":\"Instruction for the simple tag challenge\",\n    \"enabled\":false,\n    \"tags\":\"tag1,tag2\",\n    \"children\": [\n        {\n            \"name\":\"Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        },\n        {\n            \"name\":\"Task 2\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge"
+							]
 						},
 						"description": "Creates the most basic challenge with the least set of options and a couple of tags in the body json"
 					},
@@ -192,23 +232,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}"
+							]
 						},
 						"description": "Gets the challenge for the provided ID"
 					},
@@ -231,23 +282,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tasks"
+							]
 						},
 						"description": "Gets the tasks of the challenge for the provided ID"
 					},
@@ -267,23 +330,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "[\n    {\n        \"name\":\"Task 3\",\n        \"description\":\"Task 3 description\",\n        \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n    },\n    {\n        \"name\":\"Task 4\",\n        \"description\":\"Task 4 description\",\n        \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n    }\n]"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tasks"
+							]
 						},
 						"description": "Batch Upload two tasks to the challenge"
 					},
@@ -308,23 +383,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tasks"
+							]
 						},
 						"description": "Gets the tasks of the challenge for the provided ID"
 					},
@@ -347,23 +434,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tags"
+							]
 						},
 						"description": "Gets the tags for a challenge for the provided ID"
 					},
@@ -383,23 +482,41 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags?tags=tag1",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags?tags=tag1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tags"
+							],
+							"query": [
+								{
+									"key": "tags",
+									"value": "tag1"
+								}
+							]
 						},
 						"description": "Disassociates the tags from the challenge for the provided ID"
 					},
@@ -421,23 +538,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tags"
+							]
 						},
 						"description": "Gets the tags for a challenge for the provided ID"
 					},
@@ -462,23 +591,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"description\":\"Updated challenge description\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}"
+							]
 						},
 						"description": "Updates the challenge for the provided ID"
 					},
@@ -500,23 +640,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}"
+							]
 						},
 						"description": "Deletes the Tag challenge for the provided ID"
 					},
@@ -538,25 +689,919 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
 						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID}}"
+							]
+						},
 						"description": "Deletes the project that was used for the challenge tests."
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "VirtualChallenge",
+			"description": "",
+			"item": [
+				{
+					"name": "Challenge Project Creation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"SimpleProjectID\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
+									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"SimpleProject\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
+						},
+						"description": "Creates a base project for all the other Map Roulette API Testing"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Creation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"TagsChallengeID\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"TagsChallenge\";",
+									"tests[\"description\"] = jsonData.description === \"A simple challenge containing only the basic elements for a challenge and two tags\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"Instruction for the simple tag challenge\";",
+									"tests[\"challengeType\"] = jsonData.challengeType === 1;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"TagsChallenge\",\n    \"description\":\"A simple challenge containing only the basic elements for a challenge and two tags\",\n    \"parent\":{{SimpleProjectID}},\n    \"instruction\":\"Instruction for the simple tag challenge\",\n    \"enabled\":false,\n    \"tags\":\"tag1,tag2\",\n    \"children\": [\n        {\n            \"name\":\"Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        },\n        {\n            \"name\":\"Task 2\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge"
+							]
+						},
+						"description": "Creates the most basic challenge with the least set of options and a couple of tags in the body json"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Read",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"TagsChallenge\";",
+									"tests[\"description\"] = jsonData.description === \"A simple challenge containing only the basic elements for a challenge and two tags\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"Instruction for the simple tag challenge\";",
+									"tests[\"challengeType\"] = jsonData.challengeType === 1;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}"
+							]
+						},
+						"description": "Gets the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Tasks",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"Task1\"] = jsonData[0].name === \"Task 1\";",
+									"tests[\"Task2\"] = jsonData[1].name === \"Task 2\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tasks"
+							]
+						},
+						"description": "Gets the tasks of the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Creation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "52a22ad3-9739-4e09-9221-e5fea5718560",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"VirtualChallengeID\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"test\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t}\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Read",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5e033501-5ba7-41b4-be01-a381af19764a",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"test\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Read By Name",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5e033501-5ba7-41b4-be01-a381af19764a",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"test\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallengebyname/test",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallengebyname",
+								"test"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Update",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "15d75894-c8c7-4b94-aa40-df2dc493dee9",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"testUpdate\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\":\"testUpdate\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge List",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1a6e7819-860d-4a17-b2b8-6362f5ccda8f",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData[0].name === \"testUpdate\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenges",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenges"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Task List",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5c9994a2-c3c3-4bec-bebf-5176efd561c9",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"size\"] = jsonData.length === 10;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}",
+								"tasks"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Random Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "252d9d44-2975-4a1f-9d54-bc8a57e7b769",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/task",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}",
+								"task"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge GeoJSON",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9d2536b9-3357-4448-b6d6-cf827a945ba6",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/view/{{VirtualChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"view",
+								"{{VirtualChallengeID}}"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Clustered Points",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "edf43e3b-fae6-4701-a734-f1e516779056",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/clustered/{{VirtualChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"clustered",
+								"{{VirtualChallengeID}}"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Delete",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a423abbb-b93e-478a-80d4-e0d2b09d5875",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"status\"] = jsonData.status === \"OK\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Creation Expiry",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "52a22ad3-9739-4e09-9221-e5fea5718560",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"VirtualChallengeID\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"test\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t},\n\t\"expiry\":\"1 s\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Expiry Read",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5e033501-5ba7-41b4-be01-a381af19764a",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"test\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/11",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"11"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Expiry Delete",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b40a12db-871d-437b-abc6-25d2b5b32ca7",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"status\"] = jsonData.status === \"OK\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}"
+							]
+						},
+						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Project Deletion",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"Status\"] = jsonData.status === \"OK\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID}}"
+							]
+						},
+						"description": "Deletes the project that was used for the challenge tests."
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "data",
+			"description": "",
+			"item": [
+				{
+					"name": "ChallengeSummary",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/data/challenge/8953?priority=1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"data",
+								"challenge",
+								"8953"
+							],
+							"query": [
+								{
+									"key": "priority",
+									"value": "1",
+									"equals": true
+								}
+							]
+						},
+						"description": ""
 					},
 					"response": []
 				}
@@ -584,23 +1629,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"SimpleProject\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
 						},
 						"description": "Creates a base project for all the other Map Roulette API Testing"
 					},
@@ -624,23 +1679,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"ProjectWithChildren\",\n    \"description\":\"Test project containing 2 children.\",\n    \"enabled\":false,\n    \"children\": [\n        {\n            \"name\":\"Challenge1 Child\",\n            \"description\":\"Challenge1 Child description\",\n            \"instruction\":\"Challenge1 Child instruction\",\n            \"children\":[\n                {\n                    \"name\":\"Task 1\",\n                    \"description\":\"Task 1 description\",\n                    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n                },\n                {\n                    \"name\":\"Task 2\",\n                    \"description\":\"Task 2 description\",\n                    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n                }\n            ]\n        },\n        {\n            \"name\":\"Challenge2 Child\",\n            \"description\":\"Challenge2 Child description\",\n            \"instruction\":\"Challenge2 Child instruction\"\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -664,23 +1729,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/challenges",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/challenges",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{ProjectWithChildren}}",
+								"challenges"
+							]
 						},
 						"description": "Gets the children of the project"
 					},
@@ -705,23 +1782,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/children",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/children",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{ProjectWithChildren}}",
+								"children"
+							]
 						},
 						"description": "Gets the children of the project"
 					},
@@ -743,23 +1832,45 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/tasks?cs=Child&s=2",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/tasks?cs=Child&s=2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{ProjectWithChildren}}",
+								"tasks"
+							],
+							"query": [
+								{
+									"key": "cs",
+									"value": "Child"
+								},
+								{
+									"key": "s",
+									"value": "2"
+								}
+							]
 						},
 						"description": "Gets the children of the project"
 					},
@@ -780,23 +1891,41 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/search/clustered?search=%7B%22challengeSearch%22%3A%22Challenge2%22%7D",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/search/clustered?search=%7B%22challengeSearch%22%3A%22Challenge2%22%7D",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"search",
+								"clustered"
+							],
+							"query": [
+								{
+									"key": "search",
+									"value": "%7B%22challengeSearch%22%3A%22Challenge2%22%7D"
+								}
+							]
 						},
 						"description": "Gets the children of the project"
 					},
@@ -818,23 +1947,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{ProjectWithChildren}}"
+							]
 						},
 						"description": "Deletes the project just created with the children"
 					},
@@ -857,23 +1997,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"description\":\"Test project containing all children used for api testing. (Update)\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID}}"
+							]
 						},
 						"description": "Updates the project description"
 					},
@@ -896,23 +2047,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID}}"
+							]
 						},
 						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
 					},
@@ -934,23 +2096,39 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/projects?limit=-1",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"APITestProject\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/projects?limit=-1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"projects"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "-1"
+								}
+							]
 						},
 						"description": "Lists all the projects in the system"
 					},
@@ -973,23 +2151,40 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/projects/find?q=SimpleProject",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"APITestProject\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/projects/find?q=SimpleProject",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"projects",
+								"find"
+							],
+							"query": [
+								{
+									"key": "q",
+									"value": "SimpleProject"
+								}
+							]
 						},
 						"description": "Find the APITestProject in the system."
 					},
@@ -1012,23 +2207,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/projectByName/SimpleProject",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"APITestProject\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/projectByName/SimpleProject",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"projectByName",
+								"SimpleProject"
+							]
 						},
 						"description": "Retrieve the project by the provided name"
 					},
@@ -1050,23 +2256,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID}}"
+							]
 						},
 						"description": "Deletes the project created by the project creation. Would need to modify the supplied ID."
 					},
@@ -1096,23 +2313,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/tag",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"TestTag1\",\n    \"description\":\"TestTag1 description\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/tag",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"tag"
+							]
 						},
 						"description": "Creates a basic tag"
 					},
@@ -1135,23 +2362,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"tag",
+								"{{TestTagID}}"
+							]
 						},
 						"description": "Gets the tag"
 					},
@@ -1174,23 +2412,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"UpdatedTestTag1\",\n    \"description\":\"Updated Tag description\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"tag",
+								"{{TestTagID}}"
+							]
 						},
 						"description": "Updates a basic tag"
 					},
@@ -1212,23 +2461,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"tag",
+								"{{TestTagID}}"
+							]
 						},
 						"description": "Deletes the tag"
 					},
@@ -1258,23 +2518,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"TestProject\",\n    \"description\":\"Test project.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1299,23 +2569,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"TestChallenge\",\n    \"parent\": {{TestProject}},\n    \"description\":\"TestChallenge description\",\n    \"instruction\":\"TestChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        },\n        {\n            \"name\":\"Task 2\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1327,32 +2607,44 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "ccbb60bf-2a2d-45b7-8ee1-e472b52afce2",
 								"type": "text/javascript",
 								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								]
 							}
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TestChallenge}}/tasks",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TestChallenge}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TestChallenge}}",
+								"tasks"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1374,23 +2666,35 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/challenge/{{TestChallenge}}/tasks",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TestChallenge}}/tasks",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TestChallenge}}",
+								"tasks"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1414,23 +2718,33 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"NewTask\",\n    \"parent\": {{TestChallenge}},\n    \"instruction\":\"NewTask instruction\",\n    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n}"
+							"raw": "{\n    \"name\":\"NewTask\",\n    \"parent\": {{TestChallenge}},\n    \"instruction\":\"NewTask instruction\",\n    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{ \"identifier\":{\"value\":1111} }}]}\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1453,23 +2767,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task/{{NewTask}}",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\":\"NewTask\",\n    \"description\":\"NewTask description\",\n    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1492,23 +2817,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task/{{NewTask}}",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1531,18 +2867,37 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task/{{NewTask}}/comment?comment=This%20is%20a%20comment",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/comment?comment=This%20is%20a%20comment",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}",
+								"comment"
+							],
+							"query": [
+								{
+									"key": "comment",
+									"value": "This%20is%20a%20comment"
+								}
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1564,18 +2919,36 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/comment/{{NewComment}}?comment=This%20is%20an%20updated%20comment",
 						"method": "PUT",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/comment/{{NewComment}}?comment=This%20is%20an%20updated%20comment",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"comment",
+								"{{NewComment}}"
+							],
+							"query": [
+								{
+									"key": "comment",
+									"value": "This%20is%20an%20updated%20comment"
+								}
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1597,18 +2970,37 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task/{{NewTask}}/comment?comment=This%20is%20a%20comment%20Number2",
 						"method": "POST",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/comment?comment=This%20is%20a%20comment%20Number2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}",
+								"comment"
+							],
+							"query": [
+								{
+									"key": "comment",
+									"value": "This%20is%20a%20comment%20Number2"
+								}
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1630,18 +3022,30 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/comment/{{NewComment}}",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/comment/{{NewComment}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"comment",
+								"{{NewComment}}"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1663,18 +3067,31 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task/{{NewTask}}/comments",
 						"method": "GET",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/comments",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}",
+								"comments"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1694,18 +3111,32 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/task/{{NewTask}}/comment/{{NewComment}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/comment/{{NewComment}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}",
+								"comment",
+								"{{NewComment}}"
+							]
 						},
 						"description": "Creates a project with two children within the same request."
 					},
@@ -1727,23 +3158,34 @@
 						}
 					],
 					"request": {
-						"url": "http://localhost:9000/api/v2/project/{{TestProject}}",
 						"method": "DELETE",
 						"header": [
 							{
 								"key": "apiKey",
-								"value": "test",
-								"description": ""
+								"value": "test"
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{TestProject}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{TestProject}}"
+							]
 						},
 						"description": "Deletes the project just created with the children"
 					},


### PR DESCRIPTION
New Object Type included in MapRoulette, the Virtual Challenge (VC).

A VC is a challenge that is created on a temporary basis. It has no project parent and the tasks are made up of tasks from other challenges. Any parameters from the SearchParameter object can be used to filter tasks that make up the VC, however a bounding box is required that is used from the "location" field in the SearchParameters object. Tasks can be retrieved at random like a normal challenge and once retrieved through the random API it will lock the task exactly the same way that it happens for a normal challenge.

As mentioned VC's are temporary, and they will automatically expire and then be deleted from the system. The underlying tasks will remain as children of their parents as per usual. By default the expiry for a VC is 6 hours, however this can be changed in the configuration or when creating the VC by setting the "expiry" option to whatever.

The Locking mechanism for tasks was also made generic so that both the VC's and Challenges could use them.

This is only an update to the API and no UI is included for Virtual Challenges, so no mechanism exists in the website itself that can start to leverage this feature.

This PR also includes some minor bug fixes:
- Fixed issue that was causing a deadlock to occur when creating a task through the API
- Fixed caching issues when updating tasks
- Fixed exception that would occur when creating challenges without overpass query, local geojson or remote geojson.