### PR TITLE
Remove project from cache before verifying groups.

### DIFF
--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -308,4 +308,18 @@ class ProjectDAL @Inject() (override val db:Database,
         """.as(this.pointParser.*)
     }
   }
+
+  /**
+    * Clears the project cache
+    *
+    * @param id If id is supplied will only remove the project with that id
+    */
+  def clearCache(id:Long = -1) : Unit = {
+    if (id > -1) {
+      this.cacheManager.cache.remove(id)
+    }
+    else {
+      this.cacheManager.clearCaches
+    }
+  }
 }

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -814,6 +814,8 @@ class UserDAL @Inject() (override val db:Database,
     * @param projectId The id of the project you are checking
     */
   private def verifyProjectGroups(projectId:Long) : Unit = {
+    this.projectDAL.clearCache(projectId)
+
     this.projectDAL.retrieveById(projectId) match {
       case Some(p) =>
         val groups = p.groups


### PR DESCRIPTION
When verifying a project's groups to ensure they exist, first remove
that project from the cache to avoid an attempt to duplicate the groups
as a result of stale project data.