### PR TITLE
Store encrypted form of user apiKey in cache

### DIFF
--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -75,7 +75,9 @@ class SessionManager @Inject() (ws:WSClient, dalManager: DALManager, config:Conf
   }
 
   def retrieveUser(username:String, apiKey:String) : Option[User] = {
-    dalManager.user.retrieveByUsernameAndAPIKey(username, apiKey)
+    val apiSplit = apiKey.split("\\|")
+    val encryptedApiKey = crypto.encrypt(apiSplit(1))
+    dalManager.user.retrieveByUsernameAndAPIKey(username, encryptedApiKey)
   }
 
   /**

--- a/app/org/maproulette/session/User.scala
+++ b/app/org/maproulette/session/User.scala
@@ -4,14 +4,16 @@ package org.maproulette.session
 
 import java.util.{Locale, UUID}
 
+import play.api.Logger
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+import javax.crypto.{BadPaddingException, IllegalBlockSizeException}
 import org.maproulette.Config
 import org.maproulette.actions.{ItemType, UserType}
 import org.maproulette.models.BaseObject
-import org.maproulette.utils.Utils
+import org.maproulette.utils.{Crypto, Utils}
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.json._
@@ -282,6 +284,23 @@ object User {
   )
 
   val superGroup: Group = Group(DEFAULT_GROUP_ID, "SUPERUSERS", 0, Group.TYPE_SUPER_USER)
+
+  def withDecryptedAPIKey(user: User)(implicit crypto: Crypto): User = {
+    user.apiKey match {
+      case Some(key) if key.nonEmpty =>
+        try {
+          val decryptedAPIKey = Some(s"${user.id}|${crypto.decrypt(key)}")
+          new User(user.id, user.created, user.modified, user.osmProfile, user.groups,
+                   decryptedAPIKey, user.guest, user.settings, user.properties)
+        } catch {
+          case _:BadPaddingException | _:IllegalBlockSizeException =>
+            Logger.debug("Invalid key found, could be that the application secret on server changed.")
+            user
+          case e:Throwable => throw e
+        }
+      case _ => user
+    }
+  }
 
   /**
     * Simple helper function that if the provided Option[User] is None, will return a guest

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -85,26 +85,13 @@ class UserDAL @Inject() (override val db:Database,
           case Some(wkt) => new WKTReader().read(wkt).asInstanceOf[Point]
           case None => new GeometryFactory().createPoint(new Coordinate(0, 0))
         }
-        // decrypt the API key if there is one.
-        val decryptedKey = apiKey match {
-          case Some(key) if key.nonEmpty =>
-            try {
-              Some(s"$id|${crypto.decrypt(key)}")
-            } catch {
-              case _:BadPaddingException | _:IllegalBlockSizeException =>
-                Logger.debug("Invalid key found, could be that the application secret on server changed.")
-                None
-              case e:Throwable => throw e
-            }
-          case _ => None
-        }
 
         new User(id, created, modified,
           OSMProfile(osmId, displayName, description.getOrElse(""), avatarURL.getOrElse(""),
             Location(locationWKT.getX, locationWKT.getY), osmCreated, RequestToken(oauthToken, oauthSecret)),
             userGroupDAL.getUserGroups(osmId, User.superUser
           ),
-          decryptedKey, false,
+          apiKey, false,
           UserSettings(defaultEditor, defaultBasemap, customBasemap, locale, emailOptIn, leaderboardOptOut, theme),
           properties
         )
@@ -361,10 +348,6 @@ class UserDAL @Inject() (override val db:Database,
     this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit cachedItem =>
       this.permission.hasObjectAdminAccess(cachedItem, user)
       this.withMRTransaction { implicit c =>
-        val apiKey = (value \ "apiKey").asOpt[String].getOrElse(cachedItem.apiKey.getOrElse("")) match {
-          case "" => this.generateAPIKey
-          case v => crypto.encrypt(v) //cached value will be unencrypted so need to make sure we re-encrypt for the db
-        }
         val displayName = (value \ "osmProfile" \ "displayName").asOpt[String].getOrElse(cachedItem.osmProfile.displayName)
         val description = (value \ "osmProfile" \ "description").asOpt[String].getOrElse(cachedItem.osmProfile.description)
         val avatarURL = (value \ "osmProfile" \ "avatarURL").asOpt[String].getOrElse(cachedItem.osmProfile.avatarURL)
@@ -386,7 +369,7 @@ class UserDAL @Inject() (override val db:Database,
         this.updateGroups(value, user)
         this.userGroupDAL.clearUserCache(cachedItem.osmProfile.id)
 
-        val query = s"""UPDATE users SET api_key = {apiKey}, name = {name}, description = {description},
+        val query = s"""UPDATE users SET name = {name}, description = {description},
                                           avatar_url = {avatarURL}, oauth_token = {token}, oauth_secret = {secret},
                                           home_location = ST_SetSRID(ST_GeomFromEWKT({wkt}),4326), default_editor = {defaultEditor},
                                           default_basemap = {defaultBasemap}, custom_basemap_url = {customBasemap},
@@ -394,7 +377,6 @@ class UserDAL @Inject() (override val db:Database,
                                           theme = {theme}, properties = {properties}
                         WHERE id = {id} RETURNING ${this.retrieveColumns}"""
         SQL(query).on(
-          'apiKey -> crypto.encrypt(apiKey),
           'name -> displayName,
           'description -> description,
           'avatarURL -> avatarURL,
@@ -639,9 +621,17 @@ class UserDAL @Inject() (override val db:Database,
     * @param apiKeyUser The user that is requesting that their key be updated.
     * @return An optional variable that will contain the updated user if successful
     */
-  def generateAPIKey(apiKeyUser:User, user:User) : Option[User] = {
+  def generateAPIKey(apiKeyUser:User, user:User)(implicit c:Connection=null) : Option[User] = {
     this.permission.hasAdminAccess(UserType(), user)(apiKeyUser.id)
-    this.update(Json.parse(s"""{"apiKey":"${this.generateAPIKey}"}"""), User.superUser)(apiKeyUser.id)
+
+    implicit val id = apiKeyUser.id
+    this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit cachedItem =>
+      this.withMRTransaction { implicit c =>
+        val newAPIKey = crypto.encrypt(this.generateAPIKey)
+        val query = s"""UPDATE users SET api_key = {apiKey} WHERE id = {id} RETURNING ${this.retrieveColumns}"""
+        SQL(query).on('apiKey -> newAPIKey, 'id -> apiKeyUser.id).as(this.parser.*).headOption
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
* Store encrypted form of user apiKey (as it appears in database) in cache instead of decrypted form, alleviating the need to explicitly decrypt the apiKey in queries that pull back user data

* Do not allow apiKey to be updated as part of a generic user update; API keys must instead be explicitly reset

* Fixes osmlab/maproulette3#442