### PR TITLE
Add column headers and filename to CSV extracts

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -126,6 +126,9 @@ class Config @Inject() (implicit val application:Application) {
 
   lazy val sessionTimeout : Long = this.config.getOptional[Long](Config.KEY_SESSION_TIMEOUT).getOrElse(Config.DEFAULT_SESSION_TIMEOUT)
 
+  lazy val getPublicOrigin : Option[String] =
+    this.config.getOptional[String](Config.KEY_PUBLIC_ORIGIN)
+
   lazy val taskReset : Int = this.config.getOptional[Int](Config.KEY_TASK_RESET).getOrElse(Config.DEFAULT_TASK_RESET)
 
   lazy val signIn : Boolean = this.config.getOptional[Boolean](Config.KEY_SIGNIN).getOrElse(Config.DEFAULT_SIGNIN)
@@ -181,6 +184,7 @@ object Config {
   val KEY_MAX_SAVED_CHALLENGES = s"$GROUP_MAPROULETTE.limits.saved"
   val KEY_SEMANTIC_VERSION = s"$GROUP_MAPROULETTE.version"
   val KEY_SESSION_TIMEOUT = s"$GROUP_MAPROULETTE.session.timeout"
+  val KEY_PUBLIC_ORIGIN = s"$GROUP_MAPROULETTE.publicOrigin"
   val KEY_TASK_RESET = s"$GROUP_MAPROULETTE.task.reset"
   val KEY_SIGNIN = s"$GROUP_MAPROULETTE.signin"
   val KEY_TASK_SCORE_FIXED = s"$GROUP_MAPROULETTE.task.score.fixed"

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -19,6 +19,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.services.ChallengeService
 import org.maproulette.session.{SearchParameters, SessionManager, User}
 import org.maproulette.utils.Utils
+import org.maproulette.Config
 import play.api.http.HttpEntity
 import play.api.libs.Files
 import play.api.libs.json._
@@ -47,6 +48,7 @@ class ChallengeController @Inject()(override val childController: TaskController
                                     challengeService: ChallengeService,
                                     wsClient:WSClient,
                                     permission:Permission,
+                                    config:Config,
                                     components: ControllerComponents,
                                     override val bodyParsers:PlayBodyParsers)
   extends AbstractController(components) with ParentController[Challenge, Task] with TagsMixin[Challenge] {
@@ -371,15 +373,22 @@ class ChallengeController @Inject()(override val childController: TaskController
   def extractComments(challengeId:Long, limit:Int, page:Int) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       Result(
-        header = ResponseHeader(OK, Map.empty),
-        body = HttpEntity.Strict(ByteString(_extractComments(challengeId, limit, page, request.host).mkString("\n")), Some("text/csv"))
+        header = ResponseHeader(OK, Map(CONTENT_DISPOSITION -> s"attachment; filename=challenge_${challengeId}_comments.csv")),
+        body = HttpEntity.Strict(
+          ByteString(
+            "ProjectID,ChallengeID,TaskID,OSM_UserID,OSM_Username,Comment,TaskLink\n"
+          ).concat(ByteString(_extractComments(challengeId, limit, page, request.host).mkString("\n"))),
+          Some("text/csv; header=present"))
       )
     }
   }
 
   private def _extractComments(challengeId:Long, limit:Int, page:Int, host:String) : Seq[String] = {
     val comments = this.dalManager.task.retrieveComments(List.empty, List(challengeId), List.empty, limit, page)
-    val urlPrefix = s"http://$host/"
+    val urlPrefix = config.getPublicOrigin match {
+      case Some(origin) => s"${origin}/"
+      case None => s"http://$host/"
+    }
     comments.map(comment =>
       s"""${comment.projectId},$challengeId,${comment.taskId},${comment.osm_id},${comment.osm_username},"${comment.comment}",${urlPrefix}map/$challengeId/${comment.taskId}"""
     )
@@ -396,8 +405,12 @@ class ChallengeController @Inject()(override val childController: TaskController
   def extractTaskSummaries(challengeId:Long, limit:Int, page:Int) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       Result(
-        header = ResponseHeader(OK, Map.empty),
-        body = HttpEntity.Strict(ByteString(_extractTaskSummaries(challengeId, limit, page).mkString("\n")), Some("text/csv"))
+        header = ResponseHeader(OK, Map(CONTENT_DISPOSITION -> s"attachment; filename=challenge_${challengeId}_tasks.csv")),
+        body = HttpEntity.Strict(
+          ByteString(
+            "TaskID,ChallengeID,TaskName,TaskStatus,TaskPriority,OSM_Username\n"
+          ).concat(ByteString(_extractTaskSummaries(challengeId, limit, page).mkString("\n"))),
+          Some("text/csv; header=present"))
       )
     }
   }

--- a/app/org/maproulette/controllers/api/SurveyController.scala
+++ b/app/org/maproulette/controllers/api/SurveyController.scala
@@ -11,6 +11,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.services.ChallengeService
 import org.maproulette.session.{SessionManager, User}
 import org.maproulette.utils.Utils
+import org.maproulette.Config
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -32,9 +33,10 @@ class SurveyController @Inject() (override val childController:TaskController,
                                   challengeService: ChallengeService,
                                   wsClient: WSClient,
                                   permission:Permission,
+                                  config:Config,
                                   components: ControllerComponents,
                                   override val bodyParsers:PlayBodyParsers)
-  extends ChallengeController(childController, sessionManager, actionManager, dalManager.challenge, dalManager, tagDAL, challengeService, wsClient, permission, components, bodyParsers) {
+  extends ChallengeController(childController, sessionManager, actionManager, dalManager.challenge, dalManager, tagDAL, challengeService, wsClient, permission, config, components, bodyParsers) {
 
   // The type of object that this controller deals with.
   override implicit val itemType = SurveyType()

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1579,7 +1579,7 @@ GET     /challenge/:id/comments                     @org.maproulette.controllers
 # description: This will retrieve all the comments for all the children tasks of a given challenge and respond with a csv
 # response:
 #   '200':
-#     description: A CSV file containing the following data "ChallengeID,TaskID,OSM_UserID,OSM_Username,Comments"
+#     description: A CSV file containing the following data "ProjectID,ChallengeID,TaskID,OSM_UserID,OSM_Username,Comments,TaskLink"
 #   '404':
 #     description: No Challenge with provided ID found
 # parameters:

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -107,6 +107,10 @@ maproulette {
   action.level=1
   #session timeout in milliseconds, default -1 which ignores session timeouts
   session.timeout=-1
+  # The protocol://hostname:port of server for use in absolute URLs generated for
+  # links in CSV exports, email notifications, etc. E.G. https://myserver.org
+  #publicOrigin="https://myserver.org"
+
   # number of days till we reset the status if it has not been fixed
   task {
     reset = 14


### PR DESCRIPTION
* Add column headers to challenge tasks and comments CSV extracts
* Specify CSV extracts as attachments with filenames that include
challenge id
* Add new `publicOrigin` config field that can be used to specify
the public origin of the server for use in generating absolute URLs in
CSV exports
* Make use of new `publicOrigin` config field in challenge comments CSV
export for links to tasks, falling back to prior behavior of using
request host if publicOrigin isn't specified