### PR TITLE
Change project find to use fuzzySearch for display_name

### DIFF
--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -163,7 +163,7 @@ class ProjectDAL @Inject() (override val db:Database,
     this.withMRConnection { implicit c =>
       val query = s"""SELECT ${this.retrieveColumns} FROM ${this.tableName}
                       WHERE ${this.searchField("name")(None)} OR
-                      ${this.searchField("display_name")(None)} ${this.enabled(onlyEnabled)}
+                      ${this.fuzzySearch("display_name")(None)} ${this.enabled(onlyEnabled)}
                       ${this.parentFilter(parentId)}
                       ${this.order(orderColumn=Some(orderColumn), orderDirection=orderDirection, nameFix=true)}
                       LIMIT ${this.sqlLimit(limit)} OFFSET {offset}"""


### PR DESCRIPTION
Change when finding projects by name to use fuzzySearch for the display_name part of the query.