### PR TITLE
Use same tag-creation connection to retrieve tags.

### DIFF
--- a/app/org/maproulette/models/dal/TagDAL.scala
+++ b/app/org/maproulette/models/dal/TagDAL.scala
@@ -201,7 +201,7 @@ class TagDAL @Inject() (override val db:Database,
             Seq[NamedParameter]("name" -> tag.name.toLowerCase, "description" -> descriptionString, "id" -> tag.id)
           })
           BatchSql(sqlQuery, parameters.head, parameters.tail: _*).execute()
-          this.retrieveListByName(names)
+          this.retrieveListByName(names, -1, c)
         }
       }
     } else {


### PR DESCRIPTION
Fix issue where new tags created with a challenge update weren't being
added to the challenge because they were being retrieved using a
different connection and therefore outside of the transaction with no
visibility of the new tags.