### PR TITLE
New APIs.

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -5,8 +5,8 @@ package org.maproulette.controllers.api
 import java.io._
 import java.sql.Connection
 import java.util.zip.{ZipEntry, ZipOutputStream}
-import javax.inject.Inject
 
+import javax.inject.Inject
 import akka.util.ByteString
 import oauth.signpost.exception.OAuthNotAuthorizedException
 import org.apache.commons.lang3.StringUtils
@@ -61,8 +61,15 @@ class ChallengeController @Inject()(override val childController: TaskController
   override protected val cReads: Reads[Task] = Task.TaskFormat
   // The type of object that this controller deals with.
   override implicit val itemType: ItemType = ChallengeType()
-  implicit val answerWrites: Writes[Answer] = Challenge.answerWrites
-  implicit val commentWrites: Writes[Comment] = Comment.commentWrites
+
+  // implicit writes used for various JSON responses
+  implicit val answerWrites = Challenge.answerWrites
+  implicit val commentWrites = Comment.commentWrites
+  implicit val pointWrites = ClusteredPoint.pointWrites
+  implicit val clusteredPointWrites = ClusteredPoint.clusteredPointWrites
+  implicit val taskClusterWrites = TaskCluster.taskClusterWrites
+  implicit val searchParameterWrites = SearchParameters.paramsWrites
+  implicit val searchLocationWrites = SearchParameters.locationWrites
 
   override def dalWithTags: TagDALMixin[Challenge] = dal
 
@@ -167,9 +174,17 @@ class ChallengeController @Inject()(override val childController: TaskController
     }
   }
 
+  /**
+    * Gets the tasks in the form of ClusteredPoints, which is just a task with limited information,
+    * and the geometry associated with it is just the centroid of the task geometry
+    *
+    * @param challengeId The challenge id, ie. the parent of the tasks
+    * @param statusFilter Filter by status of the task
+    * @param limit limit the number of tasks returned
+    * @return A list of ClusteredPoint's
+    */
   def getClusteredPoints(challengeId: Long, statusFilter: String, limit:Int): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      implicit val writes = ClusteredPoint.clusteredPointWrites
       val filter = if (StringUtils.isEmpty(statusFilter)) {
         None
       } else {

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -327,4 +327,35 @@ class TaskController @Inject() (override val sessionManager: SessionManager,
       Ok
     }
   }
+
+  /**
+    * Gets clusters of tasks for the challenge. Uses kmeans method in postgis.
+    *
+    * @param numberOfPoints Number of clustered points you wish to have returned
+    * @return A list of ClusteredPoint's that represent clusters of tasks
+    */
+  def getTaskClusters(numberOfPoints:Int) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      SearchParameters.withSearch { implicit params =>
+        Ok(Json.toJson(this.dal.getTaskClusters(params, numberOfPoints)))
+      }
+    }
+  }
+
+  /**
+    * Gets the list of tasks that are contained within the single cluster
+    *
+    * @param clusterId The cluster id, when "getTaskClusters" is executed it will return single point clusters
+    *                  representing all the tasks in the cluster. Each cluster will contain an id, supplying
+    *                  that id to this method will allow you to retrieve all the tasks in the cluster
+    * @param numberOfPoints Number of clustered points that was originally used to get all the clusters
+    * @return A list of ClusteredPoint's that represent each of the tasks within a single cluster
+    */
+  def getTasksInCluster(clusterId:Int, numberOfPoints:Int) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      SearchParameters.withSearch { implicit params =>
+        Ok(Json.toJson(this.dal.getTasksInCluster(clusterId, params, numberOfPoints)))
+      }
+    }
+  }
 }

--- a/app/org/maproulette/models/TaskCluster.scala
+++ b/app/org/maproulette/models/TaskCluster.scala
@@ -1,0 +1,18 @@
+package org.maproulette.models
+
+import org.maproulette.session.SearchParameters
+import play.api.libs.json._
+
+/**
+  * Task cluster object that contains information about a cluster containing various tasks
+  *
+  * @author mcuthbert
+  */
+case class TaskCluster(clusterId:Int, numberOfPoints:Int, params:SearchParameters, point:Point, bounding:JsValue = Json.toJson("{}")) extends DefaultWrites
+
+object TaskCluster {
+  implicit val pointWrites: Writes[Point] = Json.writes[Point]
+  implicit val pointReads: Reads[Point] = Json.reads[Point]
+  implicit val taskClusterWrites: Writes[TaskCluster] = Json.writes[TaskCluster]
+  implicit val taskClusterReads: Reads[TaskCluster] = Json.reads[TaskCluster]
+}

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2378,6 +2378,44 @@ PUT     /task/:id/changeset                         @org.maproulette.controllers
 ###
 PUT     /task/:id/:status                           @org.maproulette.controllers.api.TaskController.setTaskStatus(id:Long, status:Int, comment:String ?= "")
 ###
+# tags: [ Challenge ]
+# summary: Retrieves task clusters
+# produces: [ application/json ]
+# description: Retrieves task clusters that contain the centroid location for a group of tasks
+# responses:
+#   '200':
+#     description: An array of task clusters that represents clusters of tasks for a challenge. If none found will return an empty list
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.TaskCluster'
+# parameters:
+#   - name: points
+#     in: query
+#     description: The number of clusters that you want returned
+###
+GET     /taskCluster                                @org.maproulette.controllers.api.TaskController.getTaskClusters(points:Int ?= 100)
+###
+# tags: [ Challenge ]
+# summary: Retrieves tasks in a cluster
+# produces: [ application/json ]
+# description: Retrieves tasks contained in a cluster retrieved from api /api/v2/challenge/:id/taskCluster
+# responses:
+#   '200':
+#     description: An array of tasks that are contained in a cluster. If none found will return an empty list.
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.ClusteredPoint'
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the parent project.
+#   - name: clusterId
+#     in: path
+#     description: The id of the single cluster.
+#   - name: points
+#     in: query
+#     description: The number of clusters that you want returned
+###
+GET     /tasksInCluster/:clusterId                  @org.maproulette.controllers.api.TaskController.getTasksInCluster(clusterId:Int, points:Int ?= 100)
+###
 # tags: [ Comment ]
 # summary: Retrieves a comment
 # produces: [ application/json ]
@@ -2967,7 +3005,7 @@ PUT     /user/:userId/refresh                        @org.maproulette.controller
 ###
 # tags: [ User ]
 # summary: Add user to project group
-# description: Adds a user with the specific id to a Admin, Write or Read project group
+# description: Adds a user with the specific ids to a Admin, Write or Read project group
 # responses:
 #   '200':
 #     description: Ok with a standard message
@@ -2985,6 +3023,30 @@ PUT     /user/:userId/refresh                        @org.maproulette.controller
 #     description: Either 1 - Admin, 2 - Write, 3 - Read
 ###
 PUT     /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.addUserToProject(userId:Long, projectId:Long, groupType:Int)
+###
+# tags: [ User ]
+# summary: Adds a list of user to project group
+# description: Adds a list of users with the specific ids to a Admin, Write or Read project group
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: projectId
+#     in: path
+#     description: The id of the project to add the user too
+#   - name: groupType
+#     in: path
+#     description: Either 1 - Admin, 2 - Write, 3 - Read
+#   - name: body
+#     in: body
+#     description: A JSON array of user ids. This can be either the MapRoulette or OSM Id.
+#     required: true
+#     schema:
+#       type: array
+###
+PUT     /user/project/:projectId/:groupType         @org.maproulette.controllers.api.UserController.addUsersToProject(projectId:Long, groupType:Int)
 ###
 # tags: [ User ]
 # summary: Removes a user from a project group
@@ -3006,6 +3068,30 @@ PUT     /user/:userId/project/:projectId/:groupType  @org.maproulette.controller
 #     description: Either 1 - Admin, 2 - Write, 3 - Read
 ###
 DELETE  /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.removeUserFromProject(userId:Long, projectId:Long, groupType:Int)
+###
+# tags: [ User ]
+# summary: Removes a list of users from a project group
+# description: Removes a list of users with the specific id from a Admin, Write or Read project group
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: projectId
+#     in: path
+#     description: The id of the project to add the user too
+#   - name: groupType
+#     in: path
+#     description: Either 1 - Admin, 2 - Write, 3 - Read
+#   - name: body
+#     in: body
+#     description: A JSON array of user ids. This can be either the MapRoulette or OSM Id.
+#     required: true
+#     schema:
+#       type: array
+###
+DELETE  /user/project/:projectId/:groupType         @org.maproulette.controllers.api.UserController.removeUsersFromProject(projectId:Long, groupType:Int)
 ### NoDocs ###
 POST    /*path                                      @org.maproulette.controllers.api.APIController.invalidAPIPath(path)
 ### NoDocs ###


### PR DESCRIPTION
This PR includes 2 new API's. 

#### Task Clusters
The API's here allow users to retrieve task clusters instead of every single task within a challenge. The API is also filterable, so you can filter the tasks within a geographic region, or filter by projects and/or challenges. And also using fuzzy search capabilities. Also supported is filtering by task status and/or priority. So generally quite flexible in how to produce the task cluster. By default 100 clusters will be returned, however this can be modified as part of the API request. Each task cluster will be returned with the id, the number of tasks in the cluster, a central location for the cluster and a bounding polygon.

#### User Management
A couple simple API's included to allow admin to add or remove users from groups in a project. So if you want to give a specific user admin or write privileges to a specific project you can do that.