### PR TITLE
Allow OAuth redirect to anywhere in mr3 dev mode

### DIFF
--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -180,7 +180,13 @@ class AuthController @Inject() (messagesApi: MessagesApi,
     if (StringUtils.isEmpty(redirect) && referer.isDefined) {
       referer.get
     } else if (StringUtils.isNotEmpty(redirect)) {
-      s"${redirectURL.substring(0, redirectURL.length - 1)}$redirect"
+      if (config.mr3DevMode) {
+        // In dev mode, allow redirects to anywhere so frontend can be run separately
+        redirect
+      }
+      else {
+        s"${redirectURL.substring(0, redirectURL.length - 1)}$redirect"
+      }
     } else {
       redirectURL
     }


### PR DESCRIPTION
Follow OAuth redirect URL as-is if `mr3.devMode` configuration field is
set to true, allowing decoupling of the front-end and back-end servers
running on different ports. The normal redirection behavior is preserved
outside of dev mode