### PR TITLE
Fix asset paths used in mr3.devMode

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -99,8 +99,8 @@ class Application @Inject() (val messagesApi: MessagesApi,
         if (config.mr3DevMode) {
           promise success Json.parse("""
                       {
-                        "main.js" : "public/static/js/bundle.js",
-                        "main.css" : "public/static/css/bundle.css"
+                        "main.js" : "static/js/bundle.js",
+                        "main.css" : "static/css/bundle.css"
                       }
                       """)
         } else {


### PR DESCRIPTION
When interacting with a front-end development server (mr3.devMode=true), the `public/` portion of the asset paths should be left off.