### PR TITLE
Add `data/status/latestActivity` API endpoint.

### DIFF
--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -259,6 +259,23 @@ class DataController @Inject() (sessionManager: SessionManager, challengeDAL: Ch
     }
   }
 
+  /**
+    * Gets the most recent activity entries for each challenge, regardless of date.
+    *
+    * @param projectIds restrict to specified projects
+    * @param challengeIds restrict to specified challenges
+    * @param entries the number of most recent activity entries per challenge. Defaults to 1.
+    * @return most recent activity entries for each challenge
+    */
+  def getLatestChallengeActivity(projectIds:String, challengeIds:String,
+                                 entries:Int) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.dataManager.getLatestChallengeActivity(
+        Utils.toLongList(projectIds), Utils.toLongList(challengeIds), entries
+      )))
+    }
+  }
+
   def getStatusSummary(userIds:String, projectIds:String, challengeIds:String, start:String, end:String,
                        limit:Int, offset:Int) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2782,6 +2782,8 @@ GET     /data/raw/activity                          @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/status/activity                       @org.maproulette.controllers.api.DataController.getStatusActivity(userIds:String ?= "", projectIds:String ?= "", challengeIds:String ?= "", start:String ?= "", end:String ?= "", newStatus:String ?= "", oldStatus:String ?= "", limit:Int ?= 10, page:Int ?= 0)
 ### NoDocs ###
+GET     /data/status/latestActivity                 @org.maproulette.controllers.api.DataController.getLatestChallengeActivity(projectIds:String ?= "", challengeIds:String ?= "", entries:Int ?= 1)
+### NoDocs ###
 GET     /data/status/summary                        @org.maproulette.controllers.api.DataController.getStatusSummary(userIds:String ?= "", projectIds:String ?= "", challengeIds:String ?= "", start:String ?= "", end:String ?= "", limit:Int ?= 10, page:Int ?= 0)
 ###
 # tags: [ User ]


### PR DESCRIPTION
New API endpoint retrieves the most recent activity entries for each
challenge regardless of activity date. Useful for supporting a "latest
activity" metric for challenges without having to worry about how far
back to go with a start date.