### PR TITLE
Support proximityId in prioritizedTasks API

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -207,9 +207,11 @@ class ChallengeController @Inject()(override val childController: TaskController
     * @param taskSearch  Filter based on the name of the task
     * @param tags        A comma separated list of tags that optionally can be used to further filter the tasks
     * @param limit       Limit of how many tasks should be returned
+    * @param proximityId Id of task that you wish to find the next task based on the proximity of that task
     * @return A list of Tasks that match the supplied filters
     */
-  def getRandomTasksWithPriority(challengeId: Long, taskSearch: String, tags: String, limit: Int): Action[AnyContent] = Action.async { implicit request =>
+  def getRandomTasksWithPriority(challengeId: Long, taskSearch: String, tags: String, limit: Int,
+                                 proximityId: Long): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { p =>
         val params = p.copy(
@@ -217,7 +219,7 @@ class ChallengeController @Inject()(override val childController: TaskController
           taskSearch = Some(taskSearch),
           taskTags = Some(Utils.split(tags))
         )
-        val result = this.dalManager.task.getRandomTasksWithPriority(User.userOrMocked(user), params, limit)
+        val result = this.dalManager.task.getRandomTasksWithPriority(User.userOrMocked(user), params, limit, Utils.negativeToOption(proximityId))
         result.foreach(task => this.actionManager.setAction(user, this.itemType.convertToItem(task.id), TaskViewed(), ""))
         Ok(Json.toJson(result))
       }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1699,8 +1699,11 @@ GET     /challenge/:cid/tasks/randomTasks           @org.maproulette.controllers
 #   - name: limit
 #     in: query
 #     description: Limit the number of results returned in the response. Default value is 1.
+#   - name: proximity
+#     in: query
+#     description: Id of task that you wish to find the next task based on the proximity of that task
 ###
-GET     /challenge/:cid/tasks/prioritizedTasks      @org.maproulette.controllers.api.ChallengeController.getRandomTasksWithPriority(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1)
+GET     /challenge/:cid/tasks/prioritizedTasks      @org.maproulette.controllers.api.ChallengeController.getRandomTasksWithPriority(cid:Long, s:String ?= "", tags:String ?= "", limit:Int ?= 1, proximity:Long ?= -1)
 ###
 # tags: [ Challenge ]
 # summary: Retrieves next Task


### PR DESCRIPTION
* Support optional proximityId parameter in GET
`challenge/:cid/tasks/prioritizedTasks` API endpoint so that nearby tasks
can be retrieved while honoring task priority