### PR TITLE
Add user leaderboard and top-challenges APIs

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -69,6 +69,21 @@ class Config @Inject() (implicit val application:Application) {
 
   lazy val changeSetEnabled : Boolean = this.config.getBoolean(Config.KEY_CHANGESET_ENABLED).getOrElse(Config.DEFAULT_CHANGESET_ENABLED)
 
+  lazy val taskScoreFixed : Int =
+    this.config.getInt(Config.KEY_TASK_SCORE_FIXED).getOrElse(Config.DEFAULT_TASK_SCORE_FIXED)
+
+  lazy val taskScoreFalsePositive : Int =
+    this.config.getInt(Config.KEY_TASK_SCORE_FALSE_POSITIVE).getOrElse(Config.DEFAULT_TASK_SCORE_FALSE_POSITIVE)
+
+  lazy val taskScoreAlreadyFixed : Int =
+    this.config.getInt(Config.KEY_TASK_SCORE_ALREADY_FIXED).getOrElse(Config.DEFAULT_TASK_SCORE_ALREADY_FIXED)
+
+  lazy val taskScoreTooHard : Int =
+    this.config.getInt(Config.KEY_TASK_SCORE_TOO_HARD).getOrElse(Config.DEFAULT_TASK_SCORE_TOO_HARD)
+
+  lazy val taskScoreSkipped : Int =
+    this.config.getInt(Config.KEY_TASK_SCORE_SKIPPED).getOrElse(Config.DEFAULT_TASK_SCORE_SKIPPED)
+
   lazy val osmMatcherEnabled : Boolean = this.config.getBoolean(Config.KEY_SCHEDULER_OSM_MATCHER_ENABLED).getOrElse(Config.DEFAULT_OSM_MATCHER_ENABLED)
 
   lazy val osmMatcherManualOnly : Boolean = this.config.getBoolean(Config.KEY_SCHEDULER_OSM_MATCHER_MANUAL).getOrElse(Config.DEFAULT_OSM_MATCHER_MANUAL)
@@ -154,6 +169,11 @@ object Config {
   val KEY_SESSION_TIMEOUT = s"$GROUP_MAPROULETTE.session.timeout"
   val KEY_TASK_RESET = s"$GROUP_MAPROULETTE.task.reset"
   val KEY_SIGNIN = s"$GROUP_MAPROULETTE.signin"
+  val KEY_TASK_SCORE_FIXED = s"$GROUP_MAPROULETTE.task.score.fixed"
+  val KEY_TASK_SCORE_FALSE_POSITIVE = s"$GROUP_MAPROULETTE.task.score.falsePositive"
+  val KEY_TASK_SCORE_ALREADY_FIXED = s"$GROUP_MAPROULETTE.task.score.alreadyFixed"
+  val KEY_TASK_SCORE_TOO_HARD = s"$GROUP_MAPROULETTE.task.score.tooHard"
+  val KEY_TASK_SCORE_SKIPPED = s"$GROUP_MAPROULETTE.task.score.skipped"
 
   val SUB_GROUP_SCHEDULER = s"$GROUP_MAPROULETTE.scheduler"
   val KEY_SCHEDULER_CLEAN_LOCKS_INTERVAL = s"$SUB_GROUP_SCHEDULER.cleanLocks.interval"
@@ -194,6 +214,11 @@ object Config {
 
   val DEFAULT_SESSION_TIMEOUT = 3600000L
   val DEFAULT_TASK_RESET = 7
+  val DEFAULT_TASK_SCORE_FIXED = 5
+  val DEFAULT_TASK_SCORE_FALSE_POSITIVE = 3
+  val DEFAULT_TASK_SCORE_ALREADY_FIXED = 3
+  val DEFAULT_TASK_SCORE_TOO_HARD = 1
+  val DEFAULT_TASK_SCORE_SKIPPED = 0
   val DEFAULT_OSM_QL_TIMEOUT = 25
   val DEFAULT_NUM_OF_CHALLENGES = 3
   val DEFAULT_RECENT_ACTIVITY = 5

--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -29,6 +29,8 @@ class DataController @Inject() (sessionManager: SessionManager, challengeDAL: Ch
   implicit val userSurveySummaryWrites = Json.writes[UserSurveySummary]
   implicit val actionSummaryWrites = Json.writes[ActionSummary]
   implicit val userSummaryWrites = Json.writes[UserSummary]
+  implicit val challengeLeaderboardWrites = Json.writes[LeaderboardChallenge]
+  implicit val userLeaderboardWrites = Json.writes[LeaderboardUser]
   implicit val challengeSummaryWrites = Json.writes[ChallengeSummary]
   implicit val challengeActivityWrites = Json.writes[ChallengeActivity]
   implicit val rawActivityWrites = Json.writes[RawActivity]
@@ -83,6 +85,42 @@ class DataController @Inject() (sessionManager: SessionManager, challengeDAL: Ch
           Utils.toLongList(projects), None, Utils.getDate(start), Utils.getDate(end), this.getPriority(priority)
         )))
       }
+    }
+  }
+
+  /**
+    * Gets the top scoring users, based on task completion, over the given
+    * start and end dates.
+    *
+    * @param start the start date
+    * @param end the end date
+    * @param limit the limit on the number of users returned
+    * @param offset paging, starting at 0
+    * @return Top-ranked users with scores based on task completion activity
+    */
+  def getUserLeaderboard(start:String, end:String, limit:Int, offset:Int) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(Json.toJson(this.dataManager.getUserLeaderboard(
+        Utils.getDate(start), Utils.getDate(end), limit, offset
+      )))
+    }
+  }
+
+  /**
+    * Gets the user's top challenges, based on activity, over the given start
+    * and end dates.
+    *
+    * @param start the start date
+    * @param end the end date
+    * @param limit the limit on the number of challenges returned
+    * @param offset paging, starting at 0
+    * @return Top challenges based on user's activity
+    */
+  def getUserTopChallenges(userId:Long, start:String, end:String, limit:Int, offset:Int) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(Json.toJson(this.dataManager.getUserTopChallenges(
+        userId, Utils.getDate(start), Utils.getDate(end), limit, offset
+      )))
     }
   }
 

--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -448,10 +448,11 @@ class DataManager @Inject()(config: Config, db:Database)(implicit application:Ap
   /**
     * Gets leaderboard of top-scoring users based on task completion activity
     * over the given period. Scoring for each completed task is based on status
-    * assigned to the task. Users are returned in descending order with top
-    * scores first; ties are broken by OSM user id with the lowest/earliest ids
-    * being ranked ahead of higher/later ids. Also included with each user are
-    * their top challenges (by amount of activity).
+    * assigned to the task (status point values are configurable). Users are
+    * returned in descending order with top scores first; ties are broken by
+    * OSM user id with the lowest/earliest ids being ranked ahead of
+    * higher/later ids. Also included with each user are their top challenges
+    * (by amount of activity).
     *
     * @param start the start date
     * @param end the end date
@@ -472,10 +473,11 @@ class DataManager @Inject()(config: Config, db:Database)(implicit application:Ap
 
       SQL"""SELECT users.id, users.name, users.avatar_url, SUM(
               CASE sa.status
-                WHEN ${Task.STATUS_FIXED} THEN 5          /* points */
-                WHEN ${Task.STATUS_FALSE_POSITIVE} THEN 3 /* points */
-                WHEN ${Task.STATUS_ALREADY_FIXED} THEN 3  /* points */
-                WHEN ${Task.STATUS_TOO_HARD} THEN 1       /* points */
+                WHEN ${Task.STATUS_FIXED} THEN ${config.taskScoreFixed}
+                WHEN ${Task.STATUS_FALSE_POSITIVE} THEN ${config.taskScoreFalsePositive}
+                WHEN ${Task.STATUS_ALREADY_FIXED} THEN ${config.taskScoreAlreadyFixed}
+                WHEN ${Task.STATUS_TOO_HARD} THEN ${config.taskScoreTooHard}
+                WHEN ${Task.STATUS_SKIPPED} THEN ${config.taskScoreSkipped}
                 ELSE 0
               END
             ) AS score
@@ -496,7 +498,7 @@ class DataManager @Inject()(config: Config, db:Database)(implicit application:Ap
     *
     * @param start the start date
     * @param end the end date
-    * @param limit limit the number of returned users
+    * @param limit limit the number of returned challenges
     * @param offset paging, starting at 0
     * @return Returns list of leaderboard challenges
     */

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2749,6 +2749,10 @@ GET     /data/user/activity                         @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/user/summary                          @org.maproulette.controllers.api.DataController.getUserSummary(projectList:String ?= "", start:String ?= "", end:String ?= "", survey:Int ?= 0, priority:Int ?= -1)
 ### NoDocs ###
+GET     /data/user/leaderboard                      @org.maproulette.controllers.api.DataController.getUserLeaderboard(start:String ?= "", end:String ?= "", limit:Int ?= 20, offset:Int ?= 0)
+### NoDocs ###
+GET     /data/user/:userId/topChallenges            @org.maproulette.controllers.api.DataController.getUserTopChallenges(userId:Long, start:String ?= "", end:String ?= "", limit:Int ?= 20, offset:Int ?= 0)
+### NoDocs ###
 GET     /data/project/activity                      @org.maproulette.controllers.api.DataController.getProjectActivity(projectList:String ?= "", start:String ?= "", end:String ?= "")
 ### NoDocs ###
 GET     /data/project/summary                       @org.maproulette.controllers.api.DataController.getProjectSummary(projectList:String ?= "")


### PR DESCRIPTION
User leaderboard API retrieves the top scoring users based on task
completion over a specified timeframe. The number of points awarded for
each completed task varies depending on the completion status. Each
user's top challenges, based on activity, are also included in the
response.

User top-challenges API retrieves the top challenges, based on user's
activity, over a specified timeframe.