### PR TITLE
Add refresh of user metrics before taking history snapshot

### DIFF
--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -477,6 +477,33 @@ class SchedulerActor @Inject()(config: Config,
     logger.info(action)
 
     db.withConnection { implicit c =>
+      SQL(s"""UPDATE user_metrics set score=data.score, total_fixed=data.total_fixed,
+              total_false_positive=data.total_false_positive, total_already_fixed=data.total_already_fixed,
+              total_too_hard=data.total_too_hard, total_skipped=data.total_skipped
+              FROM (
+              SELECT users.id,
+                       SUM(CASE sa.status
+                           WHEN ${Task.STATUS_FIXED} THEN ${config.taskScoreFixed}
+                           WHEN ${Task.STATUS_FALSE_POSITIVE} THEN ${config.taskScoreFalsePositive}
+                           WHEN ${Task.STATUS_ALREADY_FIXED} THEN ${config.taskScoreAlreadyFixed}
+                           WHEN ${Task.STATUS_TOO_HARD} THEN ${config.taskScoreTooHard}
+                           WHEN ${Task.STATUS_SKIPPED} THEN ${config.taskScoreSkipped}
+                           ELSE 0
+                       END) AS score,
+                       SUM(CASE WHEN sa.status = ${Task.STATUS_FIXED} THEN ${config.taskScoreFixed} else 0 end) total_fixed,
+                       SUM(CASE WHEN sa.status = ${Task.STATUS_FALSE_POSITIVE} THEN ${config.taskScoreFalsePositive} else 0 end) total_false_positive,
+                       SUM(CASE WHEN sa.status = ${Task.STATUS_ALREADY_FIXED} THEN ${config.taskScoreAlreadyFixed} else 0 end) total_already_fixed,
+                       SUM(CASE WHEN sa.status = ${Task.STATUS_TOO_HARD} THEN ${config.taskScoreTooHard} end) total_too_hard,
+                       SUM(CASE WHEN sa.status = ${Task.STATUS_SKIPPED} THEN ${config.taskScoreSkipped} else 0 end) total_skipped
+               FROM status_actions sa, users
+               WHERE users.osm_id = sa.osm_user_id AND sa.old_status <> sa.status
+               GROUP BY sa.osm_user_id, users.id) AS data
+              WHERE user_metrics.user_id = data.id
+           """).executeUpdate()
+      logger.info(s"Refreshed user metrics from status actions.")
+    }
+
+    db.withConnection { implicit c =>
       SQL(s"""INSERT INTO user_metrics_history
               SELECT user_id, score, total_fixed, total_false_positive, total_already_fixed,
                      total_too_hard, total_skipped, now(), initial_rejected, initial_approved,


### PR DESCRIPTION
To ensure the user score is accurate over time, add an additional refresh of the user metrics table before taking the user metrics history snapshot. 
