### PR TITLE
Add to review search methods ability to search by dates

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -290,19 +290,23 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
   /**
     * Gets tasks where a review is requested
     *
+    * @param startDate Optional start date to filter by reviewedAt date
+    * @param endDate Optional end date to filter by reviewedAt date
     * @param limit The number of tasks to return
     * @param page The page number for the results
     * @param sort The column to sort
     * @param order The order direction to sort
     * @return
     */
-  def getReviewRequestedTasks(limit:Int, page:Int, sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
+  def getReviewRequestedTasks(startDate: String=null, endDate: String=null,
+                              limit:Int, page:Int, sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         //cs => "my challenge name"
         //o => "mapper's name"
         //r => "reviewer's name"
-        val (count, result) = this.dal.getReviewRequestedTasks(User.userOrMocked(user), params, limit, page, sort, order)
+        val (count, result) = this.dal.getReviewRequestedTasks(User.userOrMocked(user), params,
+           startDate, endDate, limit, page, sort, order)
         Ok(Json.obj("total" -> count, "tasks" -> _insertExtraJSON(result)))
       }
     }
@@ -311,6 +315,8 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
   /**
     * Gets reviewed tasks where the user has reviewed or requested review
     *
+    * @param startDate Optional start date to filter by reviewedAt date
+    * @param endDate Optional end date to filter by reviewedAt date
     * @param asReviewer Whether we should return tasks reviewed by this user or reqested by this user
     * @param allowReviewNeeded Whether we should return tasks where status is review requested also
     * @param limit The number of tasks to return
@@ -319,12 +325,14 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     * @param order The order direction to sort
     * @return
     */
-  def getReviewedTasks(asReviewer: Boolean=false, allowReviewNeeded: Boolean=false, limit:Int, page:Int,
+  def getReviewedTasks(startDate: String=null, endDate: String=null,
+                       asReviewer: Boolean=false, allowReviewNeeded: Boolean=false,
+                       limit:Int, page:Int,
                        sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         val (count, result) = this.dal.getReviewedTasks(User.userOrMocked(user), params,
-             asReviewer, allowReviewNeeded, limit, page, sort, order)
+             startDate, endDate, asReviewer, allowReviewNeeded, limit, page, sort, order)
         Ok(Json.obj("total" -> count, "tasks" -> _insertExtraJSON(result)))
       }
     }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -574,6 +574,12 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #         type: object
 #         $ref: '#/definitions/org.maproulette.models.Task'
 # parameters:
+#   - name: startDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
+#   - name: endDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is -1 (all).
@@ -590,7 +596,7 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #     in: query
 #     description: The search string used to match the name of the person requesting the review. (review_requested_by)
 ###
-GET     /tasks/review                          @org.maproulette.controllers.api.TaskController.getReviewRequestedTasks(limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/review                          @org.maproulette.controllers.api.TaskController.getReviewRequestedTasks(startDate: String ?= null, endDate: String ?= null, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
 ###
 # summary: Retrieves reviewed tasks that have been reviewed either by this user or where the user requested
 #          the review.
@@ -606,6 +612,12 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #         type: object
 #         $ref: '#/definitions/org.maproulette.models.Task'
 # parameters:
+#   - name: startDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
+#   - name: endDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
 #   - name: asReviewer
 #     in: query
 #     description: Whether results should be tasks reviewed by this user or review requested by this user
@@ -631,7 +643,7 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskController.getReviewedTasks(asReviewer:Boolean ?= false, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskController.getReviewedTasks(startDate: String ?= null, endDate: String ?= null, asReviewer:Boolean ?= false, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
 ###
 # summary: Retrieves and claims a the next review needed Task
 # produces: [ application/json ]


### PR DESCRIPTION
* Add startDate and endDate to search by reviewedAt for getReviewNeeded and getReviewedTasks

* Refactored some of the common review search clauses into a shared private method 

* Fix other minor bugs introduced when task_review table was split off

* Make owner/reviewer search case insensitive