### PR TITLE
Add optional identifier for default basemaps

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -86,6 +86,7 @@ case class ChallengeExtra(defaultZoom:Int=Challenge.DEFAULT_ZOOM,
                           minZoom:Int=Challenge.MIN_ZOOM,
                           maxZoom:Int=Challenge.MAX_ZOOM,
                           defaultBasemap:Option[Int]=None,
+                          defaultBasemapId:Option[String]=None,
                           customBasemap:Option[String]=None,
                           updateTasks:Boolean=false) extends DefaultWrites
 
@@ -232,6 +233,7 @@ object Challenge {
         "minZoom" -> default(number, MIN_ZOOM),
         "maxZoom" -> default(number, MAX_ZOOM),
         "defaultBasemap" -> optional(number),
+        "defaultBasemapId" -> optional(text),
         "customBasemap" -> optional(text),
         "updateTasks" -> default(boolean, false)
       )(ChallengeExtra.apply)(ChallengeExtra.unapply),

--- a/app/org/maproulette/session/User.scala
+++ b/app/org/maproulette/session/User.scala
@@ -82,6 +82,7 @@ case class ProjectManager(projectId: Long,
   *
   * @param defaultEditor     The default editor that the user wants to use
   * @param defaultBasemap    The default basemap that the user wants to see, will be overridden by default basemap for the challenge if set
+  * @param defaultBasemapId  The string id of the default basemap that the user wants to see
   * @param customBasemap     It default basemap is custom, then this is the url to the tile server
   * @param locale            The locale for the user, if not set will default to en
   * @param emailOptIn        If the user has opted in to receive emails
@@ -92,6 +93,7 @@ case class ProjectManager(projectId: Long,
   */
 case class UserSettings(defaultEditor: Option[Int] = None,
                         defaultBasemap: Option[Int] = None,
+                        defaultBasemapId: Option[String] = None,
                         customBasemap: Option[String] = None,
                         locale: Option[String] = None,
                         emailOptIn: Option[Boolean] = None,
@@ -301,6 +303,7 @@ object User {
     mapping(
       "defaultEditor" -> optional(number),
       "defaultBasemap" -> optional(number),
+      "defaultBasemapId" -> optional(text),
       "customBasemap" -> optional(text),
       "locale" -> optional(text),
       "emailOptIn" -> optional(boolean),

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -72,6 +72,7 @@ class UserDAL @Inject() (override val db:Database,
       get[String]("users.oauth_secret") ~
       get[Option[Int]]("users.default_editor") ~
       get[Option[Int]]("users.default_basemap") ~
+      get[Option[String]]("users.default_basemap_id") ~
       get[Option[String]]("users.custom_basemap_url") ~
       get[Option[Boolean]]("users.email_opt_in") ~
       get[Option[Boolean]]("users.leaderboard_opt_out") ~
@@ -79,7 +80,7 @@ class UserDAL @Inject() (override val db:Database,
       get[Option[Int]]("users.theme") ~
       get[Option[String]]("properties") map {
       case id ~ osmId ~ created ~ modified ~ osmCreated ~ displayName ~ description ~ avatarURL ~
-        homeLocation ~ apiKey ~ oauthToken ~ oauthSecret ~ defaultEditor ~ defaultBasemap ~
+        homeLocation ~ apiKey ~ oauthToken ~ oauthSecret ~ defaultEditor ~ defaultBasemap ~ defaultBasemapId ~
         customBasemap ~ emailOptIn ~ leaderboardOptOut ~ locale ~ theme ~ properties =>
         val locationWKT = homeLocation match {
           case Some(wkt) => new WKTReader().read(wkt).asInstanceOf[Point]
@@ -105,7 +106,7 @@ class UserDAL @Inject() (override val db:Database,
             userGroupDAL.getUserGroups(osmId, User.superUser
           ),
           decryptedKey, false,
-          UserSettings(defaultEditor, defaultBasemap, customBasemap, locale, emailOptIn, leaderboardOptOut, theme),
+          UserSettings(defaultEditor, defaultBasemap, defaultBasemapId, customBasemap, locale, emailOptIn, leaderboardOptOut, theme),
           properties
         )
     }
@@ -376,6 +377,7 @@ class UserDAL @Inject() (override val db:Database,
         val ewkt = new WKTWriter().write(new GeometryFactory().createPoint(new Coordinate(latitude, longitude)))
         val defaultEditor = (value \ "settings" \ "defaultEditor").asOpt[Int].getOrElse(cachedItem.settings.defaultEditor.getOrElse(-1))
         val defaultBasemap = (value \ "settings" \ "defaultBasemap").asOpt[Int].getOrElse(cachedItem.settings.defaultBasemap.getOrElse(-1))
+        val defaultBasemapId = (value \ "settings" \ "defaultBasemapId").asOpt[String].getOrElse(cachedItem.settings.defaultBasemapId.getOrElse(""))
         val customBasemap = (value \ "settings" \ "customBasemap").asOpt[String].getOrElse(cachedItem.settings.customBasemap.getOrElse(""))
         val locale = (value \ "settings" \ "locale").asOpt[String].getOrElse(cachedItem.settings.locale.getOrElse("en"))
         val emailOptIn = (value \ "settings" \ "emailOptIn").asOpt[Boolean].getOrElse(cachedItem.settings.emailOptIn.getOrElse(false))
@@ -389,7 +391,7 @@ class UserDAL @Inject() (override val db:Database,
         val query = s"""UPDATE users SET api_key = {apiKey}, name = {name}, description = {description},
                                           avatar_url = {avatarURL}, oauth_token = {token}, oauth_secret = {secret},
                                           home_location = ST_SetSRID(ST_GeomFromEWKT({wkt}),4326), default_editor = {defaultEditor},
-                                          default_basemap = {defaultBasemap}, custom_basemap_url = {customBasemap},
+                                          default_basemap = {defaultBasemap}, default_basemap_id = {defaultBasemapId}, custom_basemap_url = {customBasemap},
                                           locale = {locale}, email_opt_in = {emailOptIn}, leaderboard_opt_out = {leaderboardOptOut},
                                           theme = {theme}, properties = {properties}
                         WHERE id = {id} RETURNING ${this.retrieveColumns}"""
@@ -404,6 +406,7 @@ class UserDAL @Inject() (override val db:Database,
           'id -> id,
           'defaultEditor -> defaultEditor,
           'defaultBasemap -> defaultBasemap,
+          'defaultBasemapId -> defaultBasemapId,
           'customBasemap -> customBasemap,
           'locale -> locale,
           'emailOptIn -> emailOptIn,

--- a/conf/evolutions/default/20.sql
+++ b/conf/evolutions/default/20.sql
@@ -1,0 +1,10 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add default_basemap_id column to challenges and users tables
+SELECT add_drop_column('challenges', 'default_basemap_id', 'character varying');;
+SELECT add_drop_column('users', 'default_basemap_id', 'character varying');;
+
+# --- !Downs
+
+


### PR DESCRIPTION
Add `default_basemap_id` to challenges and users that can be used to provide (string) layer identifiers to support additional default basemap layers such as those from the [OSM Editor Layer Index](https://github.com/osmlab/editor-layer-index) project.