### PR TITLE
Added status_message for building challenge tasks.

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -66,6 +66,7 @@ case class Challenge(override val id:Long,
                      priority:ChallengePriority,
                      extra:ChallengeExtra,
                      status:Option[Int]=Some(0),
+                     statusMessage:Option[String]=None,
                      location:Option[String]=None,
                      bounding:Option[String]=None) extends BaseObject[Long] with DefaultWrites {
 
@@ -186,6 +187,7 @@ object Challenge {
         "updateTasks" -> default(boolean, false)
       )(ChallengeExtra.apply)(ChallengeExtra.unapply),
       "status" -> default(optional(number), None),
+      "statusMessage" -> optional(text),
       "location" -> default(optional(text), None),
       "bounding" -> default(optional(text), None)
     )(Challenge.apply)(Challenge.unapply)

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -37,6 +37,7 @@ trait ChallengeWrites {
     JsPath.write[ChallengePriority] and
     JsPath.write[ChallengeExtra] and
     (JsPath \ "status").writeNullable[Int] and
+    (JsPath \ "statusMessage").writeNullable[String] and
     (JsPath \ "location").writeNullable[String](new jsonWrites("location")) and
     (JsPath \ "bounding").writeNullable[String](new jsonWrites("bounding"))
   )(unlift(Challenge.unapply))
@@ -61,6 +62,7 @@ trait ChallengeReads extends DefaultReads {
     JsPath.read[ChallengePriority] and
     JsPath.read[ChallengeExtra] and
     (JsPath \ "status").readNullable[Int] and
+    (JsPath \ "statusMessage").readNullable[String] and
     (JsPath \ "location").readNullable[String](new jsonReads("location")) and
     (JsPath \ "bounding").readNullable[String](new jsonReads("bounding"))
   )(Challenge.apply _)

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -77,6 +77,11 @@
                     <a href="#" id="pi" data-toggle="modal" data-target="#geoJsonViewer" onclick='MRManager.updateGeoJsonViewer();'>&pi;</a>
                 </div>
 
+                <div class="pull-right">
+                    <b style="color:black"><a href="/mr3">Try out the new <u style="color:red">MapRoulette V3 Public Beta</u></a></b>
+                    <b style="color:white">.................</b>
+                </div>
+
                     <!-- Default to the left -->
                 <strong>MapRoulette @{config.getSemanticVersion}</strong> - @messages("footer.getintouch"): <a href="https://github.com/maproulette/maproulette2">GitHub</a> / <a href="mailto:maproulette@@maproulette.org">@messages("general.email")</a>
 

--- a/conf/evolutions/default/14.sql
+++ b/conf/evolutions/default/14.sql
@@ -18,4 +18,7 @@ ALTER TABLE task_comments ADD CONSTRAINT task_comments_project_id_fkey
    FOREIGN KEY (project_id) REFERENCES projects (id) MATCH SIMPLE
    ON UPDATE CASCADE ON DELETE CASCADE;;
 
+-- Add status failure text
+SELECT add_drop_column('challenges', 'status_message', 'text NULL');;
+
 # --- !Downs


### PR DESCRIPTION
So that during failures there is a message included that will explain why the building tasks failed. The object will return with the key "statusMessage" that will always include the last failure. If the current status of the challenge is Failed, then the statusMessage will reflect the reasoning why.

This also includes a banner link in the footer to allow users to try out the new MR3 Beta.