### PR TITLE
Add GET challenges/listing API endpoint

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -72,6 +72,7 @@ class ChallengeController @Inject()(override val childController: TaskController
   implicit val taskClusterWrites = TaskCluster.taskClusterWrites
   implicit val searchParameterWrites = SearchParameters.paramsWrites
   implicit val searchLocationWrites = SearchParameters.locationWrites
+  implicit val challengeListingWrites: Writes[ChallengeListing] = Json.writes[ChallengeListing]
 
   override def dalWithTags: TagDALMixin[Challenge] = dal
 
@@ -419,6 +420,21 @@ class ChallengeController @Inject()(override val childController: TaskController
           Ok(Json.toJson(jsonList))
         }
       }
+    }
+  }
+
+  /**
+    * Retrieves a lightweight listing of the challenges in the given project(s).
+    *
+    * @param projectIds comma-separated list of projects
+    * @param limit limits the amount of results returned
+    * @param page paging mechanism for limited results
+    * @param onlyEnabled determines if results are restricted to enabled challenges projects
+    * @return A list of challenges
+    */
+  def listing(projectIds:String, limit:Int, page:Int, onlyEnabled:Boolean) : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.dal.listing(Utils.toLongList(projectIds), limit, page, onlyEnabled)))
     }
   }
 

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -88,6 +88,10 @@ case class ChallengeExtra(defaultZoom:Int=Challenge.DEFAULT_ZOOM,
                           defaultBasemap:Option[Int]=None,
                           customBasemap:Option[String]=None,
                           updateTasks:Boolean=false) extends DefaultWrites
+case class ChallengeListing(id:Long,
+                            parent:Long,
+                            name:String,
+                            enabled:Boolean)
 
 /**
   * The ChallengeFormFix case class is built so that we can nest the form objects as there is a limit

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -877,6 +877,39 @@ GET     /challenges/find                            @org.maproulette.controllers
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
 GET     /challenges/extendedFind                    @org.maproulette.controllers.api.ChallengeController.extendedFind(limit:Int ?= 10, page:Int ?= 0)
+
+###
+# tags: [ Challenge ]
+# summary: List challenges in specified projects
+# produces: [ application/json ]
+# description: Retrieves a lightweight listing of challenges, with just a few basic fields for each, that belong to the specified project(s).
+# responses:
+#   '200':
+#     description: A listing of challenges containing a few basic fields for each.
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.models.ChallengeListing'
+# parameters:
+#   - name: projectIds
+#     in: query
+#     description: Comma-separated list of project ids for which child challenges are desired. Default value is empty string, ie. all projects.
+#   - name: parentId
+#     in: query
+#     description: This field will be ignored for this request
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+#   - name: onlyEnabled
+#     in: query
+#     description: Flag to set if only wanting enabled Challenges returned. Default value is true.
+###
+GET     /challenges/listing                         @org.maproulette.controllers.api.ChallengeController.listing(projectIds:String ?= "", limit:Int ?= 10, page:Int ?= 0, onlyEnabled:Boolean ?= true)
+###
 ###
 # tags: [ Challenge ]
 # summary: Move Challenge to another Project


### PR DESCRIPTION
Add `challenges/listing` API endpoint that can be used to retrieve a lightweight listing of challenges across projects, with each challenge entry containing a minimal set of fields (id, parent, name, enabled).

This is to support better administrative visibility into challenges under management, while trying keeping overhead reasonable for users managing a large number of challenges.