### PR TITLE
Urlencode error messages sent to mr3 error page.

### DIFF
--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -160,7 +160,7 @@ object MPExceptionUtil {
 
   private def manageUIException(e:Throwable) : Result = {
     Logger.debug(e.getMessage, e)
-    Redirect(s"/mr3/error?errormsg=${e.getMessage}", PERMANENT_REDIRECT).withHeaders(("Cache-Control", "no-cache"))
+    Redirect(s"/mr3/error", Map("errormsg" -> Seq(e.getMessage)), PERMANENT_REDIRECT).withHeaders(("Cache-Control", "no-cache"))
   }
 
   private def manageOldUIException(e:Throwable, user:User, config:Config, dalManager:DALManager)


### PR DESCRIPTION
Use alternate form of Redirect that accepts query parameters as a Map to
ensure that error messages are properly url-encoded when redirecting to
`/mr3/error` page. This addresses the "Invalid header value character"
error that could occur during signin as a result of an error message
containing a newline being added to the Location header unencoded
during the redirect.