### PR TITLE
Delete tasks asynchronously and in batches

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -348,8 +348,30 @@ class ChallengeController @Inject()(override val childController: TaskController
     */
   def deleteTasks(challengeId: Long, statusFilters: String = ""): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      this.dal.deleteTasks(user, challengeId, Utils.split(statusFilters).map(_.toInt))
-      Ok
+      dalManager.challenge.retrieveById(challengeId) match {
+        case Some(c) =>
+          permission.hasWriteAccess(ProjectType(), user)(c.general.parent)
+          if (c.status.get == Challenge.STATUS_DELETING_TASKS) {
+            throw new InvalidException("Task deletion already in-progress for this challenge")
+          }
+          else if (c.status.get == Challenge.STATUS_BUILDING) {
+            throw new InvalidException("Tasks cannot be deleted while challenge is building")
+          }
+
+          val originalStatus = c.status
+          dalManager.challenge.update(Json.obj("status" -> Challenge.STATUS_DELETING_TASKS), user)(challengeId)
+          // Deleting a lot of tasks can be time consuming, so perform this asynchronously
+          Future {
+            try {
+              this.dal.deleteTasks(user, challengeId, Utils.split(statusFilters).map(_.toInt))
+            }
+            finally {
+              dalManager.challenge.update(Json.obj("status" -> originalStatus), user)(challengeId)
+            }
+          }
+          Ok
+        case None => throw new NotFoundException(s"No challenge found with id $challengeId")
+      }
     }
   }
 
@@ -696,6 +718,13 @@ class ChallengeController @Inject()(override val childController: TaskController
       dalManager.challenge.retrieveById(challengeId) match {
         case Some(c) =>
           permission.hasWriteAccess(ProjectType(), user)(c.general.parent)
+          if (c.status.get == Challenge.STATUS_DELETING_TASKS) {
+            throw new InvalidException("Challenge cannot be rebuilt while undergoing bulk task deletion")
+          }
+          else if (c.status.get == Challenge.STATUS_BUILDING) {
+            throw new InvalidException("Task build is already in progress for this challenge")
+          }
+
           challengeProvider.rebuildTasks(user, c, removeUnmatched)
           Ok
         case None => throw new NotFoundException(s"No challenge found with id $challengeId")
@@ -708,6 +737,13 @@ class ChallengeController @Inject()(override val childController: TaskController
       dalManager.challenge.retrieveById(challengeId) match {
         case Some(c) =>
           permission.hasObjectWriteAccess(c, user)
+          if (c.status.get == Challenge.STATUS_DELETING_TASKS) {
+            throw new InvalidException("Tasks cannot be added while challenge is undergoing bulk task deletion")
+          }
+          else if (c.status.get == Challenge.STATUS_BUILDING) {
+            throw new InvalidException("Tasks cannot be added while challenge is being built")
+          }
+
           request.body.asText match {
             case Some(j) =>
               challengeProvider.createTasksFromJson(user, c, j)
@@ -727,6 +763,13 @@ class ChallengeController @Inject()(override val childController: TaskController
         dalManager.challenge.retrieveById(challengeId) match {
           case Some(c) =>
             permission.hasObjectWriteAccess(c, user)
+            if (c.status.get == Challenge.STATUS_DELETING_TASKS) {
+              throw new InvalidException("Tasks cannot be added while challenge is undergoing bulk task deletion")
+            }
+            else if (c.status.get == Challenge.STATUS_BUILDING) {
+              throw new InvalidException("Tasks cannot be added while challenge is being built")
+            }
+
             request.body.file("json") match {
               case Some(f) if StringUtils.isNotEmpty(f.filename) =>
                 if (removeUnmatched) {

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -193,6 +193,7 @@ object Challenge {
   val STATUS_READY = 3
   val STATUS_PARTIALLY_LOADED = 4
   val STATUS_FINISHED = 5
+  val STATUS_DELETING_TASKS = 6
 
   /**
     * This will check to make sure that the json rule is fully valid. The simple check just makes sure

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -619,6 +619,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                       WHERE featured = TRUE ${this.enabled(enabledOnly, "c")} ${this.enabled(enabledOnly, "p")}
                       AND c.deleted = false and p.deleted = false
                       AND (c.status <> ${Challenge.STATUS_BUILDING} AND
+                           c.status <> ${Challenge.STATUS_DELETING_TASKS} AND
                            c.status <> ${Challenge.STATUS_FAILED} AND
                            c.status <> ${Challenge.STATUS_FINISHED})
                       AND 0 < (SELECT COUNT(*) FROM tasks WHERE parent_id = c.id)
@@ -644,6 +645,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                       WHERE c.deleted = false and p.deleted = false
                       ${this.enabled(enabledOnly, "c")} ${this.enabled(enabledOnly, "p")}
                       AND (c.status <> ${Challenge.STATUS_BUILDING} AND
+                           c.status <> ${Challenge.STATUS_DELETING_TASKS} AND
                            c.status <> ${Challenge.STATUS_FAILED} AND
                            c.status <> ${Challenge.STATUS_FINISHED})
                       AND 0 < (SELECT COUNT(*) FROM tasks WHERE parent_id = c.id)
@@ -668,6 +670,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                       WHERE ${this.enabled(enabledOnly, "c")(None)} ${this.enabled(enabledOnly, "p")}
                       AND c.deleted = false and p.deleted = false
                       AND (c.status <> ${Challenge.STATUS_BUILDING} AND
+                           c.status <> ${Challenge.STATUS_DELETING_TASKS} AND
                            c.status <> ${Challenge.STATUS_FAILED} AND
                            c.status <> ${Challenge.STATUS_FINISHED})
                       ${this.order(Some("created"), "DESC", "c", true)}
@@ -958,10 +961,16 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
       val filter = if (statusFilter.isEmpty) {
         ""
       } else {
-        s"AND status IN (${statusFilter.mkString(",")}"
+        s"AND status IN (${statusFilter.mkString(",")})"
       }
-      val query = s"""DELETE FROM tasks WHERE parent_id = {challengeId} $filter"""
-      SQL(query).on('challengeId -> challengeId).executeUpdate()
+
+      // Deleting tasks can be time consuming (~1 second per 15-20 tasks), so work in batches
+      val query = s"""DELETE FROM tasks WHERE id in (SELECT id from tasks WHERE parent_id = {challengeId} $filter LIMIT 50)"""
+      var deleteCount = 0
+      do {
+        deleteCount = SQL(query).on('challengeId -> challengeId).executeUpdate()
+      }
+      while(deleteCount > 0)
     }
   }
 


### PR DESCRIPTION
> Note: while making these changes, I discovered that there was a missing parenthesee that caused bad SQL to be generated if a status filter was given, so I suspect that this API endpoint isn't getting much (if any) use at the moment. Also, given the current webserver configuration, any attempt to delete more than a trivial number of tasks would likely result in a gateway timeout.

* Add new DELETING_TASKS challenge status

* Change the `DELETE /challenge/:id/tasks` API endpoint to delete tasks
asynchronously and to change the challenge status to DELETING_TASKS
while the delete operation is ongoing

* Change `ChallengeDal.deleteTasks` to work in small batches

* Add guard conditions to ChallengeController to prevent bulk task
deletion or challenge rebuilds while a deletion or rebuild is already in
progress