### PR TITLE
Updating proximity API and fixing bug

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -195,9 +195,13 @@ function SearchParameters() {
         Cookies.set('search', search);
     };
 
-    var reset = function() {
+    var _reset = function() {
         search = defaultState;
         update();
+    };
+
+    this.reset = function() {
+        _reset();
     };
 
     var getValue = function(key) {
@@ -222,7 +226,7 @@ function SearchParameters() {
 
     this.qsUpdate = function(resetCookie) {
         if (resetCookie) {
-            reset();
+            _reset();
         }
         setValueByQS("pid", "projectId", parseInt);
         setValueByQS("ps", "projectSearch");

--- a/app/assets/javascripts/mapping.js
+++ b/app/assets/javascripts/mapping.js
@@ -576,7 +576,14 @@ function Task() {
         if (MRManager.usingPriority()) {
             taskFunction = jsRoutes.controllers.MappingController.getRandomNextTaskWithPriority;
         }
-        taskFunction().ajax({
+        var proximity = Utils.getQSParameterByName("proximity");
+        var proximityID = -1;
+        if (typeof proximity === 'string' && proximity === 'true') {
+            proximityID = data.id;
+        }
+        // make sure the the challenge is set
+        new SearchParameters().setChallengeId(data.parentId);
+        taskFunction(proximityID).ajax({
             success:function(update) {
                 updateData(update, MRManager.getSuccessHandler(success));
             },

--- a/app/controllers/MappingController.scala
+++ b/app/controllers/MappingController.scala
@@ -9,6 +9,7 @@ import org.maproulette.exception.NotFoundException
 import org.maproulette.models.{Lock, Task}
 import org.maproulette.models.dal.TaskDAL
 import org.maproulette.session.{SearchParameters, SessionManager, User}
+import org.maproulette.utils.Utils
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, AnyContent, Controller}
 
@@ -36,10 +37,10 @@ class MappingController @Inject() (sessionManager:SessionManager,
     *
     * @return
     */
-  def getRandomNextTask : Action[AnyContent] = Action.async { implicit request =>
+  def getRandomNextTask(proximityId:Long) : Action[AnyContent] = Action.async { implicit request =>
     sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { params =>
-        Ok(getResponseJSONNoLock(taskDAL.getRandomTasks(User.userOrMocked(user), params, 1).headOption))
+        Ok(getResponseJSONNoLock(taskDAL.getRandomTasks(User.userOrMocked(user), params, 1, None, Utils.negativeToOption(proximityId)).headOption))
       }
     }
   }
@@ -50,10 +51,10 @@ class MappingController @Inject() (sessionManager:SessionManager,
     *
     * @return
     */
-  def getRandomNextTaskWithPriority : Action[AnyContent] = Action.async { implicit request =>
+  def getRandomNextTaskWithPriority(proximityId:Long) : Action[AnyContent] = Action.async { implicit request =>
     sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { params =>
-        Ok(getResponseJSONNoLock(taskDAL.getRandomTasksWithPriority(User.userOrMocked(user), params, 1).headOption))
+        Ok(getResponseJSONNoLock(taskDAL.getRandomTasksWithPriority(User.userOrMocked(user), params, 1, Utils.negativeToOption(proximityId)).headOption))
       }
     }
   }

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -319,7 +319,7 @@ class ChallengeController @Inject()(override val childController: TaskController
       SearchParameters.withSearch { implicit params =>
         val challenges = this.dal.extendedFind(params, limit, page)
         if (challenges.isEmpty) {
-          NotFound
+          Ok(Json.toJson(List[JsValue]()))
         } else {
           val tags = this.tagDAL.listByChallenges(challenges.map(c => c.id))
           val projects = Some(this.dalManager.project.retrieveListById(-1, 0)(challenges.map(c => c.general.parent)).map(p => p.id -> p).toMap)

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -214,6 +214,36 @@ class ChallengeController @Inject()(override val childController: TaskController
   }
 
   /**
+    * Gets the next task in sequential order for the specified challenge
+    *
+    * @param challengeId The current challenge id
+    * @param currentTaskId The current task id that is being viewed
+    * @param statusList Filter by task status
+    * @return The next task in the list
+    */
+  def getSequentialNextTask(challengeId:Long, currentTaskId:Long, statusList:String): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(Utils.getResponseJSON(this.dalManager.task.getNextTaskInSequence(challengeId, currentTaskId,
+        Utils.toIntList(statusList)), this.dalManager.task.getLastModifiedUser));
+    }
+  }
+
+  /**
+    * Gets the previous task in sequential order for the specified challenge
+    *
+    * @param challengeId The current challenge id
+    * @param currentTaskId The current task id that is being viewed
+    * @param statusList Filter by task status
+    * @return The previous task in the list
+    */
+  def getSequentialPreviousTask(challengeId:Long, currentTaskId:Long, statusList:String): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(Utils.getResponseJSON(this.dalManager.task.getPreviousTaskInSequence(challengeId, currentTaskId,
+        Utils.toIntList(statusList)), this.dalManager.task.getLastModifiedUser));
+    }
+  }
+
+  /**
     * Gets the featured challenges
     *
     * @param limit  The number of challenges to get

--- a/app/org/maproulette/models/dal/DALManager.scala
+++ b/app/org/maproulette/models/dal/DALManager.scala
@@ -17,6 +17,7 @@ import org.maproulette.session.dal.{UserDAL, UserGroupDAL}
 class DALManager @Inject() (tagDAL: TagDAL,
                             taskDAL: TaskDAL,
                             challengeDAL: ChallengeDAL,
+                            virtualChallengeDAL: VirtualChallengeDAL,
                             surveyDAL: SurveyDAL,
                             projectDAL: ProjectDAL,
                             userDAL: UserDAL,
@@ -27,6 +28,7 @@ class DALManager @Inject() (tagDAL: TagDAL,
   def tag:TagDAL = tagDAL
   def task:TaskDAL = taskDAL
   def challenge:ChallengeDAL = challengeDAL
+  def virtualChallenge:VirtualChallengeDAL = virtualChallengeDAL
   def survey:SurveyDAL = surveyDAL
   def project:ProjectDAL = projectDAL
   def user:UserDAL = userDAL
@@ -39,6 +41,7 @@ class DALManager @Inject() (tagDAL: TagDAL,
     itemType match {
       case ProjectType() => projectDAL
       case ChallengeType() => challengeDAL
+      case VirtualChallengeType() => virtualChallengeDAL
       case SurveyType() => surveyDAL
       case TaskType() => taskDAL
       case UserType() => userDAL

--- a/app/org/maproulette/models/dal/Locking.scala
+++ b/app/org/maproulette/models/dal/Locking.scala
@@ -112,7 +112,7 @@ trait Locking[T<:BaseObject[_]] extends TransactionManager {
       if (!user.guest) {
         val resultList = results.filter(lockItem(user, _) > 0)
         if (resultList.isEmpty) {
-          throw new NotFoundException("No objects found.")
+          List[T]()
         }
         resultList
       } else {

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -24,10 +24,7 @@ trait ChallengeWrites {
   implicit val challengeExtraWrites: Writes[ChallengeExtra] = Json.writes[ChallengeExtra]
 
   class jsonWrites(key:String) extends Writes[String] {
-    override def writes(value:String) : JsValue =
-      JsObject(Seq(
-        key -> Json.parse(value)
-      ))
+    override def writes(value:String) : JsValue = Json.parse(value)
   }
 
   implicit val challengeWrites: Writes[Challenge] = (

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -233,18 +233,23 @@ trait DALHelper {
       }
     }
 
-    params.challengeSearch match {
-      case Some(cs) if cs.nonEmpty =>
-        params.fuzzySearch match {
-          case Some(x) =>
-            this.appendInWhereClause(whereClause, this.fuzzySearch(s"$challengePrefix.name", "cs", x)(None))
-            parameters += ('cs -> cs)
-          case None =>
-            this.appendInWhereClause(whereClause, this.searchField(s"$challengePrefix.name", "cs")(None))
-            parameters += ('cs -> s"%$cs%")
+    params.challengeId match {
+      case Some(cid) if cid > -1 => this.appendInWhereClause(whereClause, s"$challengePrefix.id = $cid")
+      case _ =>
+        params.challengeSearch match {
+          case Some(cs) if cs.nonEmpty =>
+            params.fuzzySearch match {
+              case Some(x) =>
+                this.appendInWhereClause(whereClause, this.fuzzySearch(s"$challengePrefix.name", "cs", x)(None))
+                parameters += ('cs -> cs)
+              case None =>
+                this.appendInWhereClause(whereClause, this.searchField(s"$challengePrefix.name", "cs")(None))
+                parameters += ('cs -> s"%$cs%")
+            }
+          case _ => // ignore
         }
-      case _ => // ignore
     }
+
     parameters
   }
 

--- a/app/views/mr3.scala.html
+++ b/app/views/mr3.scala.html
@@ -1,5 +1,5 @@
 @import org.maproulette.session.User
-@(user:User, mr3JSSource:String, mr3CSSSource:String)(implicit messages: Messages, req: play.api.mvc.RequestHeader, webJarAssets: WebJarAssets)
+@(user:User, mr3JSSource:String, mr3CSSSource:String)(implicit messages: Messages)
 
 <!doctype html>
 <html>

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1064,6 +1064,50 @@ GET     /challenge/:cid/tasks/random                @org.maproulette.controllers
 GET     /challenge/:cid/tasks/randomTasks           @org.maproulette.controllers.api.ChallengeController.getRandomTasks(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Challenge ]
+# summary: Retrieves next Task
+# produces: [ application/json ]
+# description: Retrieves the next sequential Task based on the task ordering within the Challenge. If it is currently on the last task it will response with the first task in the challenge.
+# responses:
+#   '200':
+#     description: The next task in the list
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: cid
+#     in: path
+#     description: The id of the parent Challenge.
+#   - name: id
+#     in: path
+#     description: The id of the current task being viewed, so that we can get context of what the next task should be
+#   - name: statusList
+#     in: query
+#     description: A comma separated list of Task status' to limit to the response by.
+###
+GET     /challenge/:cid/nextTask/:id                @org.maproulette.controllers.api.ChallengeController.getSequentialNextTask(cid:Long, id:Long, statusList:String ?= "")
+###
+# tags: [ Challenge ]
+# summary: Retrieves previous Task
+# produces: [ application/json ]
+# description: Retrieves the previous sequential Task based on the task ordering within the Challenge. If it is currently on the first task it will response with the last task in the challenge.
+# responses:
+#   '200':
+#     description: The previous task in the list
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: cid
+#     in: path
+#     description: The id of the parent Challenge.
+#   - name: id
+#     in: path
+#     description: The id of the current task being viewed, so that we can get context of what the next task should be
+#   - name: statusList
+#     in: query
+#     description: A comma separated list of Task status' to limit to the response by.
+###
+GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers.api.ChallengeController.getSequentialPreviousTask(cid:Long, id:Long, statusList:String ?= "")
+###
+# tags: [ Challenge ]
 # summary: Retrieves Challenge GeoJSON
 # produces: [ application/json ]
 # description: Retrieves the GeoJSON for the Challenge that represents all the Task children of the Challenge.
@@ -1386,6 +1430,44 @@ GET     /virtualchallenge/:id/tasks                     @org.maproulette.control
 #     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
 GET     /virtualchallenge/:cid/task                 @org.maproulette.controllers.api.VirtualChallengeController.getRandomTask(cid:Long, proximity:Long ?= -1)
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves next Task
+# produces: [ application/json ]
+# description: Retrieves the next sequential Task based on the task ordering within the Virtual Challenge. If it is currently on the last task it will response with the first task in the Virtual Challenge.
+# responses:
+#   '200':
+#     description: The next task in the list
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: cid
+#     in: path
+#     description: The id of the parent Virtual Challenge.
+#   - name: id
+#     in: path
+#     description: The id of the current task being viewed, so that we can get context of what the next task should be
+###
+GET     /virtualchallenge/:cid/nextTask/:id         @org.maproulette.controllers.api.VirtualChallengeController.getSequentialNextTask(cid:Long, id:Long)
+###
+# tags: [ Virtual Challenge ]
+# summary: Retrieves previous Task
+# produces: [ application/json ]
+# description: Retrieves the previous sequential Task based on the task ordering within the Virtual Challenge. If it is currently on the first task it will response with the last task in the Virtual Challenge.
+# responses:
+#   '200':
+#     description: The previous task in the list
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: cid
+#     in: path
+#     description: The id of the parent Virtual Challenge.
+#   - name: id
+#     in: path
+#     description: The id of the current task being viewed, so that we can get context of what the next task should be
+###
+GET     /virtualchallenge/:cid/previousTask/:id     @org.maproulette.controllers.api.VirtualChallengeController.getSequentialPreviousTask(cid:Long, id:Long)
 ###
 # tags: [ Virtual Challenge ]
 # summary: Retrieves Virtual Challenge GeoJSON

--- a/conf/routes
+++ b/conf/routes
@@ -43,8 +43,8 @@ GET     /show                                                           @control
 GET     /mapping/task/:id                                               @controllers.MappingController.getTaskDisplayGeoJSON(id:Long)
 GET     /mapping/nextTask/:parentId/:id                                 @controllers.MappingController.getSequentialNextTask(parentId:Long, id:Long)
 GET     /mapping/previousTask/:parentId/:id                             @controllers.MappingController.getSequentialPreviousTask(parentId:Long, id:Long)
-GET     /mapping/randomTaskWithoutPriority                              @controllers.MappingController.getRandomNextTask
-GET     /mapping/randomTask                                             @controllers.MappingController.getRandomNextTaskWithPriority
+GET     /mapping/randomTaskWithoutPriority                              @controllers.MappingController.getRandomNextTask(proximityId:Long ?= -1)
+GET     /mapping/randomTask                                             @controllers.MappingController.getRandomNextTaskWithPriority(proximityId:Long ?= -1)
 # JsMessages Route
 GET     /jsMessages                                                     @controllers.Application.messages
 # Swagger route

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -271,12 +271,15 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "166ebb2c-eda3-4c07-9e30-71e275566ff5",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"Task1\"] = jsonData[0].name === \"Task 1\";",
-									"tests[\"Task2\"] = jsonData[1].name === \"Task 2\";"
+									"postman.setGlobalVariable(\"TagsChallengeTask1ID\", jsonData[0].id);",
+									"tests[\"Task2\"] = jsonData[1].name === \"Task 2\";",
+									"postman.setGlobalVariable(\"TagsChallengeTask2ID\", jsonData[1].id);"
 								]
 							}
 						}
@@ -313,6 +316,110 @@
 							]
 						},
 						"description": "Gets the tasks of the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Next Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"Task 2\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/nextTask/{{TagsChallengeTask1ID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"nextTask",
+								"{{TagsChallengeTask1ID}}"
+							]
+						},
+						"description": "Gets the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Previous Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5d92aa7b-b9d9-420a-a54b-789a87c04175",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"Task 1\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/previousTask/{{TagsChallengeTask2ID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"previousTask",
+								"{{TagsChallengeTask2ID}}"
+							]
+						},
+						"description": "Gets the challenge for the provided ID"
 					},
 					"response": []
 				},
@@ -964,7 +1071,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"challengeId\": {{TagsChallengeID}},\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t}\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge",
@@ -1167,12 +1274,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5c9994a2-c3c3-4bec-bebf-5176efd561c9",
+								"id": "34912ad6-d31c-4bf9-8830-85ec811bf09b",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
-									"tests[\"size\"] = jsonData.length === 10;"
+									"tests[\"size\"] = jsonData.length === 2;",
+									"postman.setGlobalVariable(\"VChallengeTask1ID\", jsonData[0].id);",
+									"postman.setGlobalVariable(\"VChallengeTask2ID\", jsonData[1].id);"
 								]
 							}
 						}
@@ -1245,6 +1354,112 @@
 							]
 						},
 						"description": ""
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Next Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ddbeaf5d-4f6b-49f7-aa23-1a1523ad2ecd",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"id\"] = jsonData.id === pm.variables.get(\"VChallengeTask2ID\");",
+									"",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/nextTask/{{VChallengeTask1ID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}",
+								"nextTask",
+								"{{VChallengeTask1ID}}"
+							]
+						},
+						"description": "Gets the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Virtual Challenge Previous Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b604695f-ce62-444d-92fd-a14a4c068997",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"id\"] = jsonData.id === pm.variables.get(\"VChallengeTask1ID\");"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/previousTask/{{VChallengeTask2ID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"virtualchallenge",
+								"{{VirtualChallengeID}}",
+								"previousTask",
+								"{{VChallengeTask2ID}}"
+							]
+						},
+						"description": "Gets the challenge for the provided ID"
 					},
 					"response": []
 				},
@@ -3192,6 +3407,11 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "user",
+			"description": "",
+			"item": []
 		}
 	]
 }


### PR DESCRIPTION
Updating API to handle the proximity option when retrieving random next task that takes proximity into account. There can be unintended side effects with this option that may need to be addressed later. Currently not connected to the UI, purely API call, so use with caution.

Also fixing a bug where the extendedFind API was not honoring the visibility of projects.

This PR now also includes the following:
- New next and previous task API functions for challenges and virtual challenges.
- Updated Postman to test new API functions
- Fixed bug causing location and bounding keys on challenges to be double keyed, so would look like 
```json
"location":{
  "location":{
     ...
  }
}
```
