### PR TITLE
Add last_task_refresh column to challenges

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -106,6 +106,7 @@ case class Challenge(override val id:Long,
                      extra:ChallengeExtra,
                      status:Option[Int]=Some(0),
                      statusMessage:Option[String]=None,
+                     lastTaskRefresh:Option[DateTime]=None,
                      location:Option[String]=None,
                      bounding:Option[String]=None) extends BaseObject[Long] with DefaultWrites {
 
@@ -237,6 +238,7 @@ object Challenge {
       )(ChallengeExtra.apply)(ChallengeExtra.unapply),
       "status" -> default(optional(number), None),
       "statusMessage" -> optional(text),
+      "lastTaskRefresh" -> optional(jodaDate),
       "location" -> default(optional(text), None),
       "bounding" -> default(optional(text), None)
     )(Challenge.apply)(Challenge.unapply)

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -41,6 +41,7 @@ trait ChallengeWrites {
     JsPath.write[ChallengeExtra] and
     (JsPath \ "status").writeNullable[Int] and
     (JsPath \ "statusMessage").writeNullable[String] and
+    (JsPath \ "lastTaskRefresh").writeNullable[DateTime] and
     (JsPath \ "location").writeNullable[String](new jsonWrites("location")) and
     (JsPath \ "bounding").writeNullable[String](new jsonWrites("bounding"))
   )(unlift(Challenge.unapply))
@@ -66,6 +67,7 @@ trait ChallengeReads extends DefaultReads {
     JsPath.read[ChallengeExtra] and
     (JsPath \ "status").readNullable[Int] and
     (JsPath \ "statusMessage").readNullable[String] and
+    (JsPath \ "lastTaskRefresh").readNullable[DateTime] and
     (JsPath \ "location").readNullable[String](new jsonReads("location")) and
     (JsPath \ "bounding").readNullable[String](new jsonReads("bounding"))
   )(Challenge.apply _)

--- a/conf/evolutions/default/21.sql
+++ b/conf/evolutions/default/21.sql
@@ -1,0 +1,9 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add last_task_refresh column to challenges table
+ALTER TABLE "challenges" ADD COLUMN last_task_refresh TIMESTAMP WITH TIME ZONE;;
+UPDATE challenges c SET last_task_refresh=created WHERE last_task_refresh IS NULL AND 0 < (SELECT COUNT(*) FROM tasks t WHERE t.parent_id = c.id LIMIT 1);;
+
+# --- !Downs
+ALTER TABLE "challenges" DROP COLUMN last_task_refresh;;


### PR DESCRIPTION
* This is the backend work to address osmlab/maproulette3#468

* Add `last_task_refresh` column to challenges that tracks the date when task data is added to the challenge, and is updated when task data is refreshed from an Overpass query

* The evolution initially sets `last_task_refresh` on existing challenges (that have at least 1 task) to the challenge's `created` date