### PR TITLE
Fix review requested tasks query 

### DIFF
--- a/app/org/maproulette/models/dal/TaskReviewDal.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDal.scala
@@ -232,7 +232,6 @@ class TaskReviewDAL @Inject()(override val db: Database,
         s"""
           SELECT count(*) FROM tasks
           ${joinClause}
-          INNER JOIN projects p ON p.id = c.parent_id
           INNER JOIN groups g ON g.project_id = p.id
           INNER JOIN user_groups ug ON g.id = ug.group_id
           WHERE ((p.enabled AND c.enabled) OR


### PR DESCRIPTION
After adding project filter, the inner join was joining on projects twice in some cases.