### PR TITLE
Avoid duplicate task_review entries for a task

### DIFF
--- a/conf/evolutions/default/33.sql
+++ b/conf/evolutions/default/33.sql
@@ -1,0 +1,9 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add unique constraint on task_review.task_id
+
+ALTER TABLE "task_review" ADD CONSTRAINT task_review_task_id UNIQUE (task_id);
+
+# --- !Downs
+ALTER TABLE "task_review" DROP CONSTRAINT task_review_task_id


### PR DESCRIPTION
* Add unique constraint to task_review table to ensure only one entry
per task_id

* Remove task entry from task_review table when review status is
reset (e.g. because task status is set back to 'created')