### PR TITLE
Add timestamp column to user_leaderboard

### DIFF
--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -69,7 +69,8 @@ case class RawActivity(date: DateTime, osmUserId: Long, osmUsername: String, pro
 case class LeaderboardChallenge(id: Long, name: String, activity: Int)
 
 case class LeaderboardUser(userId: Long, name: String, avatarURL: String,
-                           score: Int, rank: Int, topChallenges: List[LeaderboardChallenge])
+                           score: Int, rank: Int, created: DateTime,
+                           topChallenges: List[LeaderboardChallenge])
 
 /**
   * @author cuthbertm
@@ -591,7 +592,8 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
           avatarURL <- str("user_avatar_url")
           score <- int("user_score")
           rank <- int("user_ranking")
-        } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+          created <- get[DateTime]("created")
+        } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
           this.getUserTopChallenges(userId, projectFilter, challengeFilter,
             countryCodeFilter, monthDuration, start, end, onlyEnabled))
 
@@ -647,7 +649,8 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         avatarURL <- str("users.avatar_url")
         score <- int("score")
         rank <- int("row_number")
-      } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+        created <- get[DateTime]("created")
+      } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
         this.getUserTopChallenges(userId, projectList,
           challengeList, countryCodeFilter,
           monthDuration, start, end, onlyEnabled))
@@ -873,7 +876,8 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
           avatarURL <- str("user_avatar_url")
           score <- int("user_score")
           rank <- int("user_ranking")
-        } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+          created <- get[DateTime]("created")
+        } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
           this.getUserTopChallenges(userId, projectFilter, challengeFilter,
             countryCodeFilter, monthDuration, start, end, onlyEnabled))
 
@@ -922,7 +926,8 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         avatarURL <- str("users.avatar_url")
         score <- int("score")
         rank <- int("row_number")
-      } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+        created <- get[DateTime]("created")
+      } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
         this.getUserTopChallenges(userId, projectFilter, challengeFilter,
           countryCodeFilter, monthDuration, start, end, onlyEnabled))
 

--- a/conf/evolutions/default/36.sql
+++ b/conf/evolutions/default/36.sql
@@ -1,0 +1,10 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add timestamp to user_leaderboard
+
+ALTER TABLE "user_leaderboard" ADD COLUMN created timestamp without time zone DEFAULT NOW();;
+
+
+# --- !Downs
+ALTER TABLE "user_leaderboard" DROP COLUMN created;;


### PR DESCRIPTION
* Add timestamp column 'created' to user_leaderboard so that we can tell when the user leaderboard was last updated.

* In api for leaderboard return created field in json