### PR TITLE
Add default changeset source field to challenges.

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -109,6 +109,7 @@ class ChallengeController @Inject()(override val childController: TaskController
     jsonBody = Utils.insertIntoJson(jsonBody, "difficulty", Challenge.DIFFICULTY_NORMAL)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "featured", false)(BooleanWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "checkinComment", "")(StringWrites)
+    jsonBody = Utils.insertIntoJson(jsonBody, "checkinSource", "")(StringWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "defaultPriority", Challenge.PRIORITY_HIGH)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "defaultZoom", Challenge.DEFAULT_ZOOM)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "minZoom", Challenge.MIN_ZOOM)(IntWrites)

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -75,7 +75,8 @@ case class ChallengeGeneral(owner:Long,
                             enabled:Boolean=false,
                             challengeType:Int=Actions.ITEM_TYPE_CHALLENGE,
                             featured:Boolean=false,
-                            checkinComment:String="") extends DefaultWrites
+                            checkinComment:String="",
+                            checkinSource:String="") extends DefaultWrites
 case class ChallengeCreation(overpassQL:Option[String]=None, remoteGeoJson:Option[String]=None) extends DefaultWrites
 case class ChallengePriority(defaultPriority:Int=Challenge.PRIORITY_HIGH,
                              highPriorityRule:Option[String]=None,
@@ -213,7 +214,8 @@ object Challenge {
         "enabled" -> boolean,
         "challengeType" -> default(number, Actions.ITEM_TYPE_CHALLENGE),
         "featured" -> default(boolean, false),
-        "checkinComment" -> default(text, "")
+        "checkinComment" -> default(text, ""),
+        "checkinSource" -> default(text, "")
       )(ChallengeGeneral.apply)(ChallengeGeneral.unapply),
       "creation" -> mapping(
         "overpassQL" -> optional(text),

--- a/conf/evolutions/default/18.sql
+++ b/conf/evolutions/default/18.sql
@@ -1,0 +1,7 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add checkin_source column to challenges table
+SELECT add_drop_column('challenges', 'checkin_source', 'character varying');;
+
+# --- !Downs


### PR DESCRIPTION
Add new checkinSource field to challenges for tracking a default
changeset source. This is to support osmlab/maproulette3#361