### PR TITLE
Adding properties field for user object. This is essentially a json f…

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -94,7 +94,7 @@ class Application @Inject() (val messagesApi: MessagesApi,
     // if using static path, just pull the file directly, otherwise pull from http source
     val promise = Promise[JsValue]
     config.mr3StaticPath match {
-      case Some(path) => promise success Json.parse(Files.readAllBytes(Paths.get(path + "/asset-manifest.json")))
+      case Some(path) => promise success Json.parse(Files.readAllBytes(Paths.get(s"$path/${config.mr3JSManifest}")))
       case None =>
         if (config.mr3DevMode) {
           promise success Json.parse("""

--- a/app/org/maproulette/controllers/api/UserController.scala
+++ b/app/org/maproulette/controllers/api/UserController.scala
@@ -6,7 +6,7 @@ import org.maproulette.exception.{NotFoundException, StatusMessage}
 import org.maproulette.models.{Challenge, Task}
 import org.maproulette.session.dal.UserDAL
 import org.maproulette.session.{SessionManager, User, UserSettings}
-import play.api.libs.json.{DefaultWrites, JsString, JsValue, Json}
+import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, BodyParsers, Controller}
 
 /**
@@ -14,7 +14,7 @@ import play.api.mvc.{Action, AnyContent, BodyParsers, Controller}
   */
 class UserController @Inject()(userDAL: UserDAL, sessionManager: SessionManager) extends Controller with DefaultWrites {
 
-  implicit val userWrites = User.userWrites
+  implicit val userReadWrite = User.UserFormat
   implicit val challengeWrites = Challenge.writes.challengeWrites
   implicit val taskWrites = Task.TaskFormat
 
@@ -59,7 +59,7 @@ class UserController @Inject()(userDAL: UserDAL, sessionManager: SessionManager)
         case None => //just ignore, we don't have to do anything if it isn't there
       }
       implicit val settingsRead = User.settingsReads
-      userDAL.managedUpdate(request.body.as[UserSettings], user)(id) match {
+      userDAL.managedUpdate(request.body.as[UserSettings], (request.body \ "properties").toOption, user)(id) match {
         case Some(u) => Ok(Json.toJson(u))
         case None => throw new NotFoundException(s"No user found to update with id '$id'")
       }

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -2,6 +2,7 @@ package org.maproulette.models.utils
 
 import org.joda.time.DateTime
 import org.maproulette.models._
+import org.maproulette.utils.Utils.{jsonReads, jsonWrites}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
@@ -22,10 +23,6 @@ trait ChallengeWrites {
       ))
   }
   implicit val challengeExtraWrites: Writes[ChallengeExtra] = Json.writes[ChallengeExtra]
-
-  class jsonWrites(key:String) extends Writes[String] {
-    override def writes(value:String) : JsValue = Json.parse(value)
-  }
 
   implicit val challengeWrites: Writes[Challenge] = (
     (JsPath \ "id").write[Long] and
@@ -48,10 +45,6 @@ trait ChallengeReads extends DefaultReads {
   implicit val challengeCreationReads: Reads[ChallengeCreation] = Json.reads[ChallengeCreation]
   implicit val challengePriorityReads: Reads[ChallengePriority] = Json.reads[ChallengePriority]
   implicit val challengeExtraReads: Reads[ChallengeExtra] = Json.reads[ChallengeExtra]
-
-  class jsonReads(key:String) extends Reads[String] {
-    override def reads(value:JsValue) : JsResult[String] = JsSuccess(value.toString())
-  }
 
   implicit val challengeReads: Reads[Challenge] = (
     (JsPath \ "id").read[Long] and

--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -227,7 +227,7 @@ class SessionManager @Inject() (ws:WSClient, dalManager: DALManager, config:Conf
     details.get() onComplete {
       case Success(detailsResponse) if detailsResponse.status == HttpResponseStatus.OK.code() =>
         try {
-          val newUser = User(detailsResponse.body, accessToken, config)
+          val newUser = User.generate(detailsResponse.body, accessToken, config)
           val osmUser = this.dalManager.user.insert(newUser, user)
           p success Some(this.dalManager.user.initializeHomeProject(osmUser))
         } catch {

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -22,7 +22,7 @@ import org.maproulette.exception.NotFoundException
 import org.maproulette.models.{Challenge, Project, Task}
 import org.maproulette.permissions.Permission
 import org.maproulette.utils.Utils
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsString, JsValue, Json}
 import play.api.libs.oauth.RequestToken
 
 /**
@@ -71,10 +71,11 @@ class UserDAL @Inject() (override val db:Database,
       get[Option[String]]("users.custom_basemap_url") ~
       get[Option[Boolean]]("users.email_opt_in") ~
       get[Option[String]]("users.locale") ~
-      get[Option[Int]]("users.theme") map {
+      get[Option[Int]]("users.theme") ~
+      get[Option[String]]("properties") map {
       case id ~ osmId ~ created ~ modified ~ osmCreated ~ displayName ~ description ~ avatarURL ~
         homeLocation ~ apiKey ~ oauthToken ~ oauthSecret ~ defaultEditor ~ defaultBasemap ~
-        customBasemap ~ emailOptIn ~ locale ~ theme =>
+        customBasemap ~ emailOptIn ~ locale ~ theme ~ properties =>
         val locationWKT = homeLocation match {
           case Some(wkt) => new WKTReader().read(wkt).asInstanceOf[Point]
           case None => new GeometryFactory().createPoint(new Coordinate(0, 0))
@@ -86,7 +87,8 @@ class UserDAL @Inject() (override val db:Database,
             userGroupDAL.getUserGroups(osmId, User.superUser
           ),
           apiKey, false,
-          UserSettings(defaultEditor, defaultBasemap, customBasemap, locale, emailOptIn, theme)
+          UserSettings(defaultEditor, defaultBasemap, customBasemap, locale, emailOptIn, theme),
+          properties
         )
     }
   }
@@ -223,11 +225,12 @@ class UserDAL @Inject() (override val db:Database,
 
       val query = s"""WITH upsert AS (UPDATE users SET osm_id = {osmID}, osm_created = {osmCreated},
                               name = {name}, description = {description}, avatar_url = {avatarURL},
-                              oauth_token = {token}, oauth_secret = {secret},  home_location = ST_GeomFromEWKT({wkt})
+                              oauth_token = {token}, oauth_secret = {secret},  home_location = ST_GeomFromEWKT({wkt}),
+                              properties = {properties}
                             WHERE id = {id} OR osm_id = {osmID} RETURNING ${this.retrieveColumns})
             INSERT INTO users (api_key, osm_id, osm_created, name, description,
-                               avatar_url, oauth_token, oauth_secret, home_location)
-            SELECT {apiKey}, {osmID}, {osmCreated}, {name}, {description}, {avatarURL}, {token}, {secret}, ST_GeomFromEWKT({wkt})
+                               avatar_url, oauth_token, oauth_secret, home_location, properties)
+            SELECT {apiKey}, {osmID}, {osmCreated}, {name}, {description}, {avatarURL}, {token}, {secret}, ST_GeomFromEWKT({wkt}), {properties}
             WHERE NOT EXISTS (SELECT * FROM upsert)"""
       SQL(query).on(
         'apiKey -> newAPIKey,
@@ -239,7 +242,8 @@ class UserDAL @Inject() (override val db:Database,
         'token -> item.osmProfile.requestToken.token,
         'secret -> item.osmProfile.requestToken.secret,
         'wkt -> s"SRID=4326;$ewkt",
-        'id -> item.id
+        'id -> item.id,
+        'properties -> item.properties
       ).executeUpdate()
     }
     // just in case expire the osm ID
@@ -270,14 +274,19 @@ class UserDAL @Inject() (override val db:Database,
     * be updated separately
     *
     * @param settings The user settings that have been pulled from the request object
+    * @param properties Any extra properties that a client wishes to store alongside the user object
     * @param user The user making the update request
     * @param id The id of the user being updated
     * @param c an optional connection, if not provided a new connection from the pool will be retrieved
     * @return An optional user, if user with supplied ID not found, then will return empty optional
     */
-  def managedUpdate(settings:UserSettings, user:User)(implicit id:Long, c:Option[Connection]=None) : Option[User] = {
+  def managedUpdate(settings:UserSettings, properties:Option[JsValue], user:User)(implicit id:Long, c:Option[Connection]=None) : Option[User] = {
     implicit val settingsWrite = User.settingsWrites
-    this.update(Utils.insertIntoJson(Json.parse("{}"), "settings", Json.toJson(settings)), user)
+    val updateBody = Utils.insertIntoJson(Json.parse("{}"), "settings", Json.toJson(settings))
+    this.update(properties match {
+      case Some(p) => Utils.insertIntoJson(updateBody, "properties", JsString(p.toString()))
+      case None => updateBody
+    }, user)
   }
 
   /**
@@ -311,6 +320,7 @@ class UserDAL @Inject() (override val db:Database,
         val locale = (value \ "settings" \ "locale").asOpt[String].getOrElse(cachedItem.settings.locale.getOrElse("en"))
         val emailOptIn = (value \ "settings" \ "emailOptIn").asOpt[Boolean].getOrElse(cachedItem.settings.emailOptIn.getOrElse(false))
         val theme = (value \ "settings" \ "theme").asOpt[Int].getOrElse(cachedItem.settings.theme.getOrElse(-1))
+        val properties = (value \ "properties").asOpt[String].getOrElse(cachedItem.properties.getOrElse("{}"))
 
         this.updateGroups(value, user)
         this.userGroupDAL.clearUserCache(cachedItem.osmProfile.id)
@@ -319,7 +329,7 @@ class UserDAL @Inject() (override val db:Database,
                                           avatar_url = {avatarURL}, oauth_token = {token}, oauth_secret = {secret},
                                           home_location = ST_SetSRID(ST_GeomFromEWKT({wkt}),4326), default_editor = {defaultEditor},
                                           default_basemap = {defaultBasemap}, custom_basemap_url = {customBasemap},
-                                          locale = {locale}, email_opt_in = {emailOptIn}, theme = {theme}
+                                          locale = {locale}, email_opt_in = {emailOptIn}, theme = {theme}, properties = {properties}
                         WHERE id = {id} RETURNING ${this.retrieveColumns}"""
         SQL(query).on(
           'apiKey -> apiKey,
@@ -335,7 +345,8 @@ class UserDAL @Inject() (override val db:Database,
           'customBasemap -> customBasemap,
           'locale -> locale,
           'emailOptIn -> emailOptIn,
-          'theme -> theme
+          'theme -> theme,
+          'properties -> properties
         ).as(this.parser.*).headOption
       }
     }

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -22,6 +22,14 @@ import scala.reflect.runtime.universe._
   */
 object Utils extends DefaultWrites {
 
+  class jsonWrites(key:String) extends Writes[String] {
+    override def writes(value:String) : JsValue = Json.parse(value)
+  }
+
+  class jsonReads(key:String) extends Reads[String] {
+    override def reads(value:JsValue) : JsResult[String] = JsSuccess(value.toString())
+  }
+
   /**
     * Checks to see if a string is a number
     *

--- a/conf/evolutions/default/13.sql
+++ b/conf/evolutions/default/13.sql
@@ -1,0 +1,7 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+SELECT add_drop_column('users', 'properties', 'character varying');;
+SELECT create_index_if_not_exists('status_actions', 'osm_user_id_created', '(osm_user_id,created)');;
+
+# --- !Downs

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -3411,7 +3411,108 @@
 		{
 			"name": "user",
 			"description": "",
-			"item": []
+			"item": [
+				{
+					"name": "Get Super User",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "cbcada60-281a-4af6-a5ce-fab6e9cff186",
+								"type": "text/javascript",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"id\"] = jsonData.id === -999;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/user/-999",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"user",
+								"-999"
+							]
+						},
+						"description": "Gets the super user that is automatically created with the system."
+					},
+					"response": []
+				},
+				{
+					"name": "Get OSM Super User ",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a015f41e-3b14-4edf-a905-1af643a30a9e",
+								"type": "text/javascript",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"id\"] = jsonData.id === -999;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/osmuser/SuperUser",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"osmuser",
+								"SuperUser"
+							]
+						},
+						"description": "Gets the super user that is automatically created with the system by using the super user mocked OSM name."
+					},
+					"response": []
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
…ield for clients to store specific user information as it pertains to the client.

The database stores this simply as a string and doesn't have any other requirements on the string other than it is valid json. The request and response on any User objects will display the properties string correctly as json but under the hood it is just a string. Clients can then update and modify as needed. 

One caveat to this, if one Client rebuilds the string from scratch it could potentially overwrite another clients information. 