### PR TITLE
Fix created column for non-prebuilt leaderboard queries

### DIFF
--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -664,8 +664,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         avatarURL <- str("users.avatar_url")
         score <- int("score")
         rank <- int("row_number")
-        created <- get[DateTime]("created")
-      } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
+      } yield LeaderboardUser(userId, name, avatarURL, score, rank, new DateTime(),
         this.getUserTopChallenges(userId, projectList,
           challengeList, countryCodeFilter,
           monthDuration, start, end, onlyEnabled))
@@ -955,8 +954,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         avatarURL <- str("users.avatar_url")
         score <- int("score")
         rank <- int("row_number")
-        created <- get[DateTime]("created")
-      } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
+      } yield LeaderboardUser(userId, name, avatarURL, score, rank, new DateTime(),
         this.getUserTopChallenges(userId, projectFilter, challengeFilter,
           countryCodeFilter, monthDuration, start, end, onlyEnabled))
 


### PR DESCRIPTION
If a leaderboard request is not using pre-built values in the user_leaderboard table, then it should just return the current timestamp since the data is fresh.