### PR TITLE
Adding new API that will retrieve all the comments for an entire proj…

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -422,9 +422,9 @@ var deleteItem = function(itemType, itemId) {
 
     ToastUtils.Info(Messages('main.js.deletion') + " " + itemType + " [" + itemId + "]");
     if (itemType == "Project") {
-        jsRoutes.org.maproulette.controllers.api.ProjectController.delete(itemId).ajax(apiCallback);
+        jsRoutes.org.maproulette.controllers.api.ProjectController.delete(itemId, true).ajax(apiCallback);
     } else if (itemType == "Challenge") {
-        jsRoutes.org.maproulette.controllers.api.ChallengeController.delete(itemId).ajax(apiCallback);
+        jsRoutes.org.maproulette.controllers.api.ChallengeController.delete(itemId, true).ajax(apiCallback);
     } else if (itemType == "Task") {
         jsRoutes.org.maproulette.controllers.api.TaskController.delete(itemId).ajax(apiCallback);
     } else if (itemType == "User") {

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -318,11 +318,11 @@ class ChallengeController @Inject()(override val childController: TaskController
     * Retrieve all the comments for a specific challenge
     *
     * @param challengeId The id of the challenge
-    * @return A map of task id's to comments that exist for a specific challenge
+    * @return A list of comments that exist for a specific challenge
     */
   def retrieveComments(challengeId:Long, limit:Int, page:Int) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      Ok(Json.toJson(this.dalManager.task.retrieveCommentsForChallenge(challengeId, limit, page).map(c => c._1+"" -> c._2)))
+      Ok(Json.toJson(this.dalManager.task.retrieveComments(List.empty, List(challengeId), List.empty, limit, page)))
     }
   }
 
@@ -344,13 +344,11 @@ class ChallengeController @Inject()(override val childController: TaskController
   }
 
   private def _extractComments(challengeId:Long, limit:Int, page:Int, host:String) : Seq[String] = {
-    val comments = this.dalManager.task.retrieveCommentsForChallenge(challengeId, limit, page)
+    val comments = this.dalManager.task.retrieveComments(List.empty, List(challengeId), List.empty, limit, page)
     val urlPrefix = s"http://$host/"
-    comments.flatMap(c =>
-      c._2.map(comment =>
-        s"""$challengeId,${c._1},${comment.osm_id},${comment.osm_username},"${comment.comment}",${urlPrefix}map/$challengeId/${c._1}"""
-      )
-    ).toSeq
+    comments.map(comment =>
+      s"""${comment.projectId},$challengeId,${comment.taskId},${comment.osm_id},${comment.osm_username},"${comment.comment}",${urlPrefix}map/$challengeId/${comment.taskId}"""
+    )
   }
 
   /**

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -130,4 +130,16 @@ class ProjectController @Inject() (override val childController:ChallengeControl
       Ok(Json.toJson(this.dal.getClusteredPoints(pid, cids)))
     }
   }
+
+  /**
+    * Retrieve all the comments for a specific project
+    *
+    * @param projectId The id of the challenge
+    * @return A list of comments that exist for a specific challenge
+    */
+  def retrieveComments(projectId:Long, limit:Int, page:Int) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.taskDAL.retrieveComments(List(projectId), List.empty, List.empty, limit, page)))
+    }
+  }
 }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -283,7 +283,7 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
     */
   def retrieveComments(taskId:Long) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      Ok(Json.toJson(this.dal.retrieveComments(taskId)))
+      Ok(Json.toJson(this.dal.retrieveComments(List.empty, List.empty, List(taskId))))
     }
   }
 

--- a/app/org/maproulette/models/Comment.scala
+++ b/app/org/maproulette/models/Comment.scala
@@ -13,7 +13,9 @@ import play.api.libs.json.{Json, Reads, Writes}
 case class Comment(id:Long,
                    osm_id:Long,
                    osm_username:String,
-                   task_id:Long,
+                   taskId:Long,
+                   challengeId:Long,
+                   projectId:Long,
                    created:DateTime,
                    comment:String,
                    actionId:Option[Long]=None)

--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -89,7 +89,8 @@ class ProjectDAL @Inject() (override val db:Database,
     * @return The object that was inserted into the database. This will include the newly created id
     */
   override def insert(project: Project, user:User)(implicit c:Option[Connection]=None): Project = {
-    this.permission.hasObjectWriteAccess(project, user)
+    //permissions don't need to be checked, anyone can create a project
+    //this.permission.hasObjectWriteAccess(project, user)
     this.cacheManager.withOptionCaching { () =>
       // only super users can enable or disable projects
       val setProject = if (!user.isSuperUser || user.adminForProject(project.id)) {

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -494,7 +494,7 @@ class UserDAL @Inject() (override val db:Database,
           description = Some(s"Home project for user ${user.name}"),
           enabled = false,
           displayName = Some(s"${user.osmProfile.displayName}'s Project")
-        ), User.superUser).id
+        ), user).id
     }
     // make sure the user is an admin of this project
     if (!user.groups.exists(g => g.projectId == homeProjectId)) {

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -515,6 +515,30 @@ GET     /project/clustered/:id                      @org.maproulette.controllers
 ###
 GET     /project/search/clustered                   @org.maproulette.controllers.api.ProjectController.getSearchedClusteredPoints(search ?= "")
 ###
+# tags: [ Project ]
+# summary: Retrieve all comments for Project
+# description: This will retrieve all the comments of the descendent tasks of a given Project
+# response:
+#   '200':
+#     description: A list of comments of the descendent tasks of a given Project
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Comment'
+#   '404':
+#     description: No Project with provided ID found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the project
+#     required: true
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /project/:id/comments                     @org.maproulette.controllers.api.ProjectController.retrieveComments(id:Long, limit:Int ?= 10, page:Int ?= 0)
+###
 # tags: [ Challenge ]
 # summary: Create a Challenge
 # consumes: [ application/json ]
@@ -1306,7 +1330,7 @@ PUT     /challenge/:id/resetTaskInstructions        @org.maproulette.controllers
 # description: This will retrieve all the comments for all the children tasks of a given challenge
 # response:
 #   '200':
-#     description: A mapping of Task ID to list of comments for that Task ID
+#     description: A list of comments for that challenge
 #     schema:
 #       $ref: '#/definitions/org.maproulette.models.Comment'
 #   '404':

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,7 +128,7 @@ maproulette {
 osm {
   ql {
     provider="http://overpass-api.de/api/interpreter"
-    timeout=25
+    timeout=120
   }
   server="http://www.openstreetmap.org"
   server=${?MR_OSM_SERVER}

--- a/conf/evolutions/default/14.sql
+++ b/conf/evolutions/default/14.sql
@@ -1,0 +1,21 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+SELECT add_drop_column('task_comments', 'challenge_id', 'integer NOT NULL -1');;
+SELECT add_drop_column('task_comments', 'project_id', 'integer NOT NULL -1');;
+-- update current projects before adding the constraints
+UPDATE task_comments SET challenge_id = (SELECT parent_id FROM tasks WHERE task_comments.task_id = id),
+                          project_id = (SELECT c.parent_id FROM challenges c
+                                        INNER JOIN tasks t ON t.parent_id = c.id
+                                        WHERE task_comments.task_id = t.id);;
+
+ALTER TABLE task_comments DROP CONSTRAINT IF EXISTS task_comments_challenge_id_fkey;;
+ALTER TABLE task_comments ADD CONSTRAINT task_comments_challenge_id_fkey
+   FOREIGN KEY (challenge_id) REFERENCES challenges (id) MATCH SIMPLE
+   ON UPDATE CASCADE ON DELETE CASCADE;;
+ALTER TABLE task_comments DROP CONSTRAINT IF EXISTS task_comments_project_id_fkey;;
+ALTER TABLE task_comments ADD CONSTRAINT task_comments_project_id_fkey
+   FOREIGN KEY (project_id) REFERENCES projects (id) MATCH SIMPLE
+   ON UPDATE CASCADE ON DELETE CASCADE;;
+
+# --- !Downs

--- a/conf/evolutions/default/14.sql
+++ b/conf/evolutions/default/14.sql
@@ -1,8 +1,8 @@
 # --- MapRoulette Scheme
 
 # --- !Ups
-SELECT add_drop_column('task_comments', 'challenge_id', 'integer NOT NULL -1');;
-SELECT add_drop_column('task_comments', 'project_id', 'integer NOT NULL -1');;
+SELECT add_drop_column('task_comments', 'challenge_id', 'integer NOT NULL DEFAULT -1');;
+SELECT add_drop_column('task_comments', 'project_id', 'integer NOT NULL DEFAULT -1');;
 -- update current projects before adding the constraints
 UPDATE task_comments SET challenge_id = (SELECT parent_id FROM tasks WHERE task_comments.task_id = id),
                           project_id = (SELECT c.parent_id FROM challenges c


### PR DESCRIPTION
…ect. Also modified the comment object to respond with the challengeId and the projectId, so will include the entire hierarchy. The structure of the API also changed, now it is simply a list of comments.

The new API is available at /api/v2/project/<ID>/comments