### PR TITLE
Add support for all reviewed tasks

### DIFF
--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -135,14 +135,15 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param order The order direction to sort
     * @return
     */
-  def getReviewedTasks(startDate: String=null, endDate: String=null,
-                       asReviewer: Boolean=false, allowReviewNeeded: Boolean=false,
+  def getReviewedTasks(mappers: String="", reviewers: String="",
+                       startDate: String=null, endDate: String=null, allowReviewNeeded: Boolean=false,
                        limit:Int, page:Int,
                        sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         val (count, result) = this.taskReviewDAL.getReviewedTasks(User.userOrMocked(user), params,
-             startDate, endDate, asReviewer, allowReviewNeeded, limit, page, sort, order)
+             Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
+             startDate, endDate, allowReviewNeeded, limit, page, sort, order)
         Ok(Json.obj("total" -> count, "tasks" -> _insertExtraJSON(result)))
       }
     }
@@ -200,11 +201,14 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param endDate Optional end date to filter by reviewedAt date
     * @return
     */
-  def getReviewMetrics(reviewTasksType: Int, startDate: String=null, endDate: String=null,
+  def getReviewMetrics(reviewTasksType: Int, mappers: String="", reviewers: String="",
+                       startDate: String=null, endDate: String=null,
                        onlySaved: Boolean=false) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
-        val result = this.taskReviewDAL.getReviewMetrics(User.userOrMocked(user), reviewTasksType, params, startDate, endDate, onlySaved)
+        val result = this.taskReviewDAL.getReviewMetrics(User.userOrMocked(user),
+                       reviewTasksType, params, Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
+                       startDate, endDate, onlySaved)
         Ok(Json.toJson(result))
       }
     }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -662,10 +662,12 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #   - name: endDate
 #     in: query
 #     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
-#   - name: asReviewer
+#   - name: mappers
 #     in: query
-#     description: Whether results should be tasks reviewed by this user or review requested by this user
-#   - name: allowReviewNeeded
+#     description: The mapper ids to search by. (review_requested_by)
+#   - name: reviewers
+#     in: query
+#     description: The reviewer ids to search by. (review_requested_by)
 #     in: query
 #     description: Whether results should be included tasks in tasks 'review requested'
 #   - name: limit
@@ -687,7 +689,7 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(startDate: String ?= null, endDate: String ?= null, asReviewer:Boolean ?= false, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(mappers:String ?= "", reviewers:String ?= "", startDate: String ?= null, endDate: String ?= null, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
 ###
 # summary: Retrieves and claims a the next review needed Task
 # produces: [ application/json ]
@@ -732,6 +734,12 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #   - name: reviewTasksType
 #     in: query
 #     description: integer value > 1 - To Be Reviewed 2 - User's reviewed Tasks 3 - All reviewed by users
+#   - name: mappers
+#     in: query
+#     description: the mapper ids to search by (review_requested_by)
+#   - name: reviewers
+#     in: query
+#     description: the reviewer ids to search by (reviewed_by)
 #   - name: startDate
 #     in: query
 #     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
@@ -739,7 +747,7 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #     in: query
 #     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
 ###
-GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
+GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
 ###
 # tags: [ Project ]
 # summary: Retrieves clustered challenge points


### PR DESCRIPTION
Add API support for fetching all reviewed tasks. This changed existing review methods by:
- removing 'asReviewer' flag which only fetched as reviewer or as mapper
- adding support for providing ids of mappers and reviewers to filter by
- adding security checks so that only permissible tasks would come back
