### PR TITLE
Add Challenge Status search parameter for extendedFind

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -416,10 +416,10 @@ class ChallengeController @Inject()(override val childController: TaskController
     * @param page paging mechanism for limited results
     * @return A list of challenges matching the query string parameters
     */
-  def extendedFind(limit:Int, page:Int, sort:String) : Action[AnyContent] = Action.async { implicit request =>
+  def extendedFind(limit:Int, page:Int, sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
-        val challenges = this.dal.extendedFind(params, limit, page, sort)
+        val challenges = this.dal.extendedFind(params, limit, page, sort, order)
         if (challenges.isEmpty) {
           Ok(Json.toJson(List[JsValue]()))
         } else {

--- a/app/org/maproulette/controllers/api/ProjectController.scala
+++ b/app/org/maproulette/controllers/api/ProjectController.scala
@@ -67,6 +67,18 @@ class ProjectController @Inject() (override val childController:ChallengeControl
   /**
     * Retrieves the list of projects managed
     *
+    * @param projectIds Comma separated list of project ids to fetch
+    * @return json list of managed projects
+    */
+  def fetch(projectIds:String) : Action[AnyContent] = Action.async { implicit response =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.dal.fetch(Utils.toLongList(projectIds))))
+    }
+  }
+
+  /**
+    * Retrieves the list of projects managed
+    *
     * @param limit Limit of how many tasks should be returned
     * @param offset offset for pagination
     * @param onlyEnabled Only list the enabled projects

--- a/app/org/maproulette/models/dal/BaseDAL.scala
+++ b/app/org/maproulette/models/dal/BaseDAL.scala
@@ -324,7 +324,8 @@ trait BaseDAL[Key, T<:BaseObject[Key]] extends DALHelper with TransactionManager
         val query = s"""SELECT ${this.retrieveColumns} FROM ${this.tableName}
                         WHERE ${this.searchField("name")(None)}
                         ${this.enabled(onlyEnabled)} ${this.parentFilter(parentId)}
-                        ${this.order(orderColumn=Some(orderColumn), orderDirection=orderDirection, nameFix=true)}
+                        ${this.order(orderColumn=Some(orderColumn), orderDirection=orderDirection, nameFix=true,
+                          ignoreCase=(orderColumn == "name" || orderColumn == "display_name"))}
                         LIMIT ${this.sqlLimit(limit)} OFFSET {offset}"""
         SQL(query).on('ss -> this.search(searchString),
           'offset -> ToParameterValue.apply[Int].apply(offset)

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -139,7 +139,7 @@ trait DALHelper {
     * @return
     */
   def order(orderColumn:Option[String]=None, orderDirection:String="ASC", tablePrefix:String="",
-            nameFix:Boolean=false) : String = orderColumn match {
+            nameFix:Boolean=false, ignoreCase:Boolean=false) : String = orderColumn match {
     case Some(column) =>
       this.testColumnName(column)
       val direction = orderDirection match {
@@ -148,7 +148,16 @@ trait DALHelper {
       }
       // sanitize the column name to prevent sql injection. Only allow underscores and A-Za-z
       if (column.forall(this.ordinary.contains)) {
-        s"ORDER BY ${this.getPrefix(tablePrefix)}$column ${if (nameFix) {"," + this.getPrefix(tablePrefix) + "name";} else {"";}} $direction"
+        val casedColumn = new StringBuilder()
+        if (ignoreCase) {
+          casedColumn ++= "LOWER("
+        }
+        casedColumn ++= this.getPrefix(tablePrefix) + column
+
+        if (ignoreCase) {
+          casedColumn ++= ")"
+        }
+        s"ORDER BY $casedColumn ${if (nameFix) {"," + this.getPrefix(tablePrefix) + "name";} else {"";}} $direction"
       } else {
         ""
       }

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -28,6 +28,7 @@ case class SearchParameters(projectIds:Option[List[Long]]=None,
                             challengeSearch:Option[String]=None,
                             challengeEnabled:Option[Boolean]=None,
                             challengeDifficulty:Option[Int]=None,
+                            challengeStatus:Option[List[Int]]=None,
                             taskTags:Option[List[String]]=None,
                             taskTagConjunction:Option[Boolean]=None,
                             taskSearch:Option[String]=None,
@@ -136,6 +137,11 @@ object SearchParameters {
       this.getBooleanParameter(request.getQueryString("ce"), params.challengeEnabled),
       //challengeDifficulty
       this.getIntParameter(request.getQueryString("cd"), params.challengeDifficulty),
+      //challengeStatus
+      request.getQueryString("cStatus") match {
+        case Some(v) => Utils.toIntList(v)
+        case None => params.challengeStatus
+      },
       //taskTags
       request.getQueryString("tt") match {
         case Some(v) => Some(v.split(",").toList)

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -163,6 +163,28 @@ PUT     /projects                                   @org.maproulette.controllers
 GET     /project/:id                                @org.maproulette.controllers.api.ProjectController.read(id:Long)
 ###
 # tags: [ Project ]
+# summary: Retrieves already existing Projects based on a given list of ids
+# consumes: [ application/json ]
+# produces: [ application/json ]
+# description: Retrieves already existing projects based on the supplied IDs
+# responses:
+#   '200':
+#     description: A list of projects
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.models.Project'
+#   '404':
+#     description: No projects found matching the ids given
+# parameters:
+#   - name: projectIds
+#     in: query
+#     description: Comma-separated list of project ids for which projects are desired. 
+###
+GET     /projects                                @org.maproulette.controllers.api.ProjectController.fetch(projectIds:String)
+###
+# tags: [ Project ]
 # summary: Retrieves an already existing Project
 # consumes: [ application/json ]
 # produces: [ application/json ]

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -881,8 +881,11 @@ GET     /challenges/find                            @org.maproulette.controllers
 #   - name: sort
 #     in: query
 #     description: Sorts the results retuned in the response. Parameter is optional, if not provided then results will not be sorted.
+#   - name: order
+#     in: query
+#     description: Sort order direction. Either ASC or DESC. Default is "ASC" (ascending)
 ###
-GET     /challenges/extendedFind                    @org.maproulette.controllers.api.ChallengeController.extendedFind(limit:Int ?= 10, page:Int ?= 0, sort:String ?= "")
+GET     /challenges/extendedFind                    @org.maproulette.controllers.api.ChallengeController.extendedFind(limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
 ###
 # tags: [ Challenge ]
 # summary: List challenges in specified projects


### PR DESCRIPTION
* Add challenge status as a search parameter for extendedFind. If
  a status of -1 is included then it will also return any challenges
  with a NULL status.

* Add new parameter to extendedFind for sort order. Before sort
  order was included in sort (ie. "name ASC"), now there is a
  separate field for order so that we can add a LOWER() around
  the name field to make sorting case insensitive