### PR TITLE
Update project id on status actions when challenge moved

### DIFF
--- a/conf/evolutions/default/34.sql
+++ b/conf/evolutions/default/34.sql
@@ -1,0 +1,11 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+UPDATE status_actions
+SET project_id = challenges.parent_id
+FROM challenges
+WHERE   challenge_id = challenges.id AND
+        challenge_id IN (select distinct challenge_id
+                    from status_actions
+                    INNER JOIN challenges ON challenges.id = status_actions.challenge_id
+                    WHERE challenges.parent_id != status_actions.project_id);


### PR DESCRIPTION
* Update project_id on status_actions entries when a challenge is moved to a different project

* Add evolution that ensures existing status_action rows have a current project_id for their challenges