### PR TITLE
Allow project name in extendedFind search

### DIFF
--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1007,7 +1007,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
       val joinClause = new StringBuilder()
       var orderByClause = ""
 
-      parameters ++= addSearchToQuery(searchParameters, whereClause)
+      parameters ++= addSearchToQuery(searchParameters, whereClause)(false)
 
       parameters ++= addChallengeTagMatchingToQuery(searchParameters, whereClause, joinClause)
 

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -195,10 +195,10 @@ trait DALHelper {
             case Some(ps) if ps.nonEmpty =>
               params.fuzzySearch match {
                 case Some(x) =>
-                  whereClause ++= this.fuzzySearch(s"$projectPrefix.name", "ps", x)(None)
+                  whereClause ++= this.fuzzySearch(s"$projectPrefix.display_name", "ps", x)(if (whereClause.isEmpty) None else Some(AND()))
                   parameters += ('ps -> ps)
                 case None =>
-                  whereClause ++= this.searchField(s"$projectPrefix.name", "ps")(None)
+                  whereClause ++= this.searchField(s"$projectPrefix.display_name", "ps")(if (whereClause.isEmpty) None else Some(AND()))
                   parameters += ('ps -> s"%$ps%")
               }
             case _ => // we can ignore this
@@ -283,7 +283,7 @@ trait DALHelper {
     */
   def searchField(column: String, key: String = "ss")
                  (implicit conjunction: Option[SQLKey] = Some(AND())): String =
-    s"${this.getSqlKey} LOWER($column) LIKE LOWER({$key})"
+    s" ${this.getSqlKey} LOWER($column) LIKE LOWER({$key})"
 
   /**
     * Adds fuzzy search to any query. This will include the Levenshtein, Metaphone and Soundex functions
@@ -305,7 +305,7 @@ trait DALHelper {
     } else {
       3
     }
-    s"""${this.getSqlKey} ($column <> '' AND
+    s""" ${this.getSqlKey} ($column <> '' AND
           (LEVENSHTEIN(LOWER($column), LOWER({$key})) < $score OR
             METAPHONE(LOWER($column), 4) = METAPHONE(LOWER({$key}), $metaphoneSize) OR
             SOUNDEX(LOWER($column)) = SOUNDEX(LOWER({$key})))


### PR DESCRIPTION
* Support project name (`ps`) in extendedFind challenge searches to
allow further narrowing down of challenge results

* Change `ps` search to use project's display_name instead of name

* Fix missing space if `ps` query clause was added to an existing
WHERE clause