### PR TITLE
Remove properties from user insert on login. Fixes #481

### DIFF
--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -273,12 +273,11 @@ class UserDAL @Inject() (override val db:Database,
 
       val query = s"""WITH upsert AS (UPDATE users SET osm_id = {osmID}, osm_created = {osmCreated},
                               name = {name}, description = {description}, avatar_url = {avatarURL},
-                              oauth_token = {token}, oauth_secret = {secret},  home_location = ST_GeomFromEWKT({wkt}),
-                              properties = {properties}
+                              oauth_token = {token}, oauth_secret = {secret},  home_location = ST_GeomFromEWKT({wkt})
                             WHERE id = {id} OR osm_id = {osmID} RETURNING ${this.retrieveColumns})
             INSERT INTO users (api_key, osm_id, osm_created, name, description,
-                               avatar_url, oauth_token, oauth_secret, home_location, properties)
-            SELECT {apiKey}, {osmID}, {osmCreated}, {name}, {description}, {avatarURL}, {token}, {secret}, ST_GeomFromEWKT({wkt}), {properties}
+                               avatar_url, oauth_token, oauth_secret, home_location)
+            SELECT {apiKey}, {osmID}, {osmCreated}, {name}, {description}, {avatarURL}, {token}, {secret}, ST_GeomFromEWKT({wkt})
             WHERE NOT EXISTS (SELECT * FROM upsert)"""
       SQL(query).on(
         'apiKey -> newAPIKey,
@@ -290,8 +289,7 @@ class UserDAL @Inject() (override val db:Database,
         'token -> item.osmProfile.requestToken.token,
         'secret -> item.osmProfile.requestToken.secret,
         'wkt -> s"SRID=4326;$ewkt",
-        'id -> item.id,
-        'properties -> item.properties
+        'id -> item.id
       ).executeUpdate()
     }
     // just in case expire the osm ID


### PR DESCRIPTION
When a user logs in the insert method is called on UserDAL
with the OSM xml data. The OSM xml data does not include
any kind of properties so consequently the properties field
was always overwritten to empty in the DB. Since we only
need to store the OSM data with this method we do not need
to insert/update the properties field and can ignore it.