### PR TITLE
Fix new users throw error due to no user score

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -963,7 +963,9 @@ class TaskDAL @Inject()(override val db: Database,
     withMRConnection { implicit c =>
       val query =
         s"""
-           |SELECT ${userDAL.get().retrieveColumns} FROM users WHERE osm_id IN (
+           |SELECT ${userDAL.get().retrieveColumns}, score FROM users
+           |  LEFT JOIN user_metrics ON users.id = user_metrics.user_id
+           |  WHERE osm_id IN (
            |  SELECT osm_user_id FROM status_actions WHERE task_id = {id}
            |  ORDER BY created DESC
            |  LIMIT {limit}


### PR DESCRIPTION
Found bug where user data would not be returned if the user had no score (as is the case with brand new users or users who have not done any work yet.)