### PR TITLE
Add hotness/popularity scoring to challenges

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -289,6 +289,19 @@ class ChallengeController @Inject()(override val childController: TaskController
     }
   }
 
+  /**
+    * Gets the hot (recently popular) challenges
+    *
+    * @param limit  The number of challenges to get
+    * @param offset The offset
+    * @return A Json array with the hot challenges
+    */
+  def getHotChallenges(limit: Int, offset: Int): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(Json.toJson(this.dal.getHotChallenges(limit, offset)))
+    }
+  }
+
   def updateTaskPriorities(challengeId: Long): Action[AnyContent] = Action.async { implicit request =>
     implicit val requireSuperUser = true
     this.sessionManager.authenticatedRequest { implicit user =>

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -75,6 +75,7 @@ case class ChallengeGeneral(owner:Long,
                             enabled:Boolean=false,
                             challengeType:Int=Actions.ITEM_TYPE_CHALLENGE,
                             featured:Boolean=false,
+                            popularity:Option[Int]=None,
                             checkinComment:String="",
                             checkinSource:String="") extends DefaultWrites
 case class ChallengeCreation(overpassQL:Option[String]=None, remoteGeoJson:Option[String]=None) extends DefaultWrites
@@ -214,6 +215,7 @@ object Challenge {
         "enabled" -> boolean,
         "challengeType" -> default(number, Actions.ITEM_TYPE_CHALLENGE),
         "featured" -> default(boolean, false),
+        "popularity" -> optional(number),
         "checkinComment" -> default(text, ""),
         "checkinSource" -> default(text, "")
       )(ChallengeGeneral.apply)(ChallengeGeneral.unapply),

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -4,6 +4,7 @@ package org.maproulette.models.dal
 
 import java.sql.Connection
 import javax.inject.{Inject, Provider, Singleton}
+import java.time.Instant
 
 import anorm.SqlParser._
 import anorm._
@@ -424,6 +425,12 @@ class TaskDAL @Inject()(override val db: Database,
           this.matchToOSMChangeSet(task.copy(status = Some(status)), user)
         }
       }
+
+      // Update the popularity score on the parent challenge
+      Future {
+        this.challengeDAL.get().updatePopularity(Instant.now().getEpochSecond())(task.parent)
+      }
+
       updatedRows
     }
 

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -994,6 +994,28 @@ DELETE  /challenge/:id/tags                         @org.maproulette.controllers
 GET     /challenges/featured                        @org.maproulette.controllers.api.ChallengeController.getFeaturedChallenges(limit:Int ?= 10, page:Int ?= 0)
 ###
 # tags: [ Challenge ]
+# summary: Hottest Challenges.
+# produces: [ application/json ]
+# description: Get the hottest (recently popular) challenges
+# responses:
+#   '200':
+#     description: A list of all the hottest Challenges in order of recent popularity
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.models.Challenge'
+# parameters:
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /challenges/hot                             @org.maproulette.controllers.api.ChallengeController.getHotChallenges(limit:Int ?= 10, page:Int ?= 0)
+###
+# tags: [ Challenge ]
 # summary: List all the Challenges.
 # produces: [ application/json ]
 # description: Lists all the Challenges in the system

--- a/conf/evolutions/default/22.sql
+++ b/conf/evolutions/default/22.sql
@@ -1,0 +1,25 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add popularity column to challenges
+ALTER TABLE "challenges" ADD COLUMN popularity INT DEFAULT FLOOR(EXTRACT(epoch from NOW()));;
+
+-- Calculate initial popularity scores
+-- Very basic scoring for popularity p: p = (p + t) / 2 where t is timestamp
+-- Initial score set to created timestamp of challenge
+UPDATE challenges SET popularity=FLOOR(EXTRACT(epoch from created));;
+
+DO $$ DECLARE completion_action RECORD;;
+BEGIN
+  FOR completion_action IN SELECT challenge_id, FLOOR(EXTRACT(epoch FROM created)) AS createdts FROM status_actions
+                           WHERE old_status != status AND status > 0 AND status < 8 ORDER BY created ASC
+  LOOP
+    UPDATE challenges SET popularity = ((popularity + completion_action.createdts) / 2)
+    WHERE id = completion_action.challenge_id;;
+  END LOOP;;
+END$$;;
+
+SELECT create_index_if_not_exists('challenges', 'popularity', '(popularity)');;
+
+# --- !Downs
+ALTER TABLE "challenges" DROP COLUMN popularity;;


### PR DESCRIPTION
* Back-end work to address osmlab/maproulette3#447

* Add migration that adds new popularity column to challenges table and
retroactively computes popularity scores for existing challenges based
on historical task completion activity

* Add `challenges/hot` API endpoint that retrieves the hottest
challenges at present

> Note that the migration takes a little while to run, depending on the number of rows in the status_actions table (I would estimate around 15 minutes per million rows on modern consumer hardware).