### PR TITLE
Large API Updates and Backgrounds Tasks

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -175,10 +175,10 @@ var Utils = {
  */
 function SearchParameters() {
     var defaultState = {
-        projectId: -1,
+        projectIds: [],
         projectSearch: '',
         projectEnabled: true,
-        challengeId: -1,
+        challengeIds: [],
         challengeEnabled: true,
         challengeSearch: '',
         challengeTags: [],
@@ -228,10 +228,10 @@ function SearchParameters() {
         if (resetCookie) {
             _reset();
         }
-        setValueByQS("pid", "projectId", parseInt);
+        setValueByQS("pid", "projectIds", parseInt);
         setValueByQS("ps", "projectSearch");
         setValueByQS("pe", "projectEnabled", Boolean);
-        setValueByQS("cid", "challengeId", parseInt);
+        setValueByQS("cid", "challengeIds", parseInt);
         setValueByQS("ct", "challengeTags", function(v) { return v.split(","); });
         setValueByQS("ctc", "challengeTagConjunction", Boolean);
         setValueByQS("cs", "challengeSearch");
@@ -257,10 +257,10 @@ function SearchParameters() {
     };
 
     this.getProjectId = function() {
-        return getValue("projectId");
+        return getValue("projectIds");
     };
     this.setProjectId = function(id) {
-        setValue("projectId", id);
+        setValue("projectIds", id);
     };
     this.getProjectSearch = function() {
         return getValue("projectSearch");
@@ -275,10 +275,10 @@ function SearchParameters() {
         setValue("projectEnabled", enabled);
     };
     this.getChallengeId = function() {
-        return getValue("challengeId");
+        return getValue("challengeIds");
     };
     this.setChallengeId = function(id) {
-        setValue("challengeId", id);
+        setValue("challengeIds", id);
     };
     this.getChallengeTags = function() {
         return getValue("challengeTags");

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -167,6 +167,7 @@ object Config {
   val KEY_SCHEDULER_OSM_MATCHER_BATCH_SIZE = s"$SUB_GROUP_SCHEDULER.osmMatcher.batchSize"
   val KEY_SCHEDULER_OSM_MATCHER_ENABLED = s"$SUB_GROUP_SCHEDULER.osmMatcher.enabled"
   val KEY_SCHEDULER_OSM_MATCHER_MANUAL = s"$SUB_GROUP_SCHEDULER.osmMatcher.manual"
+  val KEY_SCHEDULER_CLEAN_DELETED = s"$SUB_GROUP_SCHEDULER.cleanDeleted.interval"
 
   val GROUP_OSM = "osm"
   val KEY_OSM_SERVER = s"$GROUP_OSM.server"

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -52,6 +52,9 @@ class Config @Inject() (implicit val application:Application) {
   lazy val numberOfActivities : Int =
     this.config.getInt(Config.KEY_RECENT_ACTIVITY).getOrElse(Config.DEFAULT_RECENT_ACTIVITY)
 
+  lazy val osmMatcherBatchSize : Int =
+    this.config.getInt(Config.KEY_SCHEDULER_OSM_MATCHER_BATCH_SIZE).getOrElse(Config.DEFAULT_VIRTUAL_CHALLENGE_BATCH_SIZE)
+
   lazy val virtualChallengeLimit : Double =
     this.config.getDouble(Config.KEY_VIRTUAL_CHALLENGE_LIMIT).getOrElse(Config.DEFAULT_VIRTUAL_CHALLENGE_LIMIT)
 
@@ -61,8 +64,21 @@ class Config @Inject() (implicit val application:Application) {
   lazy val virtualChallengeExpiry : Duration =
     Duration(this.config.getString(Config.KEY_VIRTUAL_CHALLENGE_EXPIRY).getOrElse(Config.DEFAULT_VIRTUAL_CHALLENGE_EXPIRY))
 
+  lazy val changeSetTimeLimit : Duration =
+    Duration(this.config.getString(Config.KEY_CHANGESET_TIME_LIMIT).getOrElse(Config.DEFAULT_CHANGESET_HOUR_LIMIT))
+
+  lazy val changeSetEnabled : Boolean = this.config.getBoolean(Config.KEY_CHANGESET_ENABLED).getOrElse(Config.DEFAULT_CHANGESET_ENABLED)
+
+  lazy val osmMatcherEnabled : Boolean = this.config.getBoolean(Config.KEY_SCHEDULER_OSM_MATCHER_ENABLED).getOrElse(Config.DEFAULT_OSM_MATCHER_ENABLED)
+
+  lazy val osmMatcherManualOnly : Boolean = this.config.getBoolean(Config.KEY_SCHEDULER_OSM_MATCHER_MANUAL).getOrElse(Config.DEFAULT_OSM_MATCHER_MANUAL)
+
+  lazy val allowMatchOSM = changeSetEnabled || osmMatcherEnabled || osmMatcherManualOnly
+
+  lazy val getOSMServer : String = this.config.getString(Config.KEY_OSM_SERVER).get
+
   lazy val getOSMOauth : OSMOAuth = {
-    val osmServer = this.config.getString(Config.KEY_OSM_SERVER).get
+    val osmServer = this.getOSMServer
     OSMOAuth(
       osmServer + this.config.getString(Config.KEY_OSM_USER_DETAILS_URL).get,
       osmServer + this.config.getString(Config.KEY_OSM_REQUEST_TOKEN_URL).get,
@@ -131,6 +147,8 @@ object Config {
   val KEY_ACTION_LEVEL = s"$GROUP_MAPROULETTE.action.level"
   val KEY_NUM_OF_CHALLENGES = s"$GROUP_MAPROULETTE.limits.challenges"
   val KEY_RECENT_ACTIVITY = s"$GROUP_MAPROULETTE.limits.activities"
+  val KEY_CHANGESET_TIME_LIMIT = s"$GROUP_MAPROULETTE.tasks.changesets.timeLimit"
+  val KEY_CHANGESET_ENABLED = s"$GROUP_MAPROULETTE.tasks.changesets.enabled"
   val KEY_MAX_SAVED_CHALLENGES = s"$GROUP_MAPROULETTE.limits.saved"
   val KEY_SEMANTIC_VERSION = s"$GROUP_MAPROULETTE.version"
   val KEY_SESSION_TIMEOUT = s"$GROUP_MAPROULETTE.session.timeout"
@@ -145,6 +163,10 @@ object Config {
   val KEY_SCHEDULER_CLEAN_TASKS_STATUS_FILTER = s"$SUB_GROUP_SCHEDULER.cleanOldTasks.statusFilter"
   val KEY_SCHEDULER_CLEAN_TASKS_OLDER_THAN = s"$SUB_GROUP_SCHEDULER.cleanOldTasks.olderThan"
   val KEY_SCHEDULER_CLEAN_VC_INTEVAL = s"$SUB_GROUP_SCHEDULER.cleanExpiredVCs.interval"
+  val KEY_SCHEDULER_OSM_MATCHER_INTERVAL = s"$SUB_GROUP_SCHEDULER.osmMatcher.interval"
+  val KEY_SCHEDULER_OSM_MATCHER_BATCH_SIZE = s"$SUB_GROUP_SCHEDULER.osmMatcher.batchSize"
+  val KEY_SCHEDULER_OSM_MATCHER_ENABLED = s"$SUB_GROUP_SCHEDULER.osmMatcher.enabled"
+  val KEY_SCHEDULER_OSM_MATCHER_MANUAL = s"$SUB_GROUP_SCHEDULER.osmMatcher.manual"
 
   val GROUP_OSM = "osm"
   val KEY_OSM_SERVER = s"$GROUP_OSM.server"
@@ -181,4 +203,9 @@ object Config {
   val DEFAULT_VIRTUAL_CHALLENGE_LIMIT = 100
   val DEFAULT_VIRTUAL_CHALLENGE_BATCH_SIZE = 500
   val DEFAULT_VIRTUAL_CHALLENGE_EXPIRY ="6 hours"
+  val DEFAULT_CHANGESET_HOUR_LIMIT = "1 hour"
+  val DEFAULT_CHANGESET_ENABLED = false
+  val DEFAULT_OSM_MATCHER_ENABLED = false
+  val DEFAULT_OSM_MATCHER_MANUAL = false
+  val DEFAULT_MATCHER_BATCH_SIZE = 5000
 }

--- a/app/org/maproulette/controllers/CRUDController.scala
+++ b/app/org/maproulette/controllers/CRUDController.scala
@@ -246,8 +246,12 @@ trait CRUDController[T<:BaseObject[Long]] extends Controller with DefaultWrites 
     this.sessionManager.authenticatedRequest { implicit user =>
       this.dal.delete(id.toLong, user, immediate)
       this.actionManager.setAction(Some(user), this.itemType.convertToItem(id.toLong), Deleted(), "")
-      Ok(Json.toJson(StatusMessage("OK",
-        JsString(s"${Actions.getTypeName(this.itemType.typeId).getOrElse("Unknown Object")} $id deleted by user ${user.id}."))))
+      val message = if (immediate) {
+        JsString(s"${Actions.getTypeName(this.itemType.typeId).getOrElse("Unknown Object")} $id deleted by user ${user.id}.")
+      } else {
+        JsString(s"${Actions.getTypeName(this.itemType.typeId).getOrElse("Unknown Object")} $id set for delayed deletion by user ${user.id}.")
+      }
+      Ok(Json.toJson(StatusMessage("OK", message)))
     }
   }
 

--- a/app/org/maproulette/controllers/CRUDController.scala
+++ b/app/org/maproulette/controllers/CRUDController.scala
@@ -15,7 +15,7 @@ import org.maproulette.session.{SessionManager, User}
 import org.maproulette.utils.Utils
 import play.api.Logger
 import play.api.libs.json._
-import play.api.mvc.{Action, AnyContent, BodyParsers, Controller}
+import play.api.mvc._
 
 /**
   * This is the base controller class that handles all the CRUD operations for the objects in MapRoulette.
@@ -45,7 +45,7 @@ trait CRUDController[T<:BaseObject[Long]] extends Controller with DefaultWrites 
     * @param obj the object being sent in the response
     * @return A Json representation of the object
     */
-  def inject(obj:T) : JsValue = Json.toJson(obj)
+  def inject(obj:T)(implicit request:Request[Any]) : JsValue = Json.toJson(obj)
 
   /**
     * Function can be implemented to extract more information than just the default create data,
@@ -239,11 +239,12 @@ trait CRUDController[T<:BaseObject[Long]] extends Controller with DefaultWrites 
     * Must be authenticated to perform operation
     *
     * @param id The id of the object to delete
+    * @param immediate if true will delete it immediately, otherwise will just flag for deletion
     * @return 204 NoContent
     */
-  def delete(id:Long) : Action[AnyContent] = Action.async { implicit request =>
+  def delete(id:Long, immediate:Boolean) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.dal.delete(id.toLong, user)
+      this.dal.delete(id.toLong, user, immediate)
       this.actionManager.setAction(Some(user), this.itemType.convertToItem(id.toLong), Deleted(), "")
       Ok(Json.toJson(StatusMessage("OK",
         JsString(s"${Actions.getTypeName(this.itemType.typeId).getOrElse("Unknown Object")} $id deleted by user ${user.id}."))))

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -53,6 +53,7 @@ class ProjectController @Inject() (override val childController:ChallengeControl
     var jsonBody = super.updateCreateBody(body, user)
     jsonBody = Utils.insertIntoJson(jsonBody, "groups", Array.emptyShortArray)(arrayWrites[Short])
     jsonBody = Utils.insertIntoJson(jsonBody, "owner", user.osmProfile.id, true)(LongWrites)
+    jsonBody = Utils.insertIntoJson(jsonBody, "deleted", false)(BooleanWrites)
     Utils.insertIntoJson(jsonBody, "enabled", true)(BooleanWrites)
   }
 
@@ -93,7 +94,7 @@ class ProjectController @Inject() (override val childController:ChallengeControl
                      tags: String, taskSearch:String, limit:Int, proximityId:Long) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       val params = SearchParameters(
-        projectId = Some(projectId),
+        projectIds = Some(List(projectId)),
         challengeSearch = Some(challengeSearch),
         challengeTags = Some(Utils.split(challengeTags)),
         taskSearch = Some(taskSearch),

--- a/app/org/maproulette/controllers/api/SurveyController.scala
+++ b/app/org/maproulette/controllers/api/SurveyController.scala
@@ -12,6 +12,7 @@ import org.maproulette.services.ChallengeService
 import org.maproulette.session.{SessionManager, User}
 import org.maproulette.utils.Utils
 import play.api.libs.json._
+import play.api.libs.ws.WSClient
 import play.api.mvc.{Action, AnyContent}
 
 /**
@@ -28,8 +29,9 @@ class SurveyController @Inject() (override val childController:TaskController,
                                   override val dal: SurveyDAL,
                                   dalManager: DALManager,
                                   override val tagDAL: TagDAL,
-                                  challengeService: ChallengeService)
-  extends ChallengeController(childController, sessionManager, actionManager, dalManager.challenge, dalManager, tagDAL, challengeService) {
+                                  challengeService: ChallengeService,
+                                  wsClient: WSClient)
+  extends ChallengeController(childController, sessionManager, actionManager, dalManager.challenge, dalManager, tagDAL, challengeService, wsClient) {
 
   // The type of object that this controller deals with.
   override implicit val itemType = SurveyType()

--- a/app/org/maproulette/controllers/api/SurveyController.scala
+++ b/app/org/maproulette/controllers/api/SurveyController.scala
@@ -8,12 +8,13 @@ import org.maproulette.actions._
 import org.maproulette.exception.NotFoundException
 import org.maproulette.models.{Answer, Challenge, Task}
 import org.maproulette.models.dal._
+import org.maproulette.permissions.Permission
 import org.maproulette.services.ChallengeService
 import org.maproulette.session.{SessionManager, User}
 import org.maproulette.utils.Utils
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
-import play.api.mvc.{Action, AnyContent}
+import play.api.mvc.{Action, AnyContent, Request}
 
 /**
   * The survey controller handles all operations for the Survey objects.
@@ -30,8 +31,9 @@ class SurveyController @Inject() (override val childController:TaskController,
                                   dalManager: DALManager,
                                   override val tagDAL: TagDAL,
                                   challengeService: ChallengeService,
-                                  wsClient: WSClient)
-  extends ChallengeController(childController, sessionManager, actionManager, dalManager.challenge, dalManager, tagDAL, challengeService, wsClient) {
+                                  wsClient: WSClient,
+                                  permission:Permission)
+  extends ChallengeController(childController, sessionManager, actionManager, dalManager.challenge, dalManager, tagDAL, challengeService, wsClient, permission) {
 
   // The type of object that this controller deals with.
   override implicit val itemType = SurveyType()
@@ -43,7 +45,7 @@ class SurveyController @Inject() (override val childController:TaskController,
     * @param obj the object being sent in the response
     * @return A Json representation of the object
     */
-  override def inject(obj: Challenge) = {
+  override def inject(obj: Challenge)(implicit request:Request[Any]) = {
     val json = super.inject(obj)
     // if no answers provided with Challenge, then provide the default answers
     val answers = this.dalManager.survey.getAnswers(obj.id) match {

--- a/app/org/maproulette/controllers/api/UserController.scala
+++ b/app/org/maproulette/controllers/api/UserController.scala
@@ -7,12 +7,16 @@ import org.maproulette.models.{Challenge, Task}
 import org.maproulette.session.dal.UserDAL
 import org.maproulette.session.{SessionManager, User, UserSettings}
 import play.api.libs.json._
-import play.api.mvc.{Action, AnyContent, BodyParsers, Controller}
+import play.api.mvc._
+
+import scala.concurrent.Promise
+import scala.util.{Failure, Success}
 
 /**
   * @author cuthbertm
   */
 class UserController @Inject()(userDAL: UserDAL, sessionManager: SessionManager) extends Controller with DefaultWrites {
+  import scala.concurrent.ExecutionContext.Implicits.global
 
   implicit val userReadWrite = User.UserFormat
   implicit val challengeWrites = Challenge.writes.challengeWrites
@@ -63,6 +67,26 @@ class UserController @Inject()(userDAL: UserDAL, sessionManager: SessionManager)
         case Some(u) => Ok(Json.toJson(u))
         case None => throw new NotFoundException(s"No user found to update with id '$id'")
       }
+    }
+  }
+
+  /**
+    * Action to refresh the user's OSM profile
+    *
+    * @return Ok Status with no content
+    */
+  def refreshProfile(osmUserId:Long) : Action[AnyContent] = Action.async { implicit request =>
+    sessionManager.authenticatedFutureRequest { implicit user =>
+      val p = Promise[Result]
+      this.userDAL.retrieveByOSMID(osmUserId, user) match {
+        case Some(u) =>
+          sessionManager.refreshProfile(u.osmProfile.requestToken, user) onComplete {
+            case Success(result) => p success Ok
+            case Failure(f) => p failure f
+          }
+        case None => p failure new NotFoundException(s"Failed to find any user with OSM User id [$osmUserId]")
+      }
+      p.future
     }
   }
 

--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -54,7 +54,8 @@ class VirtualChallengeController @Inject() (override val sessionManager: Session
       case Some(ex) => Duration(ex).toHours.toInt
       case None => config.virtualChallengeExpiry.toHours.toInt
     }
-    Utils.insertIntoJson(jsonBody, "expiry", DateTime.now().plusHours(expiryValue))(DefaultJodaDateWrites)
+    val expiryUpdate = Utils.insertIntoJson(jsonBody, "expiry", DateTime.now().plusHours(expiryValue))(DefaultJodaDateWrites)
+    Utils.insertIntoJson(expiryUpdate, "ownerId", user.osmProfile.id)
   }
 
   /**

--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -110,7 +110,7 @@ object MPExceptionUtil {
     p.future
   }
 
-  private def manageException(e:Throwable) : Result = {
+  def manageException(e:Throwable) : Result = {
     e match {
       case e:InvalidException =>
         Logger.error(e.getMessage, e)

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -27,6 +27,7 @@ class Scheduler @Inject() (val system: ActorSystem,
   schedule("cleanOldTasks", "Cleaning old tasks", 1.minute, Config.KEY_SCHEDULER_CLEAN_TASKS_INTERVAL)
   schedule("cleanExpiredVirtualChallenges", "Cleaning up expired Virtual Challenges", 1.minute, Config.KEY_SCHEDULER_CLEAN_VC_INTEVAL)
   schedule("OSMChangesetMatcher", "Matches OSM changesets to tasks", 1.minute, Config.KEY_SCHEDULER_OSM_MATCHER_INTERVAL)
+  schedule("cleanDeleted", "Deleting Project/Challenges", 1.minute, Config.KEY_SCHEDULER_CLEAN_DELETED)
 
   /**
     * Conditionally schedules message event when configured with a valid duration

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -26,6 +26,7 @@ class Scheduler @Inject() (val system: ActorSystem,
   schedule("updateLocations", "Updating locations", 1.minute, Config.KEY_SCHEDULER_UPDATE_LOCATIONS_INTERVAL)
   schedule("cleanOldTasks", "Cleaning old tasks", 1.minute, Config.KEY_SCHEDULER_CLEAN_TASKS_INTERVAL)
   schedule("cleanExpiredVirtualChallenges", "Cleaning up expired Virtual Challenges", 1.minute, Config.KEY_SCHEDULER_CLEAN_VC_INTEVAL)
+  schedule("OSMChangesetMatcher", "Matches OSM changesets to tasks", 1.minute, Config.KEY_SCHEDULER_OSM_MATCHER_INTERVAL)
 
   /**
     * Conditionally schedules message event when configured with a valid duration

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -13,8 +13,10 @@ import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.jobs.SchedulerActor.RunJob
 import org.maproulette.metrics.Metrics
+import org.maproulette.models.Task
 import org.maproulette.models.Task.STATUS_CREATED
 import org.maproulette.models.dal.DALManager
+import org.maproulette.session.User
 
 /**
   * The main actor that handles all scheduled activities
@@ -41,6 +43,8 @@ class SchedulerActor @Inject() (config:Config,
     case RunJob("cleanOldTasks", action) => this.cleanOldTasks(action)
     case RunJob("updateTaskLocations", action) => this.updateTaskLocations(action.toLong)
     case RunJob("cleanExpiredVirtualChallenges", action) => this.cleanExpiredVirtualChallenges(action)
+    case RunJob("FindChangeSets", action) => this.findChangeSets(action)
+    case RunJob("OSMChangesetMatcher", action) => this.matchChangeSets(action)
   }
 
   /**
@@ -153,6 +157,62 @@ class SchedulerActor @Inject() (config:Config,
       // Clear the task cache if any were deleted
       if (numberOfDeleted > 0) {
         this.dALManager.virtualChallenge.cacheManager.clearCaches
+      }
+    }
+  }
+
+  /**
+    * Run through all the tasks and match OSM Changesets to fixed tasks. This will run through tasks
+    * 5000 at a time, and limit the tasks returned to only tasks that have actually had their status
+    * set to FIXED and changeset value not set to -2. If the value is -2 then it assumes that we have
+    * already tried to match the changeset and couldn't find any viable option for it.
+    *
+    * @param str
+    */
+  def matchChangeSets(str:String) : Unit = {
+    if (config.osmMatcherEnabled) {
+      db.withConnection { implicit c =>
+        val query =
+          s"""
+             |SELECT ${dALManager.task.retrieveColumns} FROM tasks
+             |WHERE status = 1 AND changeset_id = -1
+             |LIMIT ${config.osmMatcherBatchSize}
+         """.stripMargin
+        SQL(query).as(dALManager.task.parser.*).foreach(t => {
+          dALManager.task.matchToOSMChangeSet(t, User.superUser)
+        })
+      }
+    }
+  }
+
+  /**
+    * Task that manually matches the OSM changesets to tasks
+    *
+    * @param str
+    */
+  def findChangeSets(str: String) : Unit = {
+    if (config.osmMatcherManualOnly) {
+      val values = str.split("=")
+      if (values.size == 2) {
+        implicit val id = values(1).toLong
+        values(0) match {
+          case "p" =>
+            dALManager.project.listChildren(-1).foreach(c => {
+              dALManager.challenge.listChildren(-1)(c.id).filter(_.status == Task.STATUS_FIXED).foreach(t =>
+                dALManager.task.matchToOSMChangeSet(t, User.superUser, false)
+              )
+            })
+          case "c" =>
+            dALManager.challenge.listChildren(-1).foreach(t => {
+              dALManager.task.matchToOSMChangeSet(t, User.superUser, false)
+            })
+          case "t" =>
+            dALManager.task.retrieveById match {
+              case Some(t) => dALManager.task.matchToOSMChangeSet(t, User.superUser, false)
+              case None =>
+            }
+          case _ => // Do nothing because there is nothing to do
+        }
       }
     }
   }

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -59,6 +59,7 @@ case class Challenge(override val id:Long,
                      override val created:DateTime,
                      override val modified:DateTime,
                      override val description:Option[String]=None,
+                     infoLink:Option[String]=None,
                      general:ChallengeGeneral,
                      creation:ChallengeCreation,
                      priority:ChallengePriority,
@@ -152,6 +153,7 @@ object Challenge {
       "created" -> default(jodaDate, DateTime.now()),
       "modified" -> default(jodaDate, DateTime.now()),
       "description" -> optional(text),
+      "infoLink" -> optional(text),
       "general" -> mapping(
         "owner" -> longNumber,
         "parent" -> longNumber,
@@ -188,7 +190,7 @@ object Challenge {
   )
 
   def emptyChallenge(ownerId:Long, parentId:Long) : Challenge = Challenge(
-    -1, "", DateTime.now(), DateTime.now(), None, ChallengeGeneral(-1, -1, ""),
+    -1, "", DateTime.now(), DateTime.now(), None, None, ChallengeGeneral(-1, -1, ""),
     ChallengeCreation(), ChallengePriority(), ChallengeExtra()
   )
 

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -59,6 +59,7 @@ case class Challenge(override val id:Long,
                      override val created:DateTime,
                      override val modified:DateTime,
                      override val description:Option[String]=None,
+                     deleted:Boolean = false,
                      infoLink:Option[String]=None,
                      general:ChallengeGeneral,
                      creation:ChallengeCreation,
@@ -153,6 +154,7 @@ object Challenge {
       "created" -> default(jodaDate, DateTime.now()),
       "modified" -> default(jodaDate, DateTime.now()),
       "description" -> optional(text),
+      "deleted" -> default(boolean, false),
       "infoLink" -> optional(text),
       "general" -> mapping(
         "owner" -> longNumber,
@@ -190,7 +192,7 @@ object Challenge {
   )
 
   def emptyChallenge(ownerId:Long, parentId:Long) : Challenge = Challenge(
-    -1, "", DateTime.now(), DateTime.now(), None, None, ChallengeGeneral(-1, -1, ""),
+    -1, "", DateTime.now(), DateTime.now(), None, false, None, ChallengeGeneral(-1, -1, ""),
     ChallengeCreation(), ChallengePriority(), ChallengeExtra()
   )
 

--- a/app/org/maproulette/models/Changeset.scala
+++ b/app/org/maproulette/models/Changeset.scala
@@ -1,0 +1,72 @@
+package org.maproulette.models
+
+import org.apache.commons.lang3.StringUtils
+import org.joda.time.DateTime
+import play.api.Logger
+
+import scala.xml._
+
+
+/**
+  * @author mcuthbert
+  */
+case class Changeset(id:Long,
+                     user:String,
+                     userId:Long,
+                     createdAt:DateTime,
+                     closedAt:DateTime,
+                     open:Boolean,
+                     minLat:Double,
+                     minLon:Double,
+                     maxLat:Double,
+                     maxLon:Double,
+                     commentsCount:Int,
+                     tags:Map[String, String],
+                     hasMapRouletteComment:Boolean)
+
+object ChangesetParser {
+  def parse(el: Elem) : List[Changeset] = {
+    (el \\ "changeset").map { c => this.parse(c) }.toList
+  }
+
+  def parse(changeSetElement: Node) : Changeset = {
+    // for some reason the open value is sometimes an empty string, so need to handle that correctly
+    val open = (changeSetElement \ "@open").text
+    if (StringUtils.isEmpty(open)) {
+      Logger.debug(s"Invalid changeset provided: ${changeSetElement.toString()}")
+    }
+    val minLat = (changeSetElement \ "@min_lat").text
+    if (StringUtils.isEmpty(minLat)) {
+      Logger.debug(s"Invalid changeset provided: ${changeSetElement.toString()}")
+    }
+    val minLon = (changeSetElement \ "@min_lon").text
+    val maxLat = (changeSetElement \ "@max_lat").text
+    val maxLon = (changeSetElement \ "@max_lon").text
+
+    var mapRouletteTag = false
+    val tags = (changeSetElement \\ "tag").map { t =>
+      val key = (t \ "k").text
+      val value = (t \ "v").text
+      if (StringUtils.equals(key, "comment") && StringUtils.containsIgnoreCase(value, "maproulette")) {
+        mapRouletteTag = true
+      }
+      key -> value
+    }.toMap
+
+    Changeset(
+      (changeSetElement \ "@id").text.toLong,
+      (changeSetElement \ "@user").text,
+      (changeSetElement \ "@uid").text.toLong,
+      DateTime.parse((changeSetElement \ "@created_at").text),
+      DateTime.parse((changeSetElement \ "@closed_at").text),
+      if (StringUtils.isEmpty(open)) { false } else { open.toBoolean },
+      if (StringUtils.isEmpty(minLat)) { 0D } else { minLat.toDouble },
+      if (StringUtils.isEmpty(minLon)) { 0D } else { minLon.toDouble },
+      if (StringUtils.isEmpty(maxLat)) { 0D } else { maxLat.toDouble },
+      if (StringUtils.isEmpty(maxLon)) { 0D } else { maxLon.toDouble },
+      (changeSetElement \ "@comments_count").text.toInt,
+      tags,
+      mapRouletteTag
+    )
+  }
+}

--- a/app/org/maproulette/models/ClusteredPoint.scala
+++ b/app/org/maproulette/models/ClusteredPoint.scala
@@ -19,6 +19,8 @@ case class Point(lat:Double, lng:Double)
   * @param owner The osm id of the owner of the object
   * @param ownerName The name of the owner
   * @param title The title of the object (or name)
+  * @param parentId The id of the parent, Challenge if Task, and Project if Challenge
+  * @param parentName The name of the parent
   * @param point The latitude and longitude of the point
   * @param blurb A short descriptive text for the object
   * @param modified The last time this set of points was modified
@@ -26,8 +28,9 @@ case class Point(lat:Double, lng:Double)
   * @param type The type of this ClusteredPoint
   * @param status The status of the task, only used for task points, ie. not challenge points
   */
-case class ClusteredPoint(id:Long, owner:Long, ownerName:String, title:String, point:Point, bounding:JsValue,
-                          blurb:String, modified:DateTime, difficulty:Int, `type`:Int, status:Int = -1)
+case class ClusteredPoint(id:Long, owner:Long, ownerName:String, title:String, parentId:Long, parentName:String,
+                          point:Point, bounding:JsValue, blurb:String, modified:DateTime, difficulty:Int,
+                          `type`:Int, status:Int, priority:Int)
 
 object ClusteredPoint {
   implicit val pointWrites: Writes[Point] = Json.writes[Point]

--- a/app/org/maproulette/models/Project.scala
+++ b/app/org/maproulette/models/Project.scala
@@ -24,7 +24,8 @@ case class Project(override val id: Long,
                    override val description: Option[String]=None,
                    groups:List[Group]=List.empty,
                    enabled:Boolean=false,
-                   displayName: Option[String]=None) extends BaseObject[Long] {
+                   displayName: Option[String]=None,
+                   deleted:Boolean=false) extends BaseObject[Long] {
 
   override val itemType: ItemType = ProjectType()
 }
@@ -56,7 +57,8 @@ object Project {
         )(Group.apply)(Group.unapply)
       ),
       "enabled" -> boolean,
-      "displayName" -> optional(text)
+      "displayName" -> optional(text),
+      "deleted" -> default(boolean, false)
     )(Project.apply)(Project.unapply)
   )
 

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -7,9 +7,9 @@ import org.joda.time.DateTime
 import org.maproulette.actions.{ItemType, TaskType}
 import org.maproulette.utils.Utils
 import play.api.data.Form
+import play.api.data.format.Formats._
 import play.api.data.Forms._
 import play.api.libs.json._
-import play.api.libs.functional.syntax._
 
 /**
   * The primary object in MapRoulette is the task, this is the object that defines the actual problem
@@ -94,7 +94,9 @@ object Task {
       Utils.insertIntoJson(updated, "geometries", Json.parse(o.geometries), true)
     }
 
-    override def reads(json: JsValue): JsResult[Task] = Json.fromJson[Task](json)(Json.reads[Task])
+    override def reads(json: JsValue): JsResult[Task] = {
+      Json.fromJson[Task](json)(Json.reads[Task])
+    }
   }
 
   val STATUS_CREATED = 0

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -39,7 +39,8 @@ case class Task(override val id:Long,
                 location: Option[String]=None,
                 geometries:String,
                 status:Option[Int]=None,
-                priority:Int=Challenge.PRIORITY_HIGH) extends BaseObject[Long] with DefaultReads with LowPriorityDefaultReads {
+                priority:Int=Challenge.PRIORITY_HIGH,
+                changesetId:Option[Long]=None) extends BaseObject[Long] with DefaultReads with LowPriorityDefaultReads {
   override val itemType: ItemType = TaskType()
 
   def getGeometryProperties() : List[Map[String, String]] = {
@@ -191,7 +192,8 @@ object Task {
       "location" -> optional(text),
       "geometries" -> nonEmptyText,
       "status" -> optional(number),
-      "priority" -> default(number, Challenge.PRIORITY_HIGH)
+      "priority" -> default(number, Challenge.PRIORITY_HIGH),
+      "changesetId" -> optional(longNumber)
     )(Task.apply)(Task.unapply)
   )
 

--- a/app/org/maproulette/models/VirtualChallenge.scala
+++ b/app/org/maproulette/models/VirtualChallenge.scala
@@ -13,6 +13,7 @@ case class VirtualChallenge(override val id:Long,
                             override val created:DateTime,
                             override val modified:DateTime,
                             override val description:Option[String]=None,
+                            ownerId:Long,
                             searchParameters:SearchParameters,
                             expiry:DateTime) extends BaseObject[Long] with DefaultWrites {
 

--- a/app/org/maproulette/models/dal/BaseDAL.scala
+++ b/app/org/maproulette/models/dal/BaseDAL.scala
@@ -145,9 +145,10 @@ trait BaseDAL[Key, T<:BaseObject[Key]] extends DALHelper with TransactionManager
     *
     * @param id The id that you want to delete
     * @param user The user executing the task
+    * @param immediate Ignored for the base function, only used by the ParentDAL which override it and uses it
     * @return Count of deleted row(s)
     */
-  def delete(id: Key, user:User)(implicit c:Option[Connection]=None): T = {
+  def delete(id: Key, user:User, immediate:Boolean=false)(implicit c:Option[Connection]=None): T = {
     implicit val key = id
     val deletedItem = this.cacheManager.withDeletingCache(Long => retrieveById) { implicit deletedItem =>
       this.permission.hasObjectWriteAccess(deletedItem.asInstanceOf[BaseObject[Long]], user)

--- a/app/org/maproulette/models/dal/BaseDAL.scala
+++ b/app/org/maproulette/models/dal/BaseDAL.scala
@@ -212,7 +212,7 @@ trait BaseDAL[Key, T<:BaseObject[Key]] extends DALHelper with TransactionManager
     this.cacheManager.withOptionCaching { () =>
       this.withMRConnection { implicit c =>
         val query = s"SELECT ${this.retrieveColumns} FROM ${this.tableName} WHERE name = {name} ${this.parentFilter(parentId)}"
-        SQL(query).on('name -> name).as(this.parser.singleOpt)
+        SQL(query).on('name -> name).as(this.parser.*).headOption
       }
     }
   }

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -389,8 +389,8 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
         case Some(s) => s"AND status IN (${s.mkString(",")}"
         case None => ""
       }
-      val pointParser = long("t.id") ~ str("t.name") ~ long("t.parent_id") ~ str("c.name") ~
-                        str("t.instruction") ~ str("location") ~ int("t.status") ~ int("t.priority") map {
+      val pointParser = long("tasks.id") ~ str("tasks.name") ~ long("tasks.parent_id") ~ str("challenges.name") ~
+                        str("tasks.instruction") ~ str("location") ~ int("tasks.status") ~ int("tasks.priority") map {
         case id ~ name ~ parentId ~ parentName ~ instruction ~ location ~ status ~ priority =>
           val locationJSON = Json.parse(location)
           val coordinates = (locationJSON \ "coordinates").as[List[Double]]

--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -61,18 +61,18 @@ class ProjectDAL @Inject() (override val db:Database,
   }
 
   val pointParser = {
-    long("c.id") ~
+    long("challenges.id") ~
       int("users.osm_id") ~
       str("users.name") ~
-      str("c.name") ~
-      int("c.parent_id") ~
-      str("p.name") ~
-      get[Option[String]]("c.blurb") ~
+      str("challenges.name") ~
+      int("challenges.parent_id") ~
+      str("projects.name") ~
+      get[Option[String]]("challenges.blurb") ~
       str("location") ~
       str("bounding") ~
-      get[DateTime]("c.last_updated") ~
-      int("c.difficulty") ~
-      int("c.challenge_type") map {
+      get[DateTime]("challenges.last_updated") ~
+      int("challenges.difficulty") ~
+      int("challenges.challenge_type") map {
       case id ~ osm_id ~ username ~ name ~ parentId ~ parentName ~ blurb ~ location ~ bounding ~ modified ~ difficulty ~ challengeType =>
         val locationJSON = Json.parse(location)
         val coordinates = (locationJSON \ "coordinates").as[List[Double]]
@@ -265,7 +265,7 @@ class ProjectDAL @Inject() (override val db:Database,
           ${this.enabled(params.enabledChallenge, "c")} ${this.enabled(params.enabledProject, "p")}
           AND c.deleted = false and p.deleted = false
           ${params.getProjectIds match {
-              case Some(v) if v.nonEmpty => s" AND c.parent_id IN (${params.projectIds.get})"
+              case Some(v) if v.nonEmpty => s" AND c.parent_id IN (${v.mkString(",")})"
               case None => ""
            }}
           $locationClause

--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -12,7 +12,6 @@ import org.maproulette.Config
 import org.maproulette.cache.CacheManager
 import org.maproulette.exception.UniqueViolationException
 import org.maproulette.models._
-import org.maproulette.models.utils.AND
 import org.maproulette.permissions.Permission
 import org.maproulette.session.{Group, SearchParameters, User}
 import org.maproulette.session.dal.UserGroupDAL
@@ -54,29 +53,32 @@ class ProjectDAL @Inject() (override val db:Database,
       get[DateTime]("projects.modified") ~
       get[Option[String]]("projects.description") ~
       get[Boolean]("projects.enabled") ~
-      get[Option[String]]("projects.display_name") map {
-      case id ~ ownerId ~ name ~ created ~ modified ~ description ~ enabled ~ displayName =>
-        new Project(id, ownerId, name, created, modified, description, userGroupDAL.getProjectGroups(id, User.superUser), enabled, displayName)
+      get[Option[String]]("projects.display_name") ~
+      get[Boolean]("projects.deleted") map {
+      case id ~ ownerId ~ name ~ created ~ modified ~ description ~ enabled ~ displayName ~ deleted =>
+        new Project(id, ownerId, name, created, modified, description, userGroupDAL.getProjectGroups(id, User.superUser), enabled, displayName, deleted)
     }
   }
 
   val pointParser = {
-    long("id") ~
-      int("osm_id") ~
+    long("c.id") ~
+      int("users.osm_id") ~
       str("users.name") ~
-      str("challenges.name") ~
-      get[Option[String]]("blurb") ~
+      str("c.name") ~
+      int("c.parent_id") ~
+      str("p.name") ~
+      get[Option[String]]("c.blurb") ~
       str("location") ~
       str("bounding") ~
-      get[DateTime]("challenges.last_updated") ~
-      int("difficulty") ~
-      int("challenge_type") map {
-      case id ~ osm_id ~ username ~ name ~ blurb ~ location ~ bounding ~ modified ~ difficulty ~ challengeType =>
+      get[DateTime]("c.last_updated") ~
+      int("c.difficulty") ~
+      int("c.challenge_type") map {
+      case id ~ osm_id ~ username ~ name ~ parentId ~ parentName ~ blurb ~ location ~ bounding ~ modified ~ difficulty ~ challengeType =>
         val locationJSON = Json.parse(location)
         val coordinates = (locationJSON \ "coordinates").as[List[Double]]
         val point = Point(coordinates(1), coordinates.head)
         val boundingJSON = Json.parse(bounding)
-        ClusteredPoint(id, osm_id, username, name, point, boundingJSON, blurb.getOrElse(""), modified, difficulty, challengeType)
+        ClusteredPoint(id, osm_id, username, name, parentId, parentName, point, boundingJSON, blurb.getOrElse(""), modified, difficulty, challengeType, -1, -1)
     }
   }
 
@@ -202,6 +204,7 @@ class ProjectDAL @Inject() (override val db:Database,
                     INNER JOIN groups g ON g.project_id = p.id
                     INNER JOIN challenges c ON c.parent_id = p.id
                     WHERE (1=${if (user.isSuperUser) { 1 } else { 0 }} OR g.id IN ({ids}))
+                     AND c.deleted = false and p.deleted = false
                     ${this.searchField("p.name")} ${this.enabled(onlyEnabled, "p")}
                     GROUP BY p.id
                     LIMIT ${this.sqlLimit(limit)} OFFSET $offset"""
@@ -246,7 +249,7 @@ class ProjectDAL @Inject() (override val db:Database,
         case None => ""
       }
       val query = s"""
-          SELECT c.id, u.osm_id, u.name, c.name, c.blurb,
+          SELECT c.id, u.osm_id, u.name, c.name, c.parent_id, p.name, c.blurb,
                   ST_AsGeoJSON(c.location) AS location, ST_AsGeoJSON(c.bounding) AS bounding,
                   c.difficulty, c.challenge_type, c.last_updated
           FROM challenges c
@@ -260,7 +263,11 @@ class ProjectDAL @Inject() (override val db:Database,
           ${this.searchField("c.name", "cs")}
           ${this.searchField("p.name", "ps")}
           ${this.enabled(params.enabledChallenge, "c")} ${this.enabled(params.enabledProject, "p")}
-          ${if (params.projectId.isDefined && params.projectId.get > 0) {s" AND c.parent_id = ${params.projectId.get}"} else {""}}
+          AND c.deleted = false and p.deleted = false
+          ${params.getProjectIds match {
+              case Some(v) if v.nonEmpty => s" AND c.parent_id IN (${params.projectIds.get})"
+              case None => ""
+           }}
           $locationClause
           ${challengeTags._2}
           LIMIT ${sqlLimit(limit)} OFFSET $offset
@@ -280,7 +287,7 @@ class ProjectDAL @Inject() (override val db:Database,
   def getClusteredPoints(projectId:Option[Long]=None, challengeIds:List[Long]=List.empty,
                               enabledOnly:Boolean=true)(implicit c:Option[Connection]=None) : List[ClusteredPoint] = {
     this.withMRConnection { implicit c =>
-      SQL"""SELECT c.id, u.osm_id, u.name, c.name, c.blurb,
+      SQL"""SELECT c.id, u.osm_id, u.name, c.name, c.parent_id, p.name, c.blurb,
                     ST_AsGeoJSON(c.location) AS location, ST_AsGeoJSON(c.bounding) AS bounding,
                     c.difficulty, c.challenge_type, c.last_updated
               FROM challenges c
@@ -290,6 +297,7 @@ class ProjectDAL @Inject() (override val db:Database,
                 SELECT id FROM tasks
                 WHERE parent_id = c.id AND status IN (${Task.STATUS_CREATED},${Task.STATUS_SKIPPED},${Task.STATUS_TOO_HARD}) LIMIT 1)
               #${this.enabled(enabledOnly, "c")} #${this.enabled(enabledOnly, "p")}
+              AND c.deleted = false AND p.deleted = false
               #${if(projectId.isDefined) { s" AND c.parent_id = ${projectId.get}"} else { "" }}
               #${if(challengeIds.nonEmpty) { s" AND c.id IN (${challengeIds.mkString(",")})"} else { "" }}
         """.as(this.pointParser.*)

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -7,13 +7,14 @@ import javax.inject.{Inject, Provider, Singleton}
 
 import anorm.SqlParser._
 import anorm._
+import com.vividsolutions.jts.geom.Envelope
 import org.apache.commons.lang3.StringUtils
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.maproulette.Config
-import org.maproulette.actions.{ActionManager, Actions, StatusActionManager, TaskType}
+import org.maproulette.actions._
 import org.maproulette.cache.CacheManager
-import org.maproulette.exception.{InvalidException, NotFoundException, UniqueViolationException}
-import org.maproulette.models.utils.{AND, DALHelper}
+import org.maproulette.exception.{InvalidException, NotFoundException}
+import org.maproulette.models.utils.DALHelper
 import org.maproulette.models._
 import org.maproulette.permissions.Permission
 import org.maproulette.session.dal.UserDAL
@@ -21,10 +22,14 @@ import org.maproulette.session.{SearchParameters, User}
 import play.api.Logger
 import play.api.db.Database
 import play.api.libs.json._
+import play.api.libs.ws.WSClient
+import org.wololo.geojson.{FeatureCollection, GeoJSONFactory}
+import org.wololo.jts2geojson.GeoJSONReader
 
 import scala.collection.mutable.ListBuffer
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
+import scala.xml.XML
 
 /**
   * The data access layer for the Task objects
@@ -39,7 +44,8 @@ class TaskDAL @Inject()(override val db: Database,
                         projectDAL: Provider[ProjectDAL],
                         challengeDAL: Provider[ChallengeDAL],
                         actions: ActionManager,
-                        statusActions:StatusActionManager)
+                        statusActions:StatusActionManager,
+                        ws:WSClient)
   extends BaseDAL[Long, Task] with DALHelper with TagDALMixin[Task] with Locking[Task] {
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -62,9 +68,10 @@ class TaskDAL @Inject()(override val db: Database,
       get[Option[String]]("tasks.instruction") ~
       get[Option[String]]("location") ~
       get[Option[Int]]("tasks.status") ~
-      get[Int]("tasks.priority") map {
-      case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ priority =>
-        Task(id, name, created, modified, parent_id, instruction, location, this.getTaskGeometries(id), status, priority)
+      get[Int]("tasks.priority") ~
+      get[Option[Long]]("tasks.changeset_id") map {
+      case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ priority ~ changesetId =>
+        Task(id, name, created, modified, parent_id, instruction, location, this.getTaskGeometries(id), status, priority, changesetId)
     }
   }
 
@@ -169,22 +176,22 @@ class TaskDAL @Inject()(override val db: Database,
       val name = (value \ "name").asOpt[String].getOrElse(cachedItem.name)
       val parentId = (value \ "parentId").asOpt[Long].getOrElse(cachedItem.parent)
       val instruction = (value \ "instruction").asOpt[String].getOrElse(cachedItem.instruction.getOrElse(""))
-      val location = (value \ "location").asOpt[String].getOrElse(cachedItem.location.getOrElse(""))
       val status = (value \ "status").asOpt[Int].getOrElse(cachedItem.status.getOrElse(0))
       if (!Task.isValidStatusProgression(cachedItem.status.getOrElse(0), status)) {
         throw new InvalidException(s"Could not set status for task [$id], " +
           s"progression from ${cachedItem.status.getOrElse(0)} to $status not valid.")
       }
       val priority = (value \ "priority").asOpt[Int].getOrElse(cachedItem.priority)
-      val geometries = (value \ "geometries").asOpt[String].getOrElse("")
+      val geometries = (value \ "geometries").asOpt[String].getOrElse(cachedItem.geometries)
+      val changesetId = (value \ "changesetId").asOpt[Long].getOrElse(cachedItem.changesetId.getOrElse(-1L))
 
       this.mergeUpdate(cachedItem.copy(name = name,
         parent = parentId,
         instruction = Some(instruction),
-        location = Some(location),
         status = Some(status),
         geometries = geometries,
-        priority = priority), user)
+        priority = priority,
+        changesetId = Some(changesetId)), user)
     }
   }
 
@@ -201,10 +208,14 @@ class TaskDAL @Inject()(override val db: Database,
     */
   override def mergeUpdate(element: Task, user: User)(implicit id: Long, c: Option[Connection] = None): Option[Task] = {
     this.permission.hasObjectWriteAccess(element, user)
-    // clear the cache, and force a refresh
-    this.cacheManager.deleteByName(element.name)
+    // before clearing the cache grab the cachedItem
+    // by setting the delete implicit to true we clear out the cache for the element
+    // The cachedItem could be
+    val cachedItem = this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit cachedItem =>
+      Some(cachedItem)
+    }(id, true, true)
     val updatedTask:Option[Task] = this.withMRTransaction { implicit c =>
-        val query = "SELECT create_update_task({name}, {parentId}, {instruction}, {status}, {id}, {priority}, {reset})"
+        val query = "SELECT create_update_task({name}, {parentId}, {instruction}, {status}, {id}, {priority}, {changesetId}, {reset})"
 
         val updatedTaskId = SQL(query).on(
           NamedParameter("name", ParameterValue.toParameterValue(element.name)),
@@ -213,9 +224,10 @@ class TaskDAL @Inject()(override val db: Database,
           NamedParameter("status", ParameterValue.toParameterValue(element.status.getOrElse(Task.STATUS_CREATED))),
           NamedParameter("id", ParameterValue.toParameterValue(element.id)),
           NamedParameter("priority", ParameterValue.toParameterValue(element.priority)),
+          NamedParameter("changesetId", ParameterValue.toParameterValue(element.changesetId.getOrElse(-1L))),
           NamedParameter("reset", ParameterValue.toParameterValue(config.taskReset + " days"))
         ).as(long("create_update_task").*).head
-        if (StringUtils.isNotEmpty(element.geometries)) {
+        if (cachedItem.isEmpty || !StringUtils.equalsIgnoreCase(cachedItem.get.geometries, element.geometries)) {
           c.commit()
           this.updateGeometries(updatedTaskId, Json.parse(element.geometries))
           this.updateTaskLocation(updatedTaskId)
@@ -394,11 +406,116 @@ class TaskDAL @Inject()(override val db: Database,
       } catch {
         case e: Exception => Logger.warn(e.getMessage)
       }
+      if (config.changeSetEnabled) {
+        // try and match the current task with a changeset from the user
+        Future {
+          c.commit()
+          this.matchToOSMChangeSet(task.copy(status = Some(status)), user)
+        }
+      }
       updatedRows
     }
 
     this.cacheManager.withOptionCaching { () => Some(task.copy(status = Some(status))) }
     updatedRows
+  }
+
+  /**
+    * Tries to match a specific changeset in OSM to the task in MapRoulette
+    *
+    * @param task The task that was fixed
+    * @param user The user making the request
+    * @param c An implicit connection
+    */
+  def matchToOSMChangeSet(task:Task, user:User, immediate:Boolean=true)(implicit c:Option[Connection]=None) : Future[Boolean] = {
+    val result = Promise[Boolean]
+    if (config.allowMatchOSM) {
+      task.status match {
+        case Some(Task.STATUS_FIXED) =>
+          val currentDateTimeUTC = DateTime.now(DateTimeZone.UTC)
+          val statusAction = statusActions.getStatusActions(task, user, Some(List(Task.STATUS_FIXED))).headOption
+          statusAction match {
+            case Some(sa) =>
+              this.getSortedChangeList(sa) onComplete {
+                case Success(response) =>
+                  val responseList = response.map(_.id)
+                  response.find(c => {
+                    // check the bounding box of the changeset, and make sure that the task geometry
+                    // bounding box at the very least intersects with the changeset bounding box
+                    if (c.hasMapRouletteComment) {
+                      true
+                    } else {
+                      val feature = GeoJSONFactory.create(task.geometries).asInstanceOf[FeatureCollection]
+                      val reader = new GeoJSONReader()
+                      val envelope = new Envelope()
+                      feature.getFeatures.foreach(f => {
+                        val current = reader.read(f.getGeometry)
+                        envelope.expandToInclude(current.getBoundary.getEnvelopeInternal)
+                      })
+
+                      val changesetEnvelope = new Envelope(c.minLon, c.maxLon, c.minLat, c.maxLat)
+                      changesetEnvelope.intersects(envelope)
+                    }
+                  }) match {
+                    case Some(change) =>
+                      this.withMRConnection { implicit c =>
+                        Logger.debug(s"Updating task [${task.id}] with changeset [${change.id}]")
+                        SQL(s"""UPDATE tasks SET changeset_id = ${change.id} WHERE id = ${task.id}""").executeUpdate()
+                      }
+                      result success true
+                    case None =>
+                      this.withMRConnection { implicit c =>
+                        Logger.debug(s"No changeset found for user ${sa.osmUserId} on Task [${task.id}] from changesets [${responseList.mkString(",")}]")
+                        // if we can't find any viable option set the id to -2 so that we don't try again
+                        // but only set it to -2 if the current time is 1 hour after the set time for the task
+                        if (Math.abs(currentDateTimeUTC.getMillis - sa.created.getMillis) > (config.changeSetTimeLimit.toHours * 3600 * 1000)) {
+                          SQL(s"""UPDATE tasks SET changeset_id = -2 WHERE id = ${task.id}""").executeUpdate()
+                        }
+                      }
+                      result success false
+                  }
+                case Failure(error) => result success false
+              }
+            case None => result success false
+          }
+        case _ =>
+          // throw some message here about something
+          result success false
+      }
+    } else {
+      result success false
+    }
+    result.future
+  }
+
+  /**
+    * This gets the sorted list of changesets. The sorting is based on how close a changeset is to the time
+    * that the task was fixed. It probably would be more efficient to
+    *
+    * @param statusAction The StatusActionItem that is for the action that set the task to fixed
+    * @return A list of sorted changesets
+    */
+  private def getSortedChangeList(statusAction:StatusActionItem) : Future[Seq[Changeset]] = {
+    val result = Promise[Seq[Changeset]]
+    val format = "YYYY-MM-dd'T'HH:mm:ss'Z'"
+    val fixedTimeDiff = statusAction.created.getMillis
+    val prevHours = statusAction.created.minusHours(config.changeSetTimeLimit.toHours.toInt).toString(format)
+    val nextHours = statusAction.created.plusHours(config.changeSetTimeLimit.toHours.toInt).toString(format)
+    ws.url(s"${config.getOSMServer}/api/0.6/changesets?user=${statusAction.osmUserId}&time=$prevHours,$nextHours")
+      .withHeaders("User-Agent" -> "MapRoulette").get() onComplete {
+      case Success(response) =>
+        if (response.status == 200) {
+          val changeSetList = ChangesetParser.parse(XML.loadString(response.body)).filter(!_.open)
+          val sortedList = changeSetList.sortWith((c1, c2) => {
+            Math.abs(c1.createdAt.getMillis - fixedTimeDiff) < Math.abs(c2.createdAt.getMillis - fixedTimeDiff)
+          })
+          result success sortedList
+        } else {
+          result failure new InvalidException(s"Response failed with status ${response.status} messages ${response.statusText}")
+        }
+      case Failure(error) => result failure error
+    }
+    result.future
   }
 
   /**
@@ -525,6 +642,9 @@ class TaskDAL @Inject()(override val db: Database,
 
           parameters ++= addChallengeTagMatchingToQuery(params, whereClause, joinClause)
           parameters ++= addSearchToQuery(params, whereClause)
+
+          //add a where clause that just makes sure that any random challenge retrieved actually has some tasks in it
+          appendInWhereClause(whereClause, "1 = (SELECT 1 FROM tasks WHERE parent_id = c.id LIMIT 1)")
 
           val query = s"""
                         SELECT c.id FROM challenges c

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -804,8 +804,8 @@ class TaskDAL @Inject()(override val db: Database,
               ORDER BY RANDOM()
               LIMIT ${sqlLimit(limit)} OFFSET $offset
             """
-          val pointParser = long("t.id") ~ str("t.name") ~ int("t.parent_id") ~ str("c.name") ~
-                            str("t.instruction") ~ str("location") ~ int("t.status") ~ int("t.priority") map {
+          val pointParser = long("tasks.id") ~ str("tasks.name") ~ int("tasks.parent_id") ~ str("challenges.name") ~
+                            str("tasks.instruction") ~ str("location") ~ int("tasks.status") ~ int("tasks.priority") map {
             case id ~ name ~ parentId ~ parentName ~ instruction ~ location ~ status ~ priority =>
               val locationJSON = Json.parse(location)
               val coordinates = (locationJSON \ "coordinates").as[List[Double]]

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -42,10 +42,11 @@ class VirtualChallengeDAL @Inject() (override val db:Database,
       get[DateTime]("virtual_challenges.created") ~
       get[DateTime]("virtual_challenges.modified") ~
       get[Option[String]]("virtual_challenges.description") ~
+      get[Long]("virtual_challenges.owner_id") ~
       get[String]("virtual_challenges.search_parameters") ~
       get[DateTime]("virtual_challenges.expiry") map {
-      case id ~ name ~ created ~ modified ~ description ~ searchParameters ~ expiry =>
-        new VirtualChallenge(id, name, created, modified, description, Json.parse(searchParameters).as[SearchParameters], expiry)
+      case id ~ name ~ created ~ modified ~ description ~ ownerId ~ searchParameters ~ expiry =>
+        new VirtualChallenge(id, name, created, modified, description, ownerId, Json.parse(searchParameters).as[SearchParameters], expiry)
     }
   }
 
@@ -58,9 +59,11 @@ class VirtualChallengeDAL @Inject() (override val db:Database,
     * @return The object that was inserted into the database. This will include the newly created id
     */
   override def insert(element: VirtualChallenge, user: User)(implicit c: Option[Connection]=None): VirtualChallenge = {
-    permission.hasWriteAccess(VirtualChallengeType(), user)(-1)
     this.cacheManager.withOptionCaching { () =>
       withMRTransaction { implicit c =>
+        // check if any virtual challenges with the same name need to expire
+        // calling the retrieve function will also remove any expired virtual challenges
+        this.retrieveListByName(List(element.name))
         element.searchParameters.location match {
           case Some(box) if ((box.right - box.left) * (box.top - box.bottom)) < config.virtualChallengeLimit =>
               val query = """INSERT INTO virtual_challenges (owner_id, name, description, search_parameters, expiry)
@@ -351,6 +354,16 @@ class VirtualChallengeDAL @Inject() (override val db:Database,
     }
   }
 
+  /**
+    * For Virtual Challenges the retrieveByName function won't quite work as expected, there is a possibility
+    * that there are multiple Virtual Challenges with the same name. This function will simply return the
+    * first one. Generally retrieveListByName should be used instead.
+    *
+    * @param name The name you are looking up by
+    * @param parentId
+    * @param c
+    * @return The object that you are looking up, None if not found
+    */
   override def retrieveByName(implicit name: String, parentId: Long, c: Option[Connection]=None): Option[VirtualChallenge] = {
     super.retrieveByName match {
       case Some(vc) if vc.isExpired =>
@@ -361,22 +374,32 @@ class VirtualChallengeDAL @Inject() (override val db:Database,
   }
 
   override def retrieveListById(limit: Int, offset: Int)(implicit ids: List[Long], c: Option[Connection]=None): List[VirtualChallenge] =
-    super.retrieveListById(limit, offset).filter(!_.isExpired)
+    this.removeExpiredFromList(super.retrieveListById(limit, offset))
 
   override def retrieveListByName(implicit names: List[String], parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
-    super.retrieveListByName.filter(!_.isExpired)
+    this.removeExpiredFromList(super.retrieveListByName)
 
   override def retrieveListByPrefix(prefix: String, limit: Int, offset: Int, onlyEnabled: Boolean, orderColumn: String, orderDirection: String)
                                    (implicit parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
-    super.retrieveListByPrefix(prefix, limit, offset, onlyEnabled, orderColumn, orderDirection).filter(!_.isExpired)
+    this.removeExpiredFromList(super.retrieveListByPrefix(prefix, limit, offset, onlyEnabled, orderColumn, orderDirection))
 
   override def find(searchString: String, limit: Int, offset: Int, onlyEnabled: Boolean, orderColumn: String, orderDirection: String)
                    (implicit parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
-    super.find(searchString, limit, offset, onlyEnabled, orderColumn, orderDirection).filter(!_.isExpired)
+    this.removeExpiredFromList(super.find(searchString, limit, offset, onlyEnabled, orderColumn, orderDirection))
 
   override def list(limit: Int, offset: Int, onlyEnabled: Boolean, searchString: String, orderColumn: String, orderDirection: String)
                    (implicit parentId: Long, c: Option[Connection]=None): List[VirtualChallenge] =
-    super.list(limit, offset, onlyEnabled, searchString, orderColumn, orderDirection).filter(!_.isExpired)
+    this.removeExpiredFromList(super.list(limit, offset, onlyEnabled, searchString, orderColumn, orderDirection))
 
+  private def removeExpiredFromList(superList:List[VirtualChallenge]) : List[VirtualChallenge] = {
+    superList.flatMap(vc => {
+      if (vc.isExpired) {
+        this.delete(vc.id, User.superUser)
+        None
+      } else {
+        Some(vc)
+      }
+    })
+  }
   // --- END OF OVERRIDDEN FUNCTIONS TO FILTER OUT ANY EXPIRED VIRTUAL CHALLENGES
 }

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -30,6 +30,7 @@ trait ChallengeWrites {
     (JsPath \ "created").write[DateTime] and
     (JsPath \ "modified").write[DateTime] and
     (JsPath \ "description").writeNullable[String] and
+    (JsPath \ "infoLink").writeNullable[String] and
     JsPath.write[ChallengeGeneral] and
     JsPath.write[ChallengeCreation] and
     JsPath.write[ChallengePriority] and
@@ -52,6 +53,7 @@ trait ChallengeReads extends DefaultReads {
     ((JsPath \ "created").read[DateTime] or Reads.pure(DateTime.now())) and
     ((JsPath \ "modified").read[DateTime] or Reads.pure(DateTime.now())) and
     (JsPath \ "description").readNullable[String] and
+    (JsPath \ "infoLink").readNullable[String] and
     JsPath.read[ChallengeGeneral] and
     JsPath.read[ChallengeCreation] and
     JsPath.read[ChallengePriority] and

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -30,6 +30,7 @@ trait ChallengeWrites {
     (JsPath \ "created").write[DateTime] and
     (JsPath \ "modified").write[DateTime] and
     (JsPath \ "description").writeNullable[String] and
+    (JsPath \ "deleted").write[Boolean] and
     (JsPath \ "infoLink").writeNullable[String] and
     JsPath.write[ChallengeGeneral] and
     JsPath.write[ChallengeCreation] and
@@ -53,6 +54,7 @@ trait ChallengeReads extends DefaultReads {
     ((JsPath \ "created").read[DateTime] or Reads.pure(DateTime.now())) and
     ((JsPath \ "modified").read[DateTime] or Reads.pure(DateTime.now())) and
     (JsPath \ "description").readNullable[String] and
+    (JsPath \ "deleted").read[Boolean] and
     (JsPath \ "infoLink").readNullable[String] and
     JsPath.read[ChallengeGeneral] and
     JsPath.read[ChallengeCreation] and

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -214,8 +214,8 @@ trait DALHelper {
     val parameters = new ListBuffer[NamedParameter]()
 
     if (!projectSearch) {
-      params.projectId match {
-        case Some(pid) if pid > -1 => whereClause ++= s"$challengePrefix.parent_id = $pid"
+      params.getProjectIds match {
+        case Some(p) if p.nonEmpty => whereClause ++= s"$challengePrefix.parent_id IN (${p.mkString(",")})"
         case _ =>
           params.projectSearch match {
             case Some(ps) if ps.nonEmpty =>
@@ -233,8 +233,8 @@ trait DALHelper {
       }
     }
 
-    params.challengeId match {
-      case Some(cid) if cid > -1 => this.appendInWhereClause(whereClause, s"$challengePrefix.id = $cid")
+    params.getChallengeIds match {
+      case Some(c) if c.nonEmpty => this.appendInWhereClause(whereClause, s"$challengePrefix.id IN (${c.mkString(",")})")
       case _ =>
         params.challengeSearch match {
           case Some(cs) if cs.nonEmpty =>

--- a/app/org/maproulette/permissions/Permission.scala
+++ b/app/org/maproulette/permissions/Permission.scala
@@ -78,12 +78,18 @@ class Permission @Inject() (dalManager: Provider[DALManager]) {
           if (obj.asInstanceOf[Challenge].general.owner != user.osmProfile.id) {
             hasProjectAccess(dalManager.get().challenge.retrieveRootObject(Right(obj.asInstanceOf[Challenge]), user), user)
           }
+        case VirtualChallengeType() =>
+          if (obj.asInstanceOf[VirtualChallenge].ownerId != user.osmProfile.id) {
+            throw new IllegalAccessException(s"Only super users or the owner of the Virtual Challenge can write to it.")
+          }
         case TaskType() =>
           hasProjectAccess(dalManager.get().task.retrieveRootObject(Right(obj.asInstanceOf[Task]), user), user)
         case TagType() =>
         case GroupType() =>
           // Currently only super users have access to group objects
           throw new IllegalAccessException(s"Only super users have access to group objects")
+        case _ =>
+          throw new IllegalAccessException(s"Unknown object type ${obj.itemType.toString}")
       }
     }
   }
@@ -117,6 +123,7 @@ class Permission @Inject() (dalManager: Provider[DALManager]) {
     }
   }
 
+  // TODO this function needs to take into account user groups
   private def hasProjectAccess(project:Option[Project], user:User) : Unit = {
     if (!user.isSuperUser) {
       project match {

--- a/app/org/maproulette/services/ChallengeService.scala
+++ b/app/org/maproulette/services/ChallengeService.scala
@@ -221,11 +221,15 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
   private def getProperties(value:JsValue, key:String) : JsValue = {
     (value \ key).asOpt[JsObject] match {
       case Some(JsObject(p)) =>
-        val updatedMap = p.map {
+        val idMap = (value \ "id").toOption match {
+          case Some(idValue) => p + ("osmid" -> idValue)
+          case None => p
+        }
+        val updatedMap = idMap.map {
           kv =>
             try {
               val strValue = kv._2 match {
-                case v: JsNumber => v.toString()
+                case v: JsNumber => v.toString
                 case v: JsArray => v.as[Seq[String]].mkString(",")
                 case v => v.as[String]
               }
@@ -234,7 +238,7 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
               // if we can't convert it into a string, then just use the toString method and hope we get something sensible
               // other option could be just to ignore it.
               case e:Throwable =>
-                kv._1 -> kv._2.toString()
+                kv._1 -> kv._2.toString
             }
         }.toMap
         Json.toJson(updatedMap)

--- a/app/org/maproulette/services/ChallengeService.scala
+++ b/app/org/maproulette/services/ChallengeService.scala
@@ -223,12 +223,19 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
       case Some(JsObject(p)) =>
         val updatedMap = p.map {
           kv =>
-            val strValue = kv._2 match {
-              case v:JsNumber => v.toString()
-              case v:JsArray => v.as[Seq[String]].mkString(",")
-              case v => v.as[String]
+            try {
+              val strValue = kv._2 match {
+                case v: JsNumber => v.toString()
+                case v: JsArray => v.as[Seq[String]].mkString(",")
+                case v => v.as[String]
+              }
+              kv._1 -> strValue
+            } catch {
+              // if we can't convert it into a string, then just use the toString method and hope we get something sensible
+              // other option could be just to ignore it.
+              case e:Throwable =>
+                kv._1 -> kv._2.toString()
             }
-            kv._1 -> strValue
         }.toMap
         Json.toJson(updatedMap)
       case _ => Json.obj()

--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -319,12 +319,30 @@ class SessionManager @Inject() (ws:WSClient, dalManager: DALManager, config:Conf
     *
     * @param block The block of code to execute after a valid session has been found
     * @param request The incoming http request
+    * @param requireSuperUser Whether a super user is required for this request
     * @return The result from the block of code
     */
   def authenticatedRequest(block:User => Result)
                           (implicit request:Request[Any], requireSuperUser:Boolean=false) : Future[Result] = {
     MPExceptionUtil.internalAsyncExceptionCatcher { () =>
       this.authenticated(Left(block))
+    }
+  }
+
+  /**
+   * For an authenticated request we expect there to currently be a valid session. If no session is
+   * available an OAuthNotAuthorizedException will be thrown. This function differs from the
+   * authenticatedRequest as it allows the lambda function to return a future
+   *
+   * @param block The block of code to execute after a valid session has been found
+   * @param request The incoming http request
+   * @param requireSuperUser Whether a super user is required for this request
+   * @return The result from the block of code
+   */
+  def authenticatedFutureRequest(block:User => Future[Result])
+                                (implicit request:Request[Any], requireSuperUser:Boolean=false) : Future[Result] = {
+    MPExceptionUtil.internalAsyncExceptionCatcher{ () =>
+      this.authenticated(Right(block))
     }
   }
 

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -381,7 +381,7 @@ class UserDAL @Inject() (override val db:Database,
     * @param id The user to delete
     * @return The rows that were deleted
     */
-  override def delete(id: Long, user:User)(implicit c:Option[Connection]=None) : User = {
+  override def delete(id: Long, user:User, immediate:Boolean=false)(implicit c:Option[Connection]=None) : User = {
     this.permission.hasSuperAccess(user)
     retrieveById(id) match {
       case Some(u) => userGroupDAL.clearUserCache(u.osmProfile.id)

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ libraryDependencies ++= Seq(
   "net.postgis" % "postgis-jdbc" % "2.2.0",
   "joda-time" % "joda-time" % "2.9.2",
   "com.vividsolutions" % "jts" % "1.13",
+  "org.wololo" % "jts2geojson" % "0.10.0",
   "org.julienrf" %% "play-jsmessages" % "2.0.0",
   "org.webjars" %% "webjars-play" % "2.5.0-4",
   "org.webjars" % "bootstrap" % "3.3.6",

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1238,6 +1238,78 @@ GET     /challenge/:id/comments                     @org.maproulette.controllers
 ###
 GET     /challenge/:id/comments/extract             @org.maproulette.controllers.api.ChallengeController.extractComments(id:Long, limit:Int ?= -1, page:Int ?= 0)
 ###
+# tags: [ Challenge ]
+# summary: Match OSM Changesets
+# description: This will go through every task and try to match an OSM changeset with the task
+# response:
+#   '200':
+#     description: Will always return Ok unless not authenticated
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Challenge with provided ID found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the challenge
+#     required: true
+#   - name: skipSet
+#     in: query
+#     description: Will skip any tasks if the changesets are already set if this is set to true
+#     default: false
+###
+GET     /challenge/:id/matchChangesets          @org.maproulette.controllers.api.ChallengeController.matchChangeSets(id:Long, skipSet:Boolean ?= false)
+###
+# tags: [ Challenge ]
+# summary: Create Challenge from Github
+# description: This will pull the following files from Github, ${name}_create.json, ${name}_geojson.json, ${name}_info.md, and create a Challenge from it. The create file will be the json used to create the challenge. Similarly to if you supplied json in the create method. The info.md file is just an informational file that can be used later for challenge information to the user. And geojson.json which is used to generate the tasks. If the challenge has been previously created, it will just update the tasks from the geojson
+# response:
+#   '200':
+#     description: The retrieved Challenge
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Challenge'
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Project with provided ID found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the parent project
+#     required: true
+#   - name: username
+#     in: path
+#     description: username of the github user that owns the repo
+#     required: true
+#   - name: repo
+#     in: path
+#     description: Github repositories that contains the challenge files
+#     required: true
+#   - name: name
+#     in: path
+#     description: The name of the challenge that prefixes all the github files
+#     required: true
+###
+POST     /project/:projectId/challenge/:username/:repo/:name   @org.maproulette.controllers.api.ChallengeController.createFromGithub(projectId:Long, username:String, repo:String, name:String, rebuild:Boolean ?= false)
+###
+# tags: [ Challenge ]
+# summary: Extracts a Challenge Package
+# description: This will retrieve a package of the challenge, which will contain json to recreate the challenge, geojson to recreate the tasks, info page in md format if any, all the comments extracted from for the challenge and any metrics and the time the challenge was extracted.
+# response:
+#   '200':
+#     description: A gzipped file containing a package of the challenge
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No project with provided ID found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the challenge
+#     required: true
+###
+GET     /challenge/:id/extract                      @org.maproulette.controllers.api.ChallengeController.extractPackage(id:Long)
+###
 # tags: [ Virtual Challenge ]
 # summary: Create a Virtual Challenge
 # consumes: [ application/json ]
@@ -2068,6 +2140,31 @@ GET     /tasks/random                               @org.maproulette.controllers
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
 GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0)
+###
+# tags: [ Task ]
+# summary: Update Task Changeset
+# produces: [ application/json ]
+# description: Will update the changeset of the task. It will do this by attempting to match the OSM changeset to the Task based on the geometry and the time that the changeset was executed.
+# responses:
+#   '200':
+#     description: The task that was updated. With the updated changeset value
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: The task with the supplied ID was not found.
+# parameters:
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: id
+#     in: path
+#     description: The ID of the task
+###
+PUT     /task/:id/changeset                         @org.maproulette.controllers.api.TaskController.matchToOSMChangeSet(id:Long)
 ###
 # tags: [ Task ]
 # summary: Update Task Status

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -198,13 +198,42 @@ GET     /projectByName/:name                        @org.maproulette.controllers
 #   - name: id
 #     in: path
 #     description: The id of the project being deleted
+#   - name: immediate
+#     in: query
+#     description: If set to true, will delete the virtual challenge immediately instead of delayed
+#     default: false
+#     type: boolean
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
 #     required: true
 #     type: string
 ###
-DELETE  /project/:id                                @org.maproulette.controllers.api.ProjectController.delete(id:Long)
+DELETE  /project/:id                                @org.maproulette.controllers.api.ProjectController.delete(id:Long, immediate:Boolean = false)
+###
+# tags: [ Project ]
+# summary: Undeletes a Project
+# description: If a Project has been setup for deletion and not removed from the database we can undelete it and make it so that it does not get deleted anymore. During the undelete of this project, and challenges that were scheduled for deletion will also be undeleted
+# responses:
+#   '200':
+#     description: The Project that was undeleted.
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Project'
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Project found matching the provided id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Project being deleted
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+PUT  /project/:id/undelete                         @org.maproulette.controllers.api.ProjectController.undelete(id:Long)
 ###
 # tags: [ Project ]
 # summary: Find project matching search criteria
@@ -678,13 +707,42 @@ GET     /project/:id/challenge/:name                @org.maproulette.controllers
 #   - name: id
 #     in: path
 #     description: The id of the Challenge being deleted
+#   - name: immediate
+#     in: query
+#     description: If set to true, will delete the virtual challenge immediately instead of delayed
+#     default: false
+#     type: boolean
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
 #     required: true
 #     type: string
 ###
-DELETE  /challenge/:id                              @org.maproulette.controllers.api.ChallengeController.delete(id:Long)
+DELETE  /challenge/:id                              @org.maproulette.controllers.api.ChallengeController.delete(id:Long, immediate:Boolean ?= false)
+###
+# tags: [ Challenge ]
+# summary: Undeletes a Challenge
+# description: If a Challenge has been setup for deletion and not removed from the database we can undelete it and make it so that it does not get deleted anymore.
+# responses:
+#   '200':
+#     description: The Challenge that was undeleted.
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Challenge'
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Challenge found matching the provided id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Project being deleted
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+PUT  /challenge/:id/undelete                         @org.maproulette.controllers.api.ChallengeController.undelete(id:Long)
 ###
 # tags: [ Challenge ]
 # summary: Deletes all Challenge Tasks
@@ -1004,6 +1062,57 @@ PUT     /challenge/:id/tasks                        @org.maproulette.controllers
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
 GET     /challenge/:id/children                     @org.maproulette.controllers.api.ChallengeController.expandedList(id:Long, limit:Int ?= 10, page:Int ?= 0)
+###
+# tags: [ Challenge ]
+# summary: Clones a Challenge
+# produces: [ application/json ]
+# description: Clones a challenge
+# responses:
+#   '200':
+#     description: The newly created cloned challenge
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Challenge'
+#   '401':
+#     description: The user is not authorized to make this request\
+#   '404':
+#     description: No Challenge found matching the provided id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Challenge to clone.
+#   - name: name
+#     in: path
+#     description: The name of the new challenge
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+PUT     /challenge/:id/clone/:name                  @org.maproulette.controllers.api.ChallengeController.cloneChallenge(id:Long, name:String)
+###
+# tags: [ Challenge ]
+# summary: Rebuild a Challenge
+# produces: [ application/json ]
+# description: Rebuilds a challenge that was originally built by an overpass query or remote geojson.
+# responses:
+#   '200':
+#     description: Empty OK status
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: No Challenge found matching the provided id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Challenge to rebuild.
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+PUT     /challenge/:id/rebuild                      @org.maproulette.controllers.api.ChallengeController.rebuildChallenge(id:Long)
 ###
 # tags: [ Challenge ]
 # summary: Retrieves random Task
@@ -1431,13 +1540,18 @@ GET     /virtualchallengebyname/:name                   @org.maproulette.control
 #   - name: id
 #     in: path
 #     description: The id of the Virtual Challenge being deleted
+#   - name: immediate
+#     in: query
+#     description: If set to true, will delete the virtual challenge immediately instead of delayed
+#     default: false
+#     type: boolean
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
 #     required: true
 #     type: string
 ###
-DELETE  /virtualchallenge/:id                           @org.maproulette.controllers.api.VirtualChallengeController.delete(id:Long)
+DELETE  /virtualchallenge/:id                           @org.maproulette.controllers.api.VirtualChallengeController.delete(id:Long, immediate:Boolean ?= true)
 ###
 # tags: [ Virtual Challenge ]
 # summary: List all the Virtual Challenge.
@@ -1975,7 +2089,7 @@ GET     /challenge/:id/task/:name                   @org.maproulette.controllers
 #     required: true
 #     type: string
 ###
-DELETE  /task/:id                                   @org.maproulette.controllers.api.TaskController.delete(id:Long)
+DELETE  /task/:id                                   @org.maproulette.controllers.api.TaskController.delete(id:Long, immediate:Boolean ?= true)
 ###
 # tags: [ Task ]
 # summary: Find Task matching search criteria
@@ -2485,11 +2599,11 @@ GET     /tag/:id                                    @org.maproulette.controllers
 #     required: true
 #     type: string
 ###
-DELETE  /keyword/:id                                @org.maproulette.controllers.api.TagController.delete(id:Long)
+DELETE  /keyword/:id                                @org.maproulette.controllers.api.TagController.delete(id:Long, immediate:Boolean ?= true)
 ###
 # tags: [ Tag (Deprecated) ]
 ###
-DELETE  /tag/:id                                    @org.maproulette.controllers.api.TagController.delete(id:Long)
+DELETE  /tag/:id                                    @org.maproulette.controllers.api.TagController.delete(id:Long, immediate:Boolean ?= true)
 ###
 # tags: [ Keyword ]
 # summary: Finds Keywords
@@ -2768,6 +2882,19 @@ DELETE   /user/:userId/unsaveTask/:taskId           @org.maproulette.controllers
 #       $ref: '#/definitions/org.maproulette.session.UserSettings'
 ###
 PUT    /user/:userId                                @org.maproulette.controllers.api.UserController.updateUser(userId:Long)
+###
+# tags: [ User ]
+# summary: Refresh User Profile
+# description: Refreshes the user profile from OSM
+# responses:
+#   '200':
+#     description: Ok with no content
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The osm id of the user to update the settings for
+###
+PUT    /user/:userId/refresh                        @org.maproulette.controllers.api.UserController.refreshProfile(userId:Long)
 ### NoDocs ###
 POST    /*path                                      @org.maproulette.controllers.api.APIController.invalidAPIPath(path)
 ### NoDocs ###

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -209,7 +209,7 @@ GET     /projectByName/:name                        @org.maproulette.controllers
 #     required: true
 #     type: string
 ###
-DELETE  /project/:id                                @org.maproulette.controllers.api.ProjectController.delete(id:Long, immediate:Boolean = false)
+DELETE  /project/:id                                @org.maproulette.controllers.api.ProjectController.delete(id:Long, immediate:Boolean ?= false)
 ###
 # tags: [ Project ]
 # summary: Undeletes a Project

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -121,6 +121,7 @@ maproulette {
       enabled = false
       manual = false
     }
+    cleanDeleted.interval = "24 hours"
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,6 +49,26 @@ play {
     autoApplyDowns = false
   }
   server.netty.transport = "native"
+  # This is the max memory for post body data
+  http.parser.maxDiskBuffer=15000K
+  http.parser.maxMemoryBuffer=15000K
+  MultipartFormData.maxLength=15000K
+  http.filters="org.maproulette.filters.Filters"
+  modules.enabled += "org.maproulette.jobs.JobModule"
+  filters.cors {
+    // CORS filters options - see https://www.playframework.com/documentation/2.5.x/CorsFilter
+    pathPrefixes=["/"]
+    allowedOrigins=null
+    allowedHttpMethods=null
+    allowedHttpHeaders=null
+  }
+  ws {
+    useragent="MapRoulette"
+    ssl {
+      default = true
+      loose.acceptAnyCertificate=true
+    }
+  }
 }
 
 # MapRoulette Settings
@@ -58,7 +78,13 @@ maproulette {
   #session timeout in milliseconds, default -1 which ignores session timeouts
   session.timeout=-1
   # number of days till we reset the status if it has not been fixed
-  task.reset=14
+  task {
+    reset = 14
+    changesets {
+      timeLimit="1 hour"
+      enabled=false
+    }
+  }
   #logo="/assets/images/companylogo.png"
   signin=false
   debug=false
@@ -81,13 +107,19 @@ maproulette {
     accounts=${?MR_SUPER_ACCOUNTS}
   }
   scheduler {
-    cleanLocks.interval="1 hour"
-    runChallengeSchedules.interval="24 hours"
-    updateLocations.interval="12 hours"
+    cleanLocks.interval = "1 hour"
+    runChallengeSchedules.interval = "24 hours"
+    updateLocations.interval = "12 hours"
     cleanOldTasks {
-      interval="24 hours"
-      olderThan="31 days"
-      statusFilter=[0, 3]
+      interval = "24 hours"
+      olderThan = "31 days"
+      statusFilter = [0, 3]
+    }
+    osmMatcher {
+      interval = "24 hours"
+      batchSize = 5000
+      enabled = false
+      manual = false
     }
   }
 }
@@ -136,23 +168,6 @@ mr3 {
 
 # Logger provided to your application:
 #logger.application=DEBUG
-
-# This is the max memory for post body data
-play.http.parser.maxDiskBuffer=15000K
-play.http.parser.maxMemoryBuffer=15000K
-parsers.MultipartFormData.maxLength=15000K
-
-play.http.filters="org.maproulette.filters.Filters"
-
-play.modules.enabled += "org.maproulette.jobs.JobModule"
-
-play.filters.cors {
-  // CORS filters options - see https://www.playframework.com/documentation/2.5.x/CorsFilter
-  pathPrefixes=["/"]
-  allowedOrigins=null
-  allowedHttpMethods=null
-  allowedHttpHeaders=null
-}
 
 api.version="2.0"
 

--- a/conf/dev.conf
+++ b/conf/dev.conf
@@ -2,17 +2,24 @@ include "application.conf"
 
 db.default.pool="bonecp"
 db.default.bonecp.logStatements=true
-db.default.url="jdbc:postgresql://localhost:5432/LatestMR2?user=osm&password=osm"
+db.default.url="jdbc:postgresql://localhost:5432/02_16_2018_prod?user=osm&password=osm"
 db.default.bonecp.maxConnectionsPerPartition=200
 db.default.bonecp.minConnectionsPerPartition=10
 db.default.hikaricp.maximumPoolSize=200
 maproulette.super.key="test"
 maproulette.super.accounts="*"
-#osm.server="http://api06.dev.openstreetmap.org"
+maproulette.signin=false
+maproulette.debug=false
+maproulette.devMode=false
+maproulette.mapillary.clientId="cDhIWU5jZDRNLXd2TkpZUTR5YTU3ZzpkOWY3OTc5NzhiZjUyYWUx"
+#osm.server="https://master.apis.dev.openstreetmap.org"
 osm.consumerKey="BxoUBat6hXflbzUWGVX3FGyGnTqduSv4a8Z7WOhx"
+#osm.consumerKey="MXIPr1I15FJxuwAeGbWitbNvqDBC1rtu7jNLkCSr"
 osm.consumerSecret="BRTrSbdy96enzaMr9JteXcvUZQi49Q2Aaf3n6Hse"
+#osm.consumerSecret="SOCV7iqJqGH0KJRoJly5WzLGgFlsIlh6mX3vz1g8"
 play.http.parser.maxDiskBuffer=100M
 play.http.parser.maxMemoryBuffer=100M
 parsers.MultipartFormData.maxLength=100M
 #mr3.host="http://localhost:3000"
-mr3.staticPath="/maproulette-frontend/build"
+mr3.staticPath="/Users/cuthbertm/opensrc/maproulette3/build/"
+mr3.devMode=true

--- a/conf/evolutions/default/13.sql
+++ b/conf/evolutions/default/13.sql
@@ -3,5 +3,65 @@
 # --- !Ups
 SELECT add_drop_column('users', 'properties', 'character varying');;
 SELECT create_index_if_not_exists('status_actions', 'osm_user_id_created', '(osm_user_id,created)');;
+-- Add changeset_id column
+SELECT add_drop_column('tasks', 'changeset_id', 'integer DEFAULT -1');;
+SELECT add_drop_column('challenges', 'info_link', 'character varying');;
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change simply adds the priority
+CREATE OR REPLACE FUNCTION create_update_task(task_name text,
+                                              task_parent_id bigint,
+                                              task_instruction text,
+                                              task_status integer,
+                                              task_id bigint DEFAULT -1,
+                                              task_priority integer DEFAULT 0,
+                                              task_changeset_id bigint DEFAULT -1,
+                                              reset_interval text DEFAULT '7 days') RETURNS integer as $$
+DECLARE
+  return_id integer;;
+BEGIN
+  return_id := task_id;;
+  IF (SELECT task_id) = -1 THEN
+    BEGIN
+      INSERT INTO tasks (name, parent_id, instruction,  priority) VALUES (task_name, task_parent_id, task_instruction, task_priority) RETURNING id INTO return_id;;
+      EXCEPTION WHEN UNIQUE_VIOLATION THEN
+      SELECT INTO return_id update_task(task_name, task_parent_id, task_instruction, task_status, task_id, task_priority, task_changeset_id, reset_interval);;
+    END;;
+  ELSE
+    PERFORM update_task(task_name, task_parent_id, task_instruction, task_status, task_id, task_priority, task_changeset_id, reset_interval);;
+  END IF;;
+  RETURN return_id;;
+END
+$$
+LANGUAGE plpgsql VOLATILE;;
+
+CREATE OR REPLACE FUNCTION update_task(task_name text,
+                                       task_parent_id bigint,
+                                       task_instruction text,
+                                       task_status integer,
+                                       task_id bigint DEFAULT -1,
+                                       task_priority integer DEFAULT 0,
+                                       task_changeset_id bigint DEFAULT -1,
+                                       reset_interval text DEFAULT '7 days') RETURNS integer as $$
+DECLARE
+  update_id integer;;
+  update_modified timestamp without time zone;;
+  update_status integer;;
+  new_status integer;;
+BEGIN
+  IF (SELECT task_id) = -1 THEN
+    SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+  ELSE
+    SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+  END IF;;
+  new_status := task_status;;
+  IF update_status = task_status AND (SELECT AGE(NOW(), update_modified)) > reset_interval::INTERVAL THEN
+    new_status := 0;;
+  END IF;;
+  UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status, priority = task_priority, changeset_id = task_changeset_id WHERE id = update_id;;
+  RETURN update_id;;
+END
+$$
+LANGUAGE plpgsql VOLATILE;;
 
 # --- !Downs

--- a/conf/evolutions/default/13.sql
+++ b/conf/evolutions/default/13.sql
@@ -85,4 +85,9 @@ END
 $$
 LANGUAGE plpgsql VOLATILE;;
 
+-- Add constraint that doesn't allow the same user to create a virtual challenge with the same name
+ALTER TABLE virtual_challenges DROP CONSTRAINT IF EXISTS CON_VIRTUAL_CHALLENGES_USER_ID_NAME;;
+ALTER TABLE virtual_challenges ADD CONSTRAINT CON_VIRTUAL_CHALLENGES_USER_ID_NAME
+  UNIQUE (owner_id, name);;
+
 # --- !Downs

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -162,6 +162,114 @@
 					"response": []
 				},
 				{
+					"name": "Challenge Retrieved Deleted",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a2946065-6872-4c57-a68c-d9db2083e7cc",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"status\"] = jsonData.status === \"OK\";",
+									"tests[\"name\"] = jsonData.name === \"SimpleChallenge\";",
+									"tests[\"deleted\"] = jsonData.deleted === true;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{SimpleChallengeID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{SimpleChallengeID}}"
+							]
+						},
+						"description": "Deletes the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Immediate Deletion",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"status\"] = jsonData.status === \"OK\";"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{SimpleChallengeID}}?immediate=true",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{SimpleChallengeID}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true",
+									"equals": true
+								}
+							]
+						},
+						"description": "Deletes the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
 					"name": "Challenge Tag Creation",
 					"event": [
 						{
@@ -763,7 +871,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}?immediate=true",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -774,6 +882,13 @@
 								"v2",
 								"challenge",
 								"{{TagsChallengeID}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true",
+									"equals": true
+								}
 							]
 						},
 						"description": "Deletes the Tag challenge for the provided ID"
@@ -812,7 +927,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}?immediate=true",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -823,6 +938,13 @@
 								"v2",
 								"project",
 								"{{SimpleProjectID}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true",
+									"equals": true
+								}
 							]
 						},
 						"description": "Deletes the project that was used for the challenge tests."
@@ -2487,7 +2609,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}?immediate=true",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -2498,6 +2620,13 @@
 								"v2",
 								"project",
 								"{{SimpleProjectID}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true",
+									"equals": true
+								}
 							]
 						},
 						"description": "Deletes the project created by the project creation. Would need to modify the supplied ID."
@@ -3418,18 +3547,21 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "cbcada60-281a-4af6-a5ce-fab6e9cff186",
+								"id": "2740d979-7705-40db-a5af-a07618e427c0",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
-									"tests[\"id\"] = jsonData.id === -999;"
+									"tests[\"id\"] = jsonData.id === -999;",
+									"tests[\"test1\"] = jsonData.properties.test1 === \"value1\";",
+									"tests[\"test2\"] = jsonData.properties.test2 === 8975;",
+									"tests[\"test3\"] = jsonData.properties.test3 === true;"
 								]
 							}
 						}
 					],
 					"request": {
-						"method": "GET",
+						"method": "PUT",
 						"header": [
 							{
 								"key": "apiKey",
@@ -3442,7 +3574,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": ""
+							"raw": "{\n\t\"properties\": {\n\t\t\"test1\":\"value1\",\n\t\t\"test2\":8975,\n\t\t\"test3\":true\n\t}\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/user/-999",

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -167,12 +167,11 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a2946065-6872-4c57-a68c-d9db2083e7cc",
+								"id": "d62e91a2-16b7-4de4-958b-0b9d45522434",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
-									"tests[\"status\"] = jsonData.status === \"OK\";",
 									"tests[\"name\"] = jsonData.name === \"SimpleChallenge\";",
 									"tests[\"deleted\"] = jsonData.deleted === true;"
 								]
@@ -421,6 +420,63 @@
 								"challenge",
 								"{{TagsChallengeID}}",
 								"tasks"
+							]
+						},
+						"description": "Gets the tasks of the challenge for the provided ID"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Random Tasks",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b4c85630-833a-4df4-b2d8-ad83f3ecb26e",
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"if (jsonData[0].name == \"Task 1\") {",
+									"    var id = pm.globals.get(\"TagsChallengeTask1ID\");    ",
+									"} else {",
+									"    var id = pm.globals.get(\"TagsChallengeTask2ID\");",
+									"}",
+									"tests[\"IDValidation\"] = jsonData[0].id == id;"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks/random",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge",
+								"{{TagsChallengeID}}",
+								"tasks",
+								"random"
 							]
 						},
 						"description": "Gets the tasks of the challenge for the provided ID"
@@ -963,10 +1019,11 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "061180ba-93d9-4165-8ea2-d5b5ce27f475",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setGlobalVariable(\"SimpleProjectID\", jsonData.id);",
+									"pm.globals.set(\"SimpleProjectID\", jsonData.id);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
@@ -1013,10 +1070,11 @@
 						{
 							"listen": "test",
 							"script": {
+								"id": "31fa6818-074e-4220-b1fa-819310da0d7d",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setGlobalVariable(\"TagsChallengeID\", jsonData.id);",
+									"pm.globals.set(\"TagsChallengeID\", jsonData.id);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"TagsChallenge\";",
 									"tests[\"description\"] = jsonData.description === \"A simple challenge containing only the basic elements for a challenge and two tags\";",
@@ -1168,11 +1226,11 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "52a22ad3-9739-4e09-9221-e5fea5718560",
+								"id": "debcb03c-61d4-41ac-b44c-c4c004a4ef17",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setGlobalVariable(\"VirtualChallengeID\", jsonData.id);",
+									"pm.globals.set(\"VirtualChallengeID\", jsonData.id);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"test\";"
 								]
@@ -1193,7 +1251,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"challengeId\": {{TagsChallengeID}},\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t}\n}"
+							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"challengeIds\": [ {{TagsChallengeID}} ],\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t}\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge",
@@ -1396,14 +1454,14 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "34912ad6-d31c-4bf9-8830-85ec811bf09b",
+								"id": "905e5406-7776-4bcf-a8cb-27617a05c142",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"size\"] = jsonData.length === 2;",
-									"postman.setGlobalVariable(\"VChallengeTask1ID\", jsonData[0].id);",
-									"postman.setGlobalVariable(\"VChallengeTask2ID\", jsonData[1].id);"
+									"pm.globals.set(\"VChallengeTask1ID\", jsonData[0].id);",
+									"pm.globals.set(\"VChallengeTask2ID\", jsonData[1].id);"
 								]
 							}
 						}
@@ -1485,14 +1543,12 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ddbeaf5d-4f6b-49f7-aa23-1a1523ad2ecd",
+								"id": "ba4b7365-f1e5-4e96-805c-469fc29537eb",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
-									"tests[\"id\"] = jsonData.id === pm.variables.get(\"VChallengeTask2ID\");",
-									"",
-									""
+									"tests[\"id\"] = jsonData.id == pm.globals.get(\"VChallengeTask2ID\");"
 								]
 							}
 						}
@@ -1539,12 +1595,12 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b604695f-ce62-444d-92fd-a14a4c068997",
+								"id": "8741daf9-46d3-4e42-aa20-f29ed39caa34",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
-									"tests[\"id\"] = jsonData.id === pm.variables.get(\"VChallengeTask1ID\");"
+									"tests[\"id\"] = jsonData.id == pm.globals.get(\"VChallengeTask1ID\");"
 								]
 							}
 						}
@@ -1720,11 +1776,11 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "52a22ad3-9739-4e09-9221-e5fea5718560",
+								"id": "66484512-de78-42a6-9a03-ab5d7049c9d7",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
-									"postman.setGlobalVariable(\"VirtualChallengeID\", jsonData.id);",
+									"pm.globals.set(\"VirtualChallengeID\", jsonData.id);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"test\";"
 								]
@@ -1745,7 +1801,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t},\n\t\"expiry\":\"1 s\"\n}"
+							"raw": "{\n\t\"name\":\"test\",\n\t\"searchParameters\":{\n\t\t\"challengeIds\": [ {{TagsChallengeID}} ],\n\t\t\"location\": {\n\t\t\t\"left\":102,\n\t\t\t\"bottom\":0,\n\t\t\t\"right\":104,\n\t\t\t\"top\":2\n\t\t}\n\t},\n\t\"expiry\":\"1 s\"\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge",
@@ -1770,12 +1826,10 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5e033501-5ba7-41b4-be01-a381af19764a",
+								"id": "9e2d657d-efa4-4dfc-800b-d094be10e9d6",
 								"type": "text/javascript",
 								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"tests[\"response code is 200\"] = responseCode.code === 200;",
-									"tests[\"name\"] = jsonData.name === \"test\";"
+									"tests[\"response code is 404\"] = responseCode.code === 404;"
 								]
 							}
 						}
@@ -1801,49 +1855,6 @@
 								"v2",
 								"virtualchallenge",
 								"11"
-							]
-						},
-						"description": ""
-					},
-					"response": []
-				},
-				{
-					"name": "Virtual Challenge Expiry Delete",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "b40a12db-871d-437b-abc6-25d2b5b32ca7",
-								"type": "text/javascript",
-								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"tests[\"response code is 200\"] = responseCode.code === 200;",
-									"tests[\"status\"] = jsonData.status === \"OK\";"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "apiKey",
-								"value": "test"
-							}
-						],
-						"body": {},
-						"url": {
-							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "9000",
-							"path": [
-								"api",
-								"v2",
-								"virtualchallenge",
-								"{{VirtualChallengeID}}"
 							]
 						},
 						"description": ""
@@ -1882,7 +1893,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}?immediate=true",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -1893,6 +1904,13 @@
 								"v2",
 								"project",
 								"{{SimpleProjectID}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true",
+									"equals": true
+								}
 							]
 						},
 						"description": "Deletes the project that was used for the challenge tests."

--- a/test/org/maproulette/models/ChallengeSpec.scala
+++ b/test/org/maproulette/models/ChallengeSpec.scala
@@ -23,7 +23,7 @@ class ChallengeSpec @Inject() (projectDAL: ProjectDAL, challengeDAL: ChallengeDA
   "Challenges" should {
     "write challenge object to database" in new WithApplication {
       val projectID = projectDAL.insert(Project(-1, User.DEFAULT_SUPER_USER_ID, "RootProject_challengeTest", DateTime.now(), DateTime.now()), User.superUser).id
-      val newChallenge = Challenge(challengeID, "NewChallenge", DateTime.now(), DateTime.now(), Some("This is a new challenge"), None,
+      val newChallenge = Challenge(challengeID, "NewChallenge", DateTime.now(), DateTime.now(), Some("This is a new challenge"), false, None,
         ChallengeGeneral(-1, projectID, ""),
         ChallengeCreation(),
         ChallengePriority(),

--- a/test/org/maproulette/models/ChallengeSpec.scala
+++ b/test/org/maproulette/models/ChallengeSpec.scala
@@ -23,7 +23,7 @@ class ChallengeSpec @Inject() (projectDAL: ProjectDAL, challengeDAL: ChallengeDA
   "Challenges" should {
     "write challenge object to database" in new WithApplication {
       val projectID = projectDAL.insert(Project(-1, User.DEFAULT_SUPER_USER_ID, "RootProject_challengeTest", DateTime.now(), DateTime.now()), User.superUser).id
-      val newChallenge = Challenge(challengeID, "NewChallenge", DateTime.now(), DateTime.now(), Some("This is a new challenge"),
+      val newChallenge = Challenge(challengeID, "NewChallenge", DateTime.now(), DateTime.now(), Some("This is a new challenge"), None,
         ChallengeGeneral(-1, projectID, ""),
         ChallengeCreation(),
         ChallengePriority(),

--- a/test/org/maproulette/models/SurveySpec.scala
+++ b/test/org/maproulette/models/SurveySpec.scala
@@ -24,7 +24,7 @@ class SurveySpec @Inject() (projectDAL: ProjectDAL, surveyDAL: SurveyDAL) extend
     "write survey object to database" in new WithApplication {
       val projectID = projectDAL.insert(Project(-1, User.DEFAULT_SUPER_USER_ID, "RootProject_challengeTest", DateTime.now(), DateTime.now()), User.superUser).id
       val answers = List(Answer(-1, "Answer1"), Answer(-1, "Answer2"))
-      val newSurvey = Challenge(surveyID, "newSurvey", DateTime.now(), DateTime.now(), Some("This is a new survey"), None,
+      val newSurvey = Challenge(surveyID, "newSurvey", DateTime.now(), DateTime.now(), Some("This is a new survey"), false, None,
         ChallengeGeneral(-1, projectID, "Default Question"),
         ChallengeCreation(),
         ChallengePriority(),

--- a/test/org/maproulette/models/SurveySpec.scala
+++ b/test/org/maproulette/models/SurveySpec.scala
@@ -24,7 +24,7 @@ class SurveySpec @Inject() (projectDAL: ProjectDAL, surveyDAL: SurveyDAL) extend
     "write survey object to database" in new WithApplication {
       val projectID = projectDAL.insert(Project(-1, User.DEFAULT_SUPER_USER_ID, "RootProject_challengeTest", DateTime.now(), DateTime.now()), User.superUser).id
       val answers = List(Answer(-1, "Answer1"), Answer(-1, "Answer2"))
-      val newSurvey = Challenge(surveyID, "newSurvey", DateTime.now(), DateTime.now(), Some("This is a new survey"),
+      val newSurvey = Challenge(surveyID, "newSurvey", DateTime.now(), DateTime.now(), Some("This is a new survey"), None,
         ChallengeGeneral(-1, projectID, "Default Question"),
         ChallengeCreation(),
         ChallengePriority(),

--- a/test/org/maproulette/models/TaskSpec.scala
+++ b/test/org/maproulette/models/TaskSpec.scala
@@ -23,7 +23,7 @@ class TaskSpec @Inject() (projectDAL: ProjectDAL, challengeDAL: ChallengeDAL, ta
   "Tasks" should {
     "write tasks object to database" in new WithApplication {
       val projectID = projectDAL.insert(Project(-1, User.DEFAULT_SUPER_USER_ID, "RootProject_tasktest", DateTime.now(), DateTime.now()), User.superUser).id
-      val challengeID = challengeDAL.insert(Challenge(-1, "ChallengeProject", DateTime.now(), DateTime.now(), None, None,
+      val challengeID = challengeDAL.insert(Challenge(-1, "ChallengeProject", DateTime.now(), DateTime.now(), None, false, None,
         ChallengeGeneral(-1, projectID, ""),
         ChallengeCreation(),
         ChallengePriority(),

--- a/test/org/maproulette/models/TaskSpec.scala
+++ b/test/org/maproulette/models/TaskSpec.scala
@@ -23,7 +23,7 @@ class TaskSpec @Inject() (projectDAL: ProjectDAL, challengeDAL: ChallengeDAL, ta
   "Tasks" should {
     "write tasks object to database" in new WithApplication {
       val projectID = projectDAL.insert(Project(-1, User.DEFAULT_SUPER_USER_ID, "RootProject_tasktest", DateTime.now(), DateTime.now()), User.superUser).id
-      val challengeID = challengeDAL.insert(Challenge(-1, "ChallengeProject", DateTime.now(), DateTime.now(), None,
+      val challengeID = challengeDAL.insert(Challenge(-1, "ChallengeProject", DateTime.now(), DateTime.now(), None, None,
         ChallengeGeneral(-1, projectID, ""),
         ChallengeCreation(),
         ChallengePriority(),


### PR DESCRIPTION
### OSM Matcher:
This will attempt to match changesets to fixed tasks. This does this using three different approaches:

- 1st approach would be to find all the changesets in the last hour from the user that set the task to fixed and see if any of those changesets potentially match the task that was fixed. This happens immediately after the user sets the task status to fixed.
- 2nd approach would run on a schedule every x hours and attempt to find matches for all the tasks that are fixed but do not contain a changeset id and we haven't tried to match it before.
- 3rd approach is purely manual, and allows a user to run the request based on all the tasks for a given project or challenge, or for a single task.

All three approaches can be disabled or enabled as desired. By default all approaches are disabled due to the potential impact on a given server.

An approach using Augmented Diffs was attempted, however without creating a store of all the augmented diffs locally, it would basically create a situation where hundreds of API requests would be made to satisfy a single fixed task and generally not viable. If we could retrieve the augmented diffs for a time period greater than 1 minute and filter by user then it would be more viable.

### New APIs
This PR includes multiple new API's. The first is the ability to extract a gzipped package of a Challenge. This would include the following files:
- a challenge json object that can be used to recreate the Challenge object
- a geojson file that contains all the tasks for the son. Can be used in conjunction with the json file.
- Comments csv file containing all the comments from all the tasks within the challenge
- Metrics cvs containing the current metrics for the challenge

The second API is the ability to create Challenges from a Github link. If using this method the file files are expected:
- A json file describing the challenge itself, much like the first file mentioned from the extract API.
- A geojson file to build all the tasks, this can be any geojson that you would ordinarily use to build tasks for challenges, and an example would be the geojson mentioned from the extract API.
- An infoLink md file that contains information about the Challenge, this is a purely optional file to include.

### Other APIs
CloneChallenge - clones a challenge
RebuildChallenge - rebuilds the tasks in a challenge if originally built using a overpass query or remote geojson.
RefreshProfile - Will refresh the user profile, by grabbing the relevant information from the User's OSM account.

### Delayed Deletion
If a challenge has a lot of tasks when deleting that challenge or deleting a project that has a lot of tasks amongst all the challenge children, due to the cascade deletes in the database the process could take quite a long time. To alleviate the issue when projects and challenges are deleted, the delete is delayed, and instead a flag is set to delete the objects later. The API does allow for immediate deletion though, so if required you can bypass the delated deletion. Caveats to this approach mean that certain objects remain in the database when in actual fact they are deleted. For the majority of find APIs the deleted objects will be ignored, but in listing functions they will be returned. Also tasks within virtual challenges that are children of deleted challenges will still be available to users. The flag will be returned with the task, so anybody using the API can react appropriately. And undelete API is also included so that any Project/Challenges that have been flagged for deletion but aren't actually deleted can be undeleted.