### PR TITLE
Updating group handling

### DIFF
--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -830,13 +830,13 @@ class UserDAL @Inject() (override val db:Database,
         val groups = p.groups
         // must contain at least 1 admin group, 1 write group and 1 read group
         if (groups.count(_.groupType == Group.TYPE_ADMIN) < 1) {
-          userGroupDAL.createGroup(projectId, s"${p.name}_Admin", Group.TYPE_ADMIN, User.superUser)
+          userGroupDAL.createGroup(projectId, Group.TYPE_ADMIN, User.superUser)
         }
         if (groups.count(_.groupType == Group.TYPE_WRITE_ACCESS) < 1) {
-          userGroupDAL.createGroup(projectId, s"${p.name}_Write", Group.TYPE_WRITE_ACCESS, User.superUser)
+          userGroupDAL.createGroup(projectId, Group.TYPE_WRITE_ACCESS, User.superUser)
         }
         if (groups.count(_.groupType == Group.TYPE_READ_ONLY) < 1) {
-          userGroupDAL.createGroup(projectId, s"${p.name}_Read", Group.TYPE_READ_ONLY, User.superUser)
+          userGroupDAL.createGroup(projectId, Group.TYPE_READ_ONLY, User.superUser)
         }
       case None => throw new NotFoundException(s"No project found with id $projectId")
     }

--- a/conf/dev.conf
+++ b/conf/dev.conf
@@ -2,7 +2,7 @@ include "application.conf"
 
 db.default {
   pool="bonecp"
-  url="jdbc:postgresql://localhost:5432/02_16_2018_prod?user=osm&password=osm"
+  url="jdbc:postgresql://localhost:5433/osm_db?user=osm&password=osm"
   bonecp.logStatements=true
   bonecp.maxConnectionsPerPartition=200
   bonecp.minConnectionsPerPartition=10

--- a/conf/evolutions/default/19.sql
+++ b/conf/evolutions/default/19.sql
@@ -1,0 +1,8 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Remove unique index on Groups
+DROP INDEX IF EXISTS idx_groups_name;
+SELECT create_index_if_not_exists('groups', 'project_id_group_type', '(project_id, group_type)');;
+
+# --- !Downs


### PR DESCRIPTION
There was a very minor edge case discovered where group names were being duplicated causing the group to not be created because of the unique index on the name column. The name of a group is not required to be unique and has no bearing on the group or the creation of it. So the index was removed. The name of the group that was being created was also moved to the base function, instead of allowing the higher level function to name the group.