### PR TITLE
Adding new functionality around building Challenge Tasks.

### DIFF
--- a/app/assets/javascripts/mapping.js
+++ b/app/assets/javascripts/mapping.js
@@ -582,7 +582,7 @@ function Task() {
             proximityID = data.id;
         }
         // make sure the the challenge is set
-        new SearchParameters().setChallengeId(data.parentId);
+        new SearchParameters().setChallengeId([data.parentId]);
         taskFunction(proximityID).ajax({
             success:function(update) {
                 updateData(update, MRManager.getSuccessHandler(success));
@@ -1027,14 +1027,14 @@ var MRManager = (function() {
             }
             // if we are mapping directly using the challenge ID, then ignore whether it is enabled or not
             else if (typeof parentId !== 'undefined' && parentId != -1) {
-                currentSearchParameters.setChallengeId(parentId);
+                currentSearchParameters.setChallengeId([parentId]);
                 currentSearchParameters.setProjectEnabled(false);
                 currentSearchParameters.setChallengeEnabled(false);
                 currentTask.getRandomNextTask();
             } else {
                 // In this case show all the challenges on the map
                 loading();
-                currentSearchParameters.setChallengeId(-1);
+                currentSearchParameters.setChallengeId([-1]);
                 currentSearchParameters.setProjectEnabled(true);
                 currentSearchParameters.setChallengeEnabled(true);
                 jsRoutes.org.maproulette.controllers.api.ProjectController.getClusteredPoints(-1).ajax({

--- a/app/controllers/FormEditController.scala
+++ b/app/controllers/FormEditController.scala
@@ -166,10 +166,11 @@ class FormEditController @Inject() (val messagesApi: MessagesApi,
                 val rerun = request.body.dataParts.getOrElse("rerun", Vector("false")).head.toBoolean
                 if (itemId < 0 || rerun) {
                   val uploadData = request.body.file("localGeoJSON") match {
-                    case Some(f) if StringUtils.isNotEmpty(f.filename) => Some(Source.fromFile(f.ref.file).getLines().mkString)
+                    case Some(f) if StringUtils.isNotEmpty(f.filename) =>
+                      Some(Source.fromFile(f.ref.file).getLines().mkString("\n"))
                     case _ => None
                   }
-                  challengeService.buildChallengeTasks(user, updatedChallenge, uploadData)
+                  challengeService.buildTasks(user, updatedChallenge, uploadData)
                 }
 
                 dal.updateItemTagNames(updatedChallenge.id, tags, user)
@@ -186,7 +187,7 @@ class FormEditController @Inject() (val messagesApi: MessagesApi,
       permission.hasWriteAccess(ProjectType(), user)(parentId)
       dalManager.challenge.retrieveById(challengeId) match {
         case Some(c) =>
-          challengeService.rebuildChallengeTasks(user, c)
+          challengeService.rebuildTasks(user, c)
           Ok
         case None => throw new NotFoundException(s"No challenge found with id $challengeId")
       }

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.StringUtils
 import org.maproulette.actions._
 import org.maproulette.controllers.ParentController
 import org.maproulette.data.{ActionSummary, ChallengeSummary}
-import org.maproulette.exception.{MPExceptionUtil, NotFoundException, StatusMessage}
+import org.maproulette.exception.{InvalidException, MPExceptionUtil, NotFoundException, StatusMessage}
 import org.maproulette.models.dal._
 import org.maproulette.models._
 import org.maproulette.permissions.Permission
@@ -21,11 +21,13 @@ import org.maproulette.services.ChallengeService
 import org.maproulette.session.{SearchParameters, SessionManager, User}
 import org.maproulette.utils.Utils
 import play.api.http.HttpEntity
+import play.api.libs.Files
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
 import scala.concurrent.{Future, Promise}
+import scala.io.Source
 import scala.util.{Failure, Success}
 
 /**
@@ -124,7 +126,7 @@ class ChallengeController @Inject()(override val childController: TaskController
       case Some(local) => Some(Json.stringify(local))
       case None => None
     }
-    if (!this.challengeService.buildChallengeTasks(user, createdObject, localJson)) {
+    if (!this.challengeService.buildTasks(user, createdObject, localJson)) {
       super.extractAndCreate(body, createdObject, user)
     }
     // we need to elevate the user permissions to super users to extract and create the tags
@@ -422,41 +424,37 @@ class ChallengeController @Inject()(override val childController: TaskController
       val baseURL = s"https://raw.githubusercontent.com/$username/$repo/master/${name}_";
       this.wsClient.url(s"${baseURL}create.json").get onComplete {
         case Success(response) =>
-          this.wsClient.url(s"${baseURL}geojson.json").get onComplete {
-            case Success(jsonResp) =>
-              try {
-                // inject the info link into the challenge
-                val challengeJson = Utils.insertIntoJson(
-                  Utils.insertIntoJson(response.json, "infoLink", s"${baseURL}info.md", false),
-                  "localGeoJSON",
-                  jsonResp.json,
-                  true
-                )
-                val challengeName = (challengeJson \ "name").asOpt[String].getOrElse(name)
-                // look for the challenge, if the name exists we will attempt to update the challenge
-                val challengeID = this.dal.retrieveByName(challengeName, projectId) match {
-                  case Some(c) => c.id
-                  case None => -1
-                }
-                val updatedBody = this.updateCreateBody(Utils.insertIntoJson(challengeJson, "parent", projectId), user)
-                if (challengeID > 0) {
-                  // if rebuild set to true, remove all the tasks first from the challenge before recreating them
-                  this.dal.deleteTasks(user, challengeID)
-                  // if you provide the ID in the post method we will send you to the update path
-                  this.internalUpdate(updatedBody, user)(challengeID.toString, -1) match {
-                    case Some(value) => result success Ok(this.inject(value))
-                    case None => result success NotModified
-                  }
-                } else {
-                  this.internalCreate(updatedBody, updatedBody.validate[Challenge].get, user) match {
-                    case Some(value) => result success Ok(this.inject(value))
-                    case None => result success NotModified
-                  }
-                }
-              } catch {
-                case e:Throwable => result success MPExceptionUtil.manageException(e)
+          try {
+            // inject the info link into the challenge
+            val challengeJson = Utils.insertIntoJson(
+              Utils.insertIntoJson(response.json, "infoLink", s"${baseURL}info.md", false),
+              "remoteGeoJson",
+              s"${baseURL}geojson_{x}.json",
+              true
+            )
+            val challengeName = (challengeJson \ "name").asOpt[String].getOrElse(name)
+            // look for the challenge, if the name exists we will attempt to update the challenge
+            val challengeID = this.dal.retrieveByName(challengeName, projectId) match {
+              case Some(c) => c.id
+              case None => -1
+            }
+            val updatedBody = this.updateCreateBody(Utils.insertIntoJson(challengeJson, "parent", projectId), user)
+            if (challengeID > 0) {
+              // if rebuild set to true, remove all the tasks first from the challenge before recreating them
+              this.dal.deleteTasks(user, challengeID)
+              // if you provide the ID in the post method we will send you to the update path
+              this.internalUpdate(updatedBody, user)(challengeID.toString, -1) match {
+                case Some(value) => result success Ok(this.inject(value))
+                case None => result success NotModified
               }
-            case Failure(error) => throw error
+            } else {
+              this.internalCreate(updatedBody, updatedBody.validate[Challenge].get, user) match {
+                case Some(value) => result success Ok(this.inject(value))
+                case None => result success NotModified
+              }
+            }
+          } catch {
+            case e:Throwable => result success MPExceptionUtil.manageException(e)
           }
         case Failure(error) => throw error
       }
@@ -543,10 +541,53 @@ class ChallengeController @Inject()(override val childController: TaskController
       dalManager.challenge.retrieveById(challengeId) match {
         case Some(c) =>
           permission.hasWriteAccess(ProjectType(), user)(c.general.parent)
-          challengeService.rebuildChallengeTasks(user, c)
+          challengeService.rebuildTasks(user, c)
           Ok
         case None => throw new NotFoundException(s"No challenge found with id $challengeId")
       }
     }
   }
+
+  def addTasksToChallenge(challengeId:Long) : Action[AnyContent] = Action.async { implicit request =>
+    sessionManager.authenticatedRequest { implicit user =>
+      dalManager.challenge.retrieveById(challengeId) match {
+        case Some(c) =>
+          permission.hasObjectWriteAccess(c, user)
+          request.body.asText match {
+            case Some(j) =>
+              challengeService.createTasksFromJson(user, c, j)
+              NoContent
+            case None =>
+              throw new InvalidException("No json data provided to create new tasks from")
+          }
+        case None =>
+          throw new NotFoundException(s"No challenge found with id $challengeId")
+      }
+    }
+  }
+
+  def addTasksToChallengeFromFile(challengeId:Long, lineByLine:Boolean) : Action[MultipartFormData[Files.TemporaryFile]] =
+    Action.async(parse.multipartFormData) { implicit request => {
+      sessionManager.authenticatedRequest { implicit user =>
+        dalManager.challenge.retrieveById(challengeId) match {
+          case Some(c) =>
+            permission.hasObjectWriteAccess(c, user)
+            request.body.file("json") match {
+              case Some(f) if StringUtils.isNotEmpty(f.filename) =>
+                // todo this should probably be streamed instead of all pulled into memory
+                val sourceData = Source.fromFile(f.ref.file).getLines()
+                if (lineByLine) {
+                  sourceData.foreach(challengeService.createTaskFromJson(user, c, _))
+                } else {
+                  challengeService.createTasksFromJson(user, c, sourceData.mkString)
+                }
+                NoContent
+              case _ =>
+                throw new InvalidException(s"No json uploaded with request to add tasks from")
+            }
+          case None =>
+            throw new NotFoundException(s"No challenge found with id $challengeId")
+        }
+      }
+    }}
 }

--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -55,7 +55,8 @@ class VirtualChallengeController @Inject() (override val sessionManager: Session
       case None => config.virtualChallengeExpiry.toHours.toInt
     }
     val expiryUpdate = Utils.insertIntoJson(jsonBody, "expiry", DateTime.now().plusHours(expiryValue))(DefaultJodaDateWrites)
-    Utils.insertIntoJson(expiryUpdate, "ownerId", user.osmProfile.id)
+    val searchUpdate = Utils.insertIntoJson(expiryUpdate, "searchParameters", SearchParameters())
+    Utils.insertIntoJson(searchUpdate, "ownerId", user.osmProfile.id)
   }
 
   /**

--- a/app/org/maproulette/models/VirtualChallenge.scala
+++ b/app/org/maproulette/models/VirtualChallenge.scala
@@ -15,7 +15,8 @@ case class VirtualChallenge(override val id:Long,
                             override val description:Option[String]=None,
                             ownerId:Long,
                             searchParameters:SearchParameters,
-                            expiry:DateTime) extends BaseObject[Long] with DefaultWrites {
+                            expiry:DateTime,
+                            taskIdList:Option[List[Long]]=None) extends BaseObject[Long] with DefaultWrites {
 
   override val itemType: ItemType = VirtualChallengeType()
 

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1064,6 +1064,63 @@ POST    /challenge/:id/tasks                        @org.maproulette.controllers
 PUT     /challenge/:id/tasks                        @org.maproulette.controllers.api.ChallengeController.updateChildren(id:Long)
 ###
 # tags: [ Challenge ]
+# summary: Add tasks to a challenge
+# consumes: [ application/json ]
+# description: This will create tasks within a challenge based on the provided geojson in the body of the PUT request
+# responses:
+#   '304':
+#     description: No Content, just a successful creation when getting this message
+#   '400':
+#     description: Invalid json payload. It is required that the body is JSON.
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the parent Challenge where all the children are being created.
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: body
+#     in: body
+#     description: The geojson to build the tasks from.
+#     required: true
+###
+PUT     /challenge/:id/addTasks                     @org.maproulette.controllers.api.ChallengeController.addTasksToChallenge(id:Long)
+###
+# tags: [ Challenge ]
+# summary: Add tasks to a challenge
+# consumes: [ application/json ]
+# description: This will create tasks within a challenge based on the provided file uploaded as part of the PUT request.
+# responses:
+#   '304':
+#     description: No Content, just a successful creation when getting this message
+#   '400':
+#     description: Invalid json payload. It is required that the file is JSON.
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the parent Challenge where all the children are being created.
+#   - name: lineByLine
+#     in: query
+#     description: If the JSON provided includes seperate GeoJSON on each line, then this must be true
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: body
+#     in: body
+#     description: The geojson to build the tasks from.
+#     required: true
+###
+PUT     /challenge/:id/addFileTasks                 @org.maproulette.controllers.api.ChallengeController.addTasksToChallengeFromFile(id:Long, lineByLine:Boolean ?= true)
+###
+# tags: [ Challenge ]
 # summary: Retrieves children for Challenge
 # produces: [ application/json ]
 # description: Retrieves all the children for a Challenge in an expanded list. Unlike the GET


### PR DESCRIPTION
This PR includes various methods updates the way that geojson is handled to build the tasks for a challenge and virtual challenges. This includes the following:

- Adds API that allows user to create a VirtualChallenge based on specific task ID's instead of search parameters
- Adds new API to allow user to add new tasks to an existing challenge
- Updates the ChallengeService so that when uploading local or remote JSON files it will check if the file is a line by line GeoJSON file. If it is, then it will read each line and create a task for each separate line.

This also fixes an issue in the old UI that messed up the mapping for a challenge URL, and so would never find tasks for that specific challenge. or by very random chance could. This is issue #385 