### PR TITLE
New STATUS_FINISHED for challenges with no more incomplete tasks

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -260,6 +260,7 @@ object Challenge {
   val STATUS_NA = 0
   val STATUS_BUILDING = 1
   val STATUS_FAILED = 2
-  val STATUS_COMPLETE = 3
+  val STATUS_READY = 3
   val STATUS_PARTIALLY_LOADED = 4
+  val STATUS_FINISHED = 5
 }

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -597,7 +597,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
     this.withMRConnection { implicit c =>
       this.retrieveById(id) match {
         case Some(challenge) =>
-          if (challenge.status.get != Challenge.STATUS_FINISHED) {
+          if (challenge.status.get == Challenge.STATUS_READY) {
             this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit item =>
               // If the challenge has no tasks in the created status it need to be marked finished.
               val updateStatusQuery =
@@ -628,7 +628,7 @@ class ChallengeDAL @Inject() (override val db:Database, taskDAL: TaskDAL,
     this.withMRConnection { implicit c =>
       this.retrieveById(id) match {
         case Some(challenge) =>
-          if (challenge.status.get != Challenge.STATUS_READY) {
+          if (challenge.status.get == Challenge.STATUS_FINISHED) {
             this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit item =>
               // If the challenge was finished and any tasks were reset back to created
               // we need to set the challenge status back to ready

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -435,6 +435,8 @@ class TaskDAL @Inject()(override val db: Database,
     }
 
     this.cacheManager.withOptionCaching { () => Some(task.copy(status = Some(status))) }
+    this.challengeDAL.get().updateFinishedStatus()(task.parent)
+
     updatedRows
   }
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -194,13 +194,22 @@ class TaskDAL @Inject()(override val db: Database,
       val geometries = (value \ "geometries").asOpt[String].getOrElse(cachedItem.geometries)
       val changesetId = (value \ "changesetId").asOpt[Long].getOrElse(cachedItem.changesetId.getOrElse(-1L))
 
-      this.mergeUpdate(cachedItem.copy(name = name,
+      val task = this.mergeUpdate(cachedItem.copy(name = name,
         parent = parentId,
         instruction = Some(instruction),
         status = Some(status),
         geometries = geometries,
         priority = priority,
         changesetId = Some(changesetId)), user)
+
+      if (status == Task.STATUS_CREATED) {
+        this.challengeDAL.get().updateReadyStatus()(parentId)
+      }
+      else {
+        this.challengeDAL.get().updateFinishedStatus()(parentId)
+      }
+
+      task
     }
   }
 

--- a/app/org/maproulette/services/ChallengeService.scala
+++ b/app/org/maproulette/services/ChallengeService.scala
@@ -59,7 +59,7 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
               if (failedLines.nonEmpty) {
                 this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_PARTIALLY_LOADED, "statusMessage" -> s"GeoJSON lines [${failedLines.mkString(",")}] failed to parse"), user)(challenge.id)
               } else {
-                this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_COMPLETE), user)(challenge.id)
+                this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(challenge.id)
                 this.challengeDAL.markTasksRefreshed()(challenge.id)
               }
             } else {
@@ -140,7 +140,7 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
           val splitJson = resp.body.split("\n")
           if (this.isLineByLineGeoJson(splitJson)) {
             splitJson.foreach(line => this.createNewTask(user, UUID.randomUUID().toString, challenge, Json.parse(line)))
-            this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_COMPLETE), user)(challenge.id)
+            this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(challenge.id)
             this.challengeDAL.markTasksRefreshed()(challenge.id)
           } else {
             this.createTasksFromFeatures(user, challenge, Json.parse(resp.body))
@@ -152,13 +152,13 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
         if (seqJSON) {
           this.buildTasksFromRemoteJson(filePrefix, fileNumber + 1, challenge, user)
         } else {
-          this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_COMPLETE), user)(challenge.id)
+          this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(challenge.id)
           this.challengeDAL.markTasksRefreshed()(challenge.id)
         }
       case Failure(f) =>
         if (fileNumber > 1) {
           // todo need to figure out if actual failure or if not finding the next file
-          this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_COMPLETE), user)(challenge.id)
+          this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(challenge.id)
         } else {
           this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_FAILED, "StatusMessage" -> f.getMessage), user)(challenge.id)
         }
@@ -196,7 +196,7 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
         }
       }
 
-      this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_COMPLETE), user)(parent.id)
+      this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(parent.id)
       this.challengeDAL.markTasksRefreshed()(parent.id)
       if (single) {
         this.createNewTask(user, UUID.randomUUID().toString, parent, jsonData) match {
@@ -274,7 +274,7 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
                   case true =>
                     this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_PARTIALLY_LOADED), user)(challenge.id)
                   case false =>
-                    this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_COMPLETE), user)(challenge.id)
+                    this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(challenge.id)
                     this.challengeDAL.markTasksRefreshed(true)(challenge.id)
                 }
               }

--- a/app/views/admin/challenge.scala.html
+++ b/app/views/admin/challenge.scala.html
@@ -135,8 +135,8 @@
         getChallenge(itemId, function(data) {
             if (data.status == "@{Challenge.STATUS_BUILDING}") {
                 $("#statusName_" + itemId).html("@messages(s"challenge.column.status.${Challenge.STATUS_BUILDING}")");
-            } else if (data.status == "@{Challenge.STATUS_COMPLETE}") {
-                $("#statusName_" + itemId).html("@messages(s"challenge.column.status.${Challenge.STATUS_COMPLETE}")");
+            } else if (data.status == "@{Challenge.STATUS_READY}") {
+                $("#statusName_" + itemId).html("@messages(s"challenge.column.status.${Challenge.STATUS_READY}")");
             } else if (data.status == "@{Challenge.STATUS_FAILED}") {
                 $("#statusName_" + itemId).html("@messages(s"challenge.column.status.${Challenge.STATUS_FAILED}")");
             } else if (data.status == "@{Challenge.STATUS_PARTIALLY_LOADED}") {

--- a/conf/evolutions/default/23.sql
+++ b/conf/evolutions/default/23.sql
@@ -1,0 +1,9 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Updates all challenges to a STATUS_FINISHED that have no incomplete tasks
+UPDATE challenges c SET status=5 WHERE c.status=3 AND
+          0=(SELECT COUNT(*) AS total FROM tasks
+          WHERE tasks.parent_id=c.id AND status=0)
+
+# --- !Downs


### PR DESCRIPTION
* Rename STATUS_COMPLETE to STATUS_READY to avoid potential confusion

* setTaskStatus sets challenge status to STATUS_FINISHED if no more tasks
remain with CREATED status

* Add evolution that sets existing challenges to STATUS_FINISHED if their tasks
are all complete