### PR TITLE
Change migration sql on needsReview default bug

### DIFF
--- a/conf/evolutions/default/31.sql
+++ b/conf/evolutions/default/31.sql
@@ -8,8 +8,9 @@ ALTER TABLE users ALTER COLUMN needs_review SET DEFAULT null;
 
 ALTER TABLE users ALTER COLUMN needs_review TYPE INTEGER USING
     CASE
-      WHEN false then 0
-      ELSE 1
+      WHEN needs_review = true then 1
+      WHEN needs_review = false then 0
+      ELSE NULL
     END;
 
 


### PR DESCRIPTION
Migration sql was not correctly converting the needsReview
flag from boolean to integer as expected