### PR TITLE
Add api method to consolidate fetch of preferred challenges

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -305,6 +305,21 @@ class ChallengeController @Inject()(override val childController: TaskController
     }
   }
 
+  /**
+    * Gets the preferred challenges (hottest, newest, featured)
+    *
+    * @param limit  The number of challenges to get
+    * @param offset The offset
+    * @return A Json array with the hot challenges
+    */
+  def getPreferredChallenges(limit: Int): Action[AnyContent] = Action.async { implicit request =>
+    val all = Map("popular" -> this.dal.getHotChallenges(limit, 0),
+                  "newest" -> this.dal.getNewChallenges(limit, 0),
+                  "featured" -> this.dal.getFeaturedChallenges(limit, 0))
+
+    Future(Ok(Json.toJson(all)))
+  }
+
   def updateTaskPriorities(challengeId: Long): Action[AnyContent] = Action.async { implicit request =>
     implicit val requireSuperUser = true
     this.sessionManager.authenticatedRequest { implicit user =>

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -180,7 +180,7 @@ GET     /project/:id                                @org.maproulette.controllers
 # parameters:
 #   - name: projectIds
 #     in: query
-#     description: Comma-separated list of project ids for which projects are desired. 
+#     description: Comma-separated list of project ids for which projects are desired.
 ###
 GET     /projects                                @org.maproulette.controllers.api.ProjectController.fetch(projectIds:String)
 ###
@@ -1076,6 +1076,22 @@ GET     /challenges/featured                        @org.maproulette.controllers
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
 GET     /challenges/hot                             @org.maproulette.controllers.api.ChallengeController.getHotChallenges(limit:Int ?= 10, page:Int ?= 0)
+###
+# tags: [ Challenge ]
+# summary: Preferred Challenges.
+# produces: [ application/json ]
+# description: Get the preferred challenges which include popular, featured, and newest
+# responses:
+#   '200':
+#     description: A map of each list challenge types ("popular":[], "featured":[], "newest":[])
+#     schema:
+#       type: object
+# parameters:
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in each category. Default value is 10.
+###
+GET     /challenges/preferred                             @org.maproulette.controllers.api.ChallengeController.getPreferredChallenges(limit:Int ?= 10)
 ###
 # tags: [ Challenge ]
 # summary: List all the Challenges.


### PR DESCRIPTION
Add method to fetch a consolidated list of preferred challenges. Preferred challenges are most popular, newest and featured.