### PR TITLE
Verify project groups in new setUserProjectGroup.

### DIFF
--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -556,6 +556,7 @@ class UserDAL @Inject() (override val db:Database,
     implicit val osmKey = osmID
     implicit val requestingUser = User.superUser
     userGroupDAL.clearUserCache(osmID)
+    this.verifyProjectGroups(projectId)
     this.cacheManager.withUpdatingCache(Long => retrieveByOSMID) { cachedUser =>
       this.withMRTransaction { implicit c =>
         // Remove all groups types for project from user and then add desired group type


### PR DESCRIPTION
In the new setUserProjectGroup method, add call to verify that the
project's groups are setup correctly before proceeding.