### PR TITLE
Add `user/whoami` API endpoint

### DIFF
--- a/app/org/maproulette/controllers/api/UserController.scala
+++ b/app/org/maproulette/controllers/api/UserController.scala
@@ -43,6 +43,12 @@ class UserController @Inject()(userDAL: UserDAL,
     }
   }
 
+  def whoami(): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(user))
+    }
+  }
+
   def getUser(userId: Long): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       if (userId == user.id || userId == user.osmProfile.id) {

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2907,6 +2907,26 @@ GET     /data/status/latestActivity                 @org.maproulette.controllers
 GET     /data/status/summary                        @org.maproulette.controllers.api.DataController.getStatusSummary(userIds:String ?= "", projectIds:String ?= "", challengeIds:String ?= "", start:String ?= "", end:String ?= "", limit:Int ?= 10, page:Int ?= 0)
 ###
 # tags: [ User ]
+# summary: Retrieves current user's JSON information
+# produces: [ application/json ]
+# description: Retrieves current logged-in user's JSON
+# responses:
+#   '200':
+#     description: The current logged-in User
+#     schema:
+#       $ref: '#/definitions/org.maproulette.session.User'
+#   '401':
+#     description: If user is not logged in.
+# parameters:
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+GET     /user/whoami                               @org.maproulette.controllers.api.UserController.whoami()
+###
+# tags: [ User ]
 # summary: Retrieves Users Json information
 # produces: [ application/json ]
 # description: Retrieves User Json based on the supplied ID


### PR DESCRIPTION
New `user/whoami` API endpoint retrieves information on the currently
logged-in user or generates a 401 if no user is logged in. This can be
useful for determining if the user has logged-out behind the back of a
client front-end (or logged-in as a different user) using an alternative
front-end.