### PR TITLE
Support challenge difficulty in extendedFind API.

### DIFF
--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -691,6 +691,11 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
         case _ =>
       }
 
+      searchParameters.challengeDifficulty match {
+        case Some(v) if v != -1 => this.appendInWhereClause(whereClause, s"c.difficulty = ${v}")
+        case _ =>
+      }
+
       val query =
         s"""
            |SELECT ${this.retrieveColumns} FROM challenges c

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -692,7 +692,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
       }
 
       searchParameters.challengeDifficulty match {
-        case Some(v) if v != -1 => this.appendInWhereClause(whereClause, s"c.difficulty = ${v}")
+        case Some(v) if v > 0 && v < 4 => this.appendInWhereClause(whereClause, s"c.difficulty = ${v}")
         case _ =>
       }
 

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -27,6 +27,7 @@ case class SearchParameters(projectIds:Option[List[Long]]=None,
                             challengeTagConjunction:Option[Boolean]=None,
                             challengeSearch:Option[String]=None,
                             challengeEnabled:Option[Boolean]=None,
+                            challengeDifficulty:Option[Int]=None,
                             taskTags:Option[List[String]]=None,
                             taskTagConjunction:Option[Boolean]=None,
                             taskSearch:Option[String]=None,
@@ -50,6 +51,11 @@ case class SearchParameters(projectIds:Option[List[Long]]=None,
   def getPriority : Option[Int] = priority match {
     case Some(v) if v == -1 => None
     case _ => priority
+  }
+
+  def getChallengeDifficulty : Option[Int] = challengeDifficulty match {
+    case Some(v) if v == -1 => None
+    case _ => challengeDifficulty
   }
 
   def hasTaskTags : Boolean = taskTags.getOrElse(List.empty).exists(tt => tt.nonEmpty)
@@ -128,6 +134,8 @@ object SearchParameters {
       this.getStringParameter(request.getQueryString("cs"), params.challengeSearch),
       //challengeEnabled
       this.getBooleanParameter(request.getQueryString("ce"), params.challengeEnabled),
+      //challengeDifficulty
+      this.getIntParameter(request.getQueryString("cd"), params.challengeDifficulty),
       //taskTags
       request.getQueryString("tt") match {
         case Some(v) => Some(v.split(",").toList)

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -840,6 +840,9 @@ GET     /challenges/find                            @org.maproulette.controllers
 #   - name: ce
 #     in: query
 #     description: Boolean variable true|false that limits the search by enabled projects only if set to true. Default will is true.
+#   - name: cd
+#     in: query
+#     description: The difficulty level to limit the returned challenges by. Following difficulty Integers can be used. 1 - Easy, 2 - Normal, 3 - Expert, -1 - Any difficulty. Default value is -1.
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 10.


### PR DESCRIPTION
Add support for `cd` query parameter to challenges/extendedFind API for
limiting challenge results by difficulty. Defaults to any difficulty,
preserving existing search behavior in absence of new parameter.