### PR TITLE
Don't attempt to create tasks from null geometry

### DIFF
--- a/app/org/maproulette/services/ChallengeService.scala
+++ b/app/org/maproulette/services/ChallengeService.scala
@@ -231,7 +231,11 @@ class ChallengeService @Inject() (challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
     try {
       val createdTasks = featureList.flatMap { value =>
         if (!single) {
-          this.createNewTask(user, taskNameFromJsValue(value), parent, (value \ "geometry").as[JsObject], getProperties(value, "properties"))
+          (value \ "geometry").asOpt[JsObject] match {
+            case Some(geometry) =>
+              this.createNewTask(user, taskNameFromJsValue(value), parent, geometry, getProperties(value, "properties"))
+            case None => None // skip task if no geometry
+          }
         } else {
           None
         }


### PR DESCRIPTION
When creating a challenge, skip creation of tasks from features with
null geometry. This is done silently, with no warning sent back to the
caller. Fixes osmlab/maproulette3#551