### PR TITLE
Minor bug fixes

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -165,7 +165,7 @@ class ChallengeController @Inject()(override val childController: TaskController
     }
   }
 
-  def getClusteredPoints(challengeId: Long, statusFilter: String): Action[AnyContent] = Action.async { implicit request =>
+  def getClusteredPoints(challengeId: Long, statusFilter: String, limit:Int): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       implicit val writes = ClusteredPoint.clusteredPointWrites
       val filter = if (StringUtils.isEmpty(statusFilter)) {
@@ -173,7 +173,7 @@ class ChallengeController @Inject()(override val childController: TaskController
       } else {
         Some(Utils.split(statusFilter).map(_.toInt))
       }
-      Ok(Json.toJson(this.dal.getClusteredPoints(challengeId, filter)))
+      Ok(Json.toJson(this.dal.getClusteredPoints(challengeId, filter, limit)))
     }
   }
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -382,7 +382,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
     * @param statusFilter Filter the displayed task cluster points by their status
     * @return A list of clustered point objects
     */
-  def getClusteredPoints(challengeId:Long, statusFilter:Option[List[Int]]=None)
+  def getClusteredPoints(challengeId:Long, statusFilter:Option[List[Int]]=None, limit:Int=2500)
                                (implicit c:Option[Connection]=None) : List[ClusteredPoint] = {
     this.withMRConnection { implicit c =>
       val filter = statusFilter match {
@@ -405,7 +405,9 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
               INNER JOIN projects p ON p.id = c.parent_id
               WHERE t.parent_id = $challengeId
                 AND p.deleted = false AND c.deleted = false
-              #$filter"""
+                AND ST_AsGeoJSON(t.location) IS NOT NULL
+              #$filter
+              LIMIT #${sqlLimit(limit)}"""
           .as(pointParser.*)
     }
   }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1252,7 +1252,7 @@ GET     /challenge/view/:id                         @org.maproulette.controllers
 #     in: query
 #     description: Can filter the Tasks returned by the status of the Task. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
 ###
-GET     /challenge/clustered/:id                    @org.maproulette.controllers.api.ChallengeController.getClusteredPoints(id:Long, filter:String ?= "")
+GET     /challenge/clustered/:id                    @org.maproulette.controllers.api.ChallengeController.getClusteredPoints(id:Long, filter:String ?= "", limit:Int ?= 2500)
 ###
 # tags: [ Challenge ]
 # summary: Update Task Priorities

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,10 +64,10 @@ play {
   }
   ws {
     useragent="MapRoulette"
-    ssl {
-      default = true
-      loose.acceptAnyCertificate=true
-    }
+    #ssl {
+    #  default = true
+    #  loose.acceptAnyCertificate=true
+    #}
   }
 }
 

--- a/conf/evolutions/default/13.sql
+++ b/conf/evolutions/default/13.sql
@@ -16,7 +16,7 @@ CREATE OR REPLACE FUNCTION on_project_delete_update() RETURNS TRIGGER AS $$
 BEGIN
   IF new.deleted = true AND old.deleted = false THEN
     UPDATE challenges SET deleted = true WHERE parent_id = new.id;;
-  ELSEIF IF new.deleted = false AND old.deleted = true THEN
+  ELSEIF new.deleted = false AND old.deleted = true THEN
     UPDATE challenges SET deleted = false WHERE parent_id = new.id;;
   END IF;;
   RETURN new;;


### PR DESCRIPTION
If a challenge had 10,000+ tasks in it the response would become incredibly slow as it would require all 10,000+ tasks to be serialized to json and respond which just takes a lot of time and can cause issues on the client side as well. So this includes a limit that defaults to 2500 which remains fairly quick but user can increase if so desired. It seems at around 10,000 tasks it takes around 20 seconds to process, whereas 2500 will take just about 2 seconds.

This PR also includes a fix to a typo in the sql script.