### PR TITLE
Add API for csv export of challenge task summaries

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -155,8 +155,16 @@ object Challenge {
   val DIFFICULTY_EXPERT = 3
 
   val PRIORITY_HIGH = 0
+  val PRIORITY_HIGH_NAME = "High"
   val PRIORITY_MEDIUM = 1
+  val PRIORITY_MEDIUM_NAME = "Medium"
   val PRIORITY_LOW = 2
+  val PRIORITY_LOW_NAME = "Low"
+  val priorityMap = Map(
+    PRIORITY_HIGH -> PRIORITY_HIGH_NAME,
+    PRIORITY_MEDIUM -> PRIORITY_MEDIUM_NAME,
+    PRIORITY_LOW -> PRIORITY_LOW_NAME,
+  )
 
   val DEFAULT_ZOOM = 13
   val MIN_ZOOM = 1

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1439,6 +1439,28 @@ GET     /challenge/:id/comments                     @org.maproulette.controllers
 GET     /challenge/:id/comments/extract             @org.maproulette.controllers.api.ChallengeController.extractComments(id:Long, limit:Int ?= -1, page:Int ?= 0)
 ###
 # tags: [ Challenge ]
+# summary: Retrieve summaries of all tasks for Challenge
+# description: This will retrieve summaries of all the tasks of a given challenge and respond with a csv
+# response:
+#   '200':
+#     description: A CSV file containing the following data "TaskID,ChallengeID,TaskName,TaskStatus,TaskPriority,Username"
+#   '404':
+#     description: No Challenge with provided ID found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the challenge
+#     required: true
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0)
+###
+# tags: [ Challenge ]
 # summary: Match OSM Changesets
 # description: This will go through every task and try to match an OSM changeset with the task
 # response:


### PR DESCRIPTION
Add `/challenge/:id/tasks/extract` API endpoint that exports summaries
of the tasks in the given challenge as a CSV file, including: task id, challenge id,
task name, status, priority, and username of user who completed the task
(if completed).