### PR TITLE
Add onlyEnabled flag to project summary API

### DIFF
--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -187,10 +187,10 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
     }
   }
 
-  def getProjectSummary(projects: String): Action[AnyContent] = Action.async { implicit request =>
+  def getProjectSummary(projects: String, onlyEnabled: Boolean = true): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       Ok(Json.toJson(
-        this.dataManager.getChallengeSummary(Utils.toLongList(projects))
+        this.dataManager.getChallengeSummary(Utils.toLongList(projects), onlyEnabled = onlyEnabled)
       ))
     }
   }
@@ -223,7 +223,7 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
     * @param projectIds A comma separated list of projects to filter by
     * @return
     */
-  def getChallengeSummaries(projectIds: String, priority: Int): Action[AnyContent] = Action.async { implicit request =>
+  def getChallengeSummaries(projectIds: String, priority: Int, onlyEnabled:Boolean = true): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       val postData = request.body.asInstanceOf[AnyContentAsFormUrlEncoded].data
       val draw = postData.get("draw").head.head.toInt
@@ -235,7 +235,7 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
       val orderColumnName = postData.get(s"columns[$orderColumnID][name]").head.headOption
       val projectList = Utils.toLongList(projectIds)
       val challengeSummaries =
-        this.dataManager.getChallengeSummary(projectList, None, length, start, orderColumnName, orderDirection, search, this.getPriority(priority))
+        this.dataManager.getChallengeSummary(projectList, None, length, start, orderColumnName, orderDirection, search, this.getPriority(priority), onlyEnabled)
 
       val summaryMap = challengeSummaries.map(summary => Map(
         "id" -> summary.id.toString,

--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -322,7 +322,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
     */
   def getChallengeSummary(projectList: Option[List[Long]] = None, challengeId: Option[Long] = None,
                           limit: Int = (-1), offset: Int = 0, orderColumn: Option[String] = None, orderDirection: String = "ASC",
-                          searchString: String = "", priority: Option[Int] = None): List[ChallengeSummary] = {
+                          searchString: String = "", priority: Option[Int] = None, onlyEnabled: Boolean = false): List[ChallengeSummary] = {
     this.db.withConnection { implicit c =>
       val parser = for {
         id <- int("tasks.parent_id")
@@ -374,7 +374,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
                               INNER JOIN challenges c ON c.id = t.parent_id
                               INNER JOIN projects p ON p.id = c.parent_id
                               WHERE ${
-        if (challengeId.isEmpty) {
+        if (onlyEnabled) {
           "c.enabled = true AND p.enabled = true AND"
         } else {
           ""

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -3316,7 +3316,7 @@ GET     /data/challenge/:challengeId                @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/challenge/:challengeId/users          @org.maproulette.controllers.api.DataController.getUserChallengeSummary(challengeId:Long, start:String ?= "", end:String ?= "", survey:Int ?= 0, priority:Int ?= -1)
 ### NoDocs ###
-POST    /data/challenge/summary                     @org.maproulette.controllers.api.DataController.getChallengeSummaries(projectList:String ?= "", priority:Int ?= -1)
+POST    /data/challenge/summary                     @org.maproulette.controllers.api.DataController.getChallengeSummaries(projectList:String ?= "", priority:Int ?= -1, onlyEnabled:Boolean ?= true)
 ### NoDocs ###
 GET     /data/user/activity                         @org.maproulette.controllers.api.DataController.getRecentUserActivity(limit:Int ?= -1, offset:Int ?= 0)
 ### NoDocs ###
@@ -3332,7 +3332,7 @@ GET     /data/user/:userId/metrics                  @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/project/activity                      @org.maproulette.controllers.api.DataController.getProjectActivity(projectList:String ?= "", start:String ?= "", end:String ?= "")
 ### NoDocs ###
-GET     /data/project/summary                       @org.maproulette.controllers.api.DataController.getProjectSummary(projectList:String ?= "")
+GET     /data/project/summary                       @org.maproulette.controllers.api.DataController.getProjectSummary(projectList:String ?= "", onlyEnabled:Boolean ?= true)
 ### NoDocs ###
 GET     /data/challenge/:challengeId/activity       @org.maproulette.controllers.api.DataController.getChallengeActivity(challengeId:Long, start:String ?= "", end:String ?= "", survey:Int ?= 0, priority:Int ?= -1)
 ### NoDocs ###


### PR DESCRIPTION
Add ability to return a full project summary that includes both
enabled and not enabled challenges & projects. Default remains
as onlyEnabled so this should not change current behavior.