### PR TITLE
merge to dev

### DIFF
--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -222,6 +222,8 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
     *
     * @param projectIds A comma separated list of projects to filter by
     * @return
+    *
+    * @deprecated("This method does not support virtual projects.", "05-23-2019")
     */
   def getChallengeSummaries(projectIds: String, priority: Int, onlyEnabled:Boolean = true): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>

--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -135,14 +135,15 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param order The order direction to sort
     * @return
     */
-  def getReviewedTasks(startDate: String=null, endDate: String=null,
-                       asReviewer: Boolean=false, allowReviewNeeded: Boolean=false,
+  def getReviewedTasks(mappers: String="", reviewers: String="",
+                       startDate: String=null, endDate: String=null, allowReviewNeeded: Boolean=false,
                        limit:Int, page:Int,
                        sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         val (count, result) = this.taskReviewDAL.getReviewedTasks(User.userOrMocked(user), params,
-             startDate, endDate, asReviewer, allowReviewNeeded, limit, page, sort, order)
+             Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
+             startDate, endDate, allowReviewNeeded, limit, page, sort, order)
         Ok(Json.obj("total" -> count, "tasks" -> _insertExtraJSON(result)))
       }
     }
@@ -200,11 +201,14 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param endDate Optional end date to filter by reviewedAt date
     * @return
     */
-  def getReviewMetrics(reviewTasksType: Int, startDate: String=null, endDate: String=null,
+  def getReviewMetrics(reviewTasksType: Int, mappers: String="", reviewers: String="",
+                       startDate: String=null, endDate: String=null,
                        onlySaved: Boolean=false) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
-        val result = this.taskReviewDAL.getReviewMetrics(User.userOrMocked(user), reviewTasksType, params, startDate, endDate, onlySaved)
+        val result = this.taskReviewDAL.getReviewMetrics(User.userOrMocked(user),
+                       reviewTasksType, params, Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
+                       startDate, endDate, onlySaved)
         Ok(Json.toJson(result))
       }
     }

--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -69,7 +69,8 @@ case class RawActivity(date: DateTime, osmUserId: Long, osmUsername: String, pro
 case class LeaderboardChallenge(id: Long, name: String, activity: Int)
 
 case class LeaderboardUser(userId: Long, name: String, avatarURL: String,
-                           score: Int, rank: Int, topChallenges: List[LeaderboardChallenge])
+                           score: Int, rank: Int, created: DateTime,
+                           topChallenges: List[LeaderboardChallenge])
 
 /**
   * @author cuthbertm
@@ -208,12 +209,38 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
       .as(get[Option[Int]]("count").single).getOrElse(0)
   }
 
+  private def buildProjectSearch(projectList: Option[List[Long]] = None, projectColumn: String, challengeColumn: String): String = {
+    projectList match {
+      case Some(idList) if idList.nonEmpty =>
+        s"""AND ($projectColumn IN (${idList.mkString(",")})
+                 OR 1 IN (SELECT 1 FROM unnest(ARRAY[${idList.mkString(",")}]) AS pIds
+                     WHERE pIds IN (SELECT vp.project_id FROM virtual_project_challenges vp
+                                    WHERE vp.challenge_id = ${challengeColumn})))"""
+      case _ => ""
+    }
+  }
+
+  private def findRelevantChallenges(projectList: Option[List[Long]]): Option[List[Long]] = {
+    this.db.withConnection { implicit c =>
+      // Let's determine all the challenges that are in these projects
+      // to make our query faster.
+      implicit val conjunction = Some(WHERE())
+      val projectChallengeQuery =
+        s"""SELECT id FROM challenges
+         ${getLongListFilter(projectList, "parent_id")} OR id IN
+          (SELECT challenge_id FROM virtual_project_challenges vp
+           ${getLongListFilter(projectList, "vp.project_id")})
+         """
+      Some(SQL(projectChallengeQuery).as(long("id").*))
+    }
+  }
+
   def getUserChallengeSummary(projectList: Option[List[Long]] = None, challengeId: Option[Long] = None,
                               start: Option[DateTime] = None, end: Option[DateTime] = None, priority: Option[Int]): UserSummary = {
     this.db.withConnection { implicit c =>
       val challengeProjectFilter = challengeId match {
         case Some(id) => s"AND sa.challenge_id = $id"
-        case None => getLongListFilter(projectList, "sa.project_id")
+        case None => buildProjectSearch(projectList, "sa.project_id", "sa.challenge_id")
       }
       val actionParser = for {
         available <- get[Option[Double]]("available")
@@ -400,12 +427,14 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
     * @param challengeId  The challenge used to filter the results, optional
     * @param searchString The search string that was applied to the query
     * @return A integer value which is the total challenges included in the results
+    *
+    * @deprecated("This method does not support virtual projects.", "05-23-2019")
     */
   def getTotalSummaryCount(projectList: Option[List[Long]] = None, challengeId: Option[Long] = None, searchString: String = ""): Int = {
     this.db.withConnection { implicit c =>
       val challengeFilter = challengeId match {
         case Some(id) if id != -1 => s"AND id = $id"
-        case _ => buildProjectSearch(projectList, "c.parent_id", "c.id")
+        case _ => getLongListFilter(projectList, "c.parent_id")
       }
       val query =
         s"""SELECT COUNT(*) AS total FROM challenges c
@@ -489,7 +518,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
       } yield ChallengeActivity(seriesDate, status, Task.getStatusName(status).getOrElse("Unknown"), count)
       val challengeProjectFilter = challengeId match {
         case Some(id) => s"AND challenge_id = $id"
-        case None => buildProjectSearch(projectList, "project_id", "challenge_id")
+        case None => buildProjectSearch(projectList, "project_id", "c.id")
       }
       val dates = this.getDates(start, end)
       SQL"""
@@ -537,6 +566,12 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         status <- int("status_actions.status")
       } yield RawActivity(date, osmUserId, osmUsername, projectId, projectName, challengeId,
         challengeName, taskId, oldStatus, status)
+
+      var challengeList = challengeFilter
+      if (projectFilter != None) {
+        challengeList = findRelevantChallenges(projectFilter)
+      }
+
       SQL"""
          SELECT sa.created, sa.osm_user_id, u.name, sa.project_id, p.name, sa.challenge_id,
                  c.name, sa.task_id, sa.old_status, sa.status
@@ -545,8 +580,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
          INNER JOIN projects p ON p.id = sa.project_id
          INNER JOIN challenges c ON c.id = sa.challenge_id
          WHERE #${getDateClause("sa.created", start, end)}
-         #${getLongListFilter(projectFilter, "sa.project_id")}
-         #${getLongListFilter(challengeFilter, "sa.challenge_id")}
+         #${getLongListFilter(challengeList, "sa.challenge_id")}
          #${getLongListFilter(userFilter, "sa.osm_user_id")}
          """.as(parser.*)
     }
@@ -591,7 +625,8 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
           avatarURL <- str("user_avatar_url")
           score <- int("user_score")
           rank <- int("user_ranking")
-        } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+          created <- get[DateTime]("created")
+        } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
           this.getUserTopChallenges(userId, projectFilter, challengeFilter,
             countryCodeFilter, monthDuration, start, end, onlyEnabled))
 
@@ -630,14 +665,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
       // Let's determine all the challenges that are in these projects
       // to make our query faster.
       if (projectList != None) {
-        implicit val conjunction = Some(WHERE())
-        val projectChallengeQuery =
-          s"""SELECT id FROM challenges
-           ${getLongListFilter(projectFilter, "parent_id")} OR id IN
-            (SELECT challenge_id FROM virtual_project_challenges vp
-             ${getLongListFilter(projectFilter, "vp.project_id")})
-           """
-        challengeList = Some(SQL(projectChallengeQuery).as(long("id").*))
+        challengeList = findRelevantChallenges(projectList)
         projectList = None
       }
 
@@ -647,7 +675,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         avatarURL <- str("users.avatar_url")
         score <- int("score")
         rank <- int("row_number")
-      } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+      } yield LeaderboardUser(userId, name, avatarURL, score, rank, new DateTime(),
         this.getUserTopChallenges(userId, projectList,
           challengeList, countryCodeFilter,
           monthDuration, start, end, onlyEnabled))
@@ -694,6 +722,14 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
       case _ => ""
     }
 
+    var challengeList = challengeFilter
+
+    // Let's determine all the challenges that are in these projects
+    // to make our query faster.
+    if (projectFilter != None) {
+      challengeList = findRelevantChallenges(projectFilter)
+    }
+
     s"""
         SELECT users.id, users.name, users.avatar_url, ${this.scoreSumSQL()} AS score,
                ROW_NUMBER() OVER( ORDER BY ${this.scoreSumSQL()} DESC, sa.osm_user_id ASC)
@@ -705,8 +741,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
               $boundingSearch
               users.leaderboard_opt_out = FALSE
               ${getLongListFilter(userFilter, "users.id")}
-              ${getLongListFilter(projectFilter, "sa.project_id")}
-              ${getLongListFilter(challengeFilter, "sa.challenge_id")}
+              ${getLongListFilter(challengeList, "sa.challenge_id")}
         GROUP BY sa.osm_user_id, users.id
         ORDER BY score DESC, sa.osm_user_id ASC
       """
@@ -823,6 +858,14 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         case _ => ""
       }
 
+      var challengeList = challengeFilter
+
+      // Let's determine all the challenges that are in these projects
+      // to make our query faster.
+      if (projectFilter != None) {
+        challengeList = findRelevantChallenges(projectFilter)
+      }
+
       SQL"""SELECT sa.challenge_id, c.name, count(sa.challenge_id) as activity
             FROM status_actions sa, challenges c, projects p, users u
             #${taskTableIfNeeded}
@@ -831,8 +874,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
                   sa.osm_user_id = u.osm_id AND
                   #${boundingSearch}
                   sa.challenge_id = c.id
-                  #${getLongListFilter(projectFilter, "sa.project_id")}
-                  #${getLongListFilter(challengeFilter, "sa.challenge_id")}
+                  #${getLongListFilter(challengeList, "sa.challenge_id")}
                   #${enabledFilter}
             GROUP BY sa.challenge_id, c.name
             ORDER BY activity DESC, sa.challenge_id ASC
@@ -873,7 +915,8 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
           avatarURL <- str("user_avatar_url")
           score <- int("user_score")
           rank <- int("user_ranking")
-        } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+          created <- get[DateTime]("created")
+        } yield LeaderboardUser(userId, name, avatarURL, score, rank, created,
           this.getUserTopChallenges(userId, projectFilter, challengeFilter,
             countryCodeFilter, monthDuration, start, end, onlyEnabled))
 
@@ -922,7 +965,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
         avatarURL <- str("users.avatar_url")
         score <- int("score")
         rank <- int("row_number")
-      } yield LeaderboardUser(userId, name, avatarURL, score, rank,
+      } yield LeaderboardUser(userId, name, avatarURL, score, rank, new DateTime(),
         this.getUserTopChallenges(userId, projectFilter, challengeFilter,
           countryCodeFilter, monthDuration, start, end, onlyEnabled))
 
@@ -976,6 +1019,14 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
       } yield RawActivity(date, osmUserId, osmUsername, projectId, projectName, challengeId,
         challengeName, taskId, oldStatus, status)
 
+      var challengeList = challengeFilter
+
+      // Let's determine all the challenges that are in these projects
+      // to make our query faster.
+      if (projectFilter != None) {
+        challengeList = findRelevantChallenges(projectFilter)
+      }
+
       SQL"""SELECT sa.*, challenges.name, projects.name, users.name FROM challenges, projects, users
             JOIN LATERAL (
               SELECT * FROM status_actions
@@ -986,8 +1037,7 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
             ) sa ON true
             WHERE challenges.parent_id = projects.id
             AND users.osm_id = sa.osm_user_id
-            #${getLongListFilter(projectFilter, "projects.id")}
-            #${getLongListFilter(challengeFilter, "challenges.id")}
+            #${getLongListFilter(challengeList, "challenges.id")}
       """.as(parser.*)
     }
   }

--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -193,6 +193,7 @@ object Challenge {
   val STATUS_READY = 3
   val STATUS_PARTIALLY_LOADED = 4
   val STATUS_FINISHED = 5
+  val STATUS_DELETING_TASKS = 6
 
   /**
     * This will check to make sure that the json rule is fully valid. The simple check just makes sure

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -195,10 +195,10 @@ trait DALHelper {
             case Some(ps) if ps.nonEmpty =>
               params.fuzzySearch match {
                 case Some(x) =>
-                  whereClause ++= this.fuzzySearch(s"$projectPrefix.name", "ps", x)(None)
+                  whereClause ++= this.fuzzySearch(s"$projectPrefix.display_name", "ps", x)(if (whereClause.isEmpty) None else Some(AND()))
                   parameters += ('ps -> ps)
                 case None =>
-                  whereClause ++= this.searchField(s"$projectPrefix.name", "ps")(None)
+                  whereClause ++= this.searchField(s"$projectPrefix.display_name", "ps")(if (whereClause.isEmpty) None else Some(AND()))
                   parameters += ('ps -> s"%$ps%")
               }
             case _ => // we can ignore this
@@ -283,7 +283,7 @@ trait DALHelper {
     */
   def searchField(column: String, key: String = "ss")
                  (implicit conjunction: Option[SQLKey] = Some(AND())): String =
-    s"${this.getSqlKey} LOWER($column) LIKE LOWER({$key})"
+    s" ${this.getSqlKey} LOWER($column) LIKE LOWER({$key})"
 
   /**
     * Adds fuzzy search to any query. This will include the Levenshtein, Metaphone and Soundex functions
@@ -305,7 +305,7 @@ trait DALHelper {
     } else {
       3
     }
-    s"""${this.getSqlKey} ($column <> '' AND
+    s""" ${this.getSqlKey} ($column <> '' AND
           (LEVENSHTEIN(LOWER($column), LOWER({$key})) < $score OR
             METAPHONE(LOWER($column), 4) = METAPHONE(LOWER({$key}), $metaphoneSize) OR
             SOUNDEX(LOWER($column)) = SOUNDEX(LOWER({$key})))

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -662,10 +662,12 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #   - name: endDate
 #     in: query
 #     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
-#   - name: asReviewer
+#   - name: mappers
 #     in: query
-#     description: Whether results should be tasks reviewed by this user or review requested by this user
-#   - name: allowReviewNeeded
+#     description: The mapper ids to search by. (review_requested_by)
+#   - name: reviewers
+#     in: query
+#     description: The reviewer ids to search by. (review_requested_by)
 #     in: query
 #     description: Whether results should be included tasks in tasks 'review requested'
 #   - name: limit
@@ -687,7 +689,7 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(startDate: String ?= null, endDate: String ?= null, asReviewer:Boolean ?= false, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(mappers:String ?= "", reviewers:String ?= "", startDate: String ?= null, endDate: String ?= null, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
 ###
 # summary: Retrieves and claims a the next review needed Task
 # produces: [ application/json ]
@@ -732,6 +734,12 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #   - name: reviewTasksType
 #     in: query
 #     description: integer value > 1 - To Be Reviewed 2 - User's reviewed Tasks 3 - All reviewed by users
+#   - name: mappers
+#     in: query
+#     description: the mapper ids to search by (review_requested_by)
+#   - name: reviewers
+#     in: query
+#     description: the reviewer ids to search by (reviewed_by)
 #   - name: startDate
 #     in: query
 #     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
@@ -739,7 +747,7 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #     in: query
 #     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
 ###
-GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
+GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
 ###
 # tags: [ Project ]
 # summary: Retrieves clustered challenge points
@@ -1751,11 +1759,17 @@ GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers
 #   - name: id
 #     in: path
 #     description: The id of the parent Challenge limiting the tasks to only a descendent of that Challenge.
-#   - name: filter
+#   - name: status
 #     in: query
 #     description: Can filter the Tasks returned by the status of the Task. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
+#   - name: priority
+#     in: query
+#     description: Can filter the Tasks returned by the priority of the Task. 0 - High, 1 - Medium, 2 - Low
+#   - name: reviewStatus
+#     in: query
+#     description: Can filter the Tasks returned by the reviewStatus of the Task. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted, 4 - Disputed
 ###
-GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, filter:String ?= "")
+GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves clustered Task points
@@ -3359,7 +3373,9 @@ GET     /tags                                       @org.maproulette.controllers
 GET     /data/challenge/:challengeId                @org.maproulette.controllers.api.DataController.getChallengeSummary(challengeId:Long, survey:Int ?= -1, priority:Int ?= -1)
 ### NoDocs ###
 GET     /data/challenge/:challengeId/users          @org.maproulette.controllers.api.DataController.getUserChallengeSummary(challengeId:Long, start:String ?= "", end:String ?= "", survey:Int ?= 0, priority:Int ?= -1)
-### NoDocs ###
+###
+# deprecated: true
+###
 POST    /data/challenge/summary                     @org.maproulette.controllers.api.DataController.getChallengeSummaries(projectList:String ?= "", priority:Int ?= -1, onlyEnabled:Boolean ?= true)
 ### NoDocs ###
 GET     /data/user/activity                         @org.maproulette.controllers.api.DataController.getRecentUserActivity(limit:Int ?= -1, offset:Int ?= 0)

--- a/conf/evolutions/default/36.sql
+++ b/conf/evolutions/default/36.sql
@@ -1,0 +1,10 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add timestamp to user_leaderboard
+
+ALTER TABLE "user_leaderboard" ADD COLUMN created timestamp without time zone DEFAULT NOW();;
+
+
+# --- !Downs
+ALTER TABLE "user_leaderboard" DROP COLUMN created;;

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -2962,6 +2962,942 @@
 			]
 		},
 		{
+			"name": "VirtualProject",
+			"item": [
+				{
+					"name": "Virtual Project Creation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e8b33660-98cc-40fd-88a5-6a51bf8e541d",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"VPProjectID\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"VPProject\";",
+									"tests[\"description\"] = jsonData.description === \"Test virtual project for api testing.\";",
+									"tests[\"isVirtual\"] = jsonData.isVirtual === true;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"VPProject\",\n    \"description\":\"Test virtual project for api testing.\",\n    \"enabled\":true,\n    \"isVirtual\":true\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
+						},
+						"description": "Creates a base project for all the other Map Roulette API Testing"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Project Creation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e2e239b5-f0bb-4db2-9ff5-c35dcad3ac9a",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"SimpleProjectID1\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"SimpleProject1\";",
+									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"SimpleProject1\",\n    \"description\":\"Test project containing all children used for api testing.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
+						},
+						"description": "Creates a base project for all the other Map Roulette API Testing"
+					},
+					"response": []
+				},
+				{
+					"name": "Challenge Creation",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "8c9d2e3d-d15e-404e-b481-401d3784fa86",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"SimpleChallengeID1\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"SimpleChallenge1\";",
+									"tests[\"description\"] = jsonData.description === \"A simple challenge containing only the basic elements for a challenge\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"Instruction for the simple challenge\";",
+									"tests[\"challengeType\"] = jsonData.challengeType === 1;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"SimpleChallenge1\",\n    \"description\":\"A simple challenge containing only the basic elements for a challenge\",\n    \"parent\":{{SimpleProjectID1}},\n    \"instruction\":\"Instruction for the simple challenge\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge"
+							]
+						},
+						"description": "Creates the most basic challenge with the least set of options in the body json"
+					},
+					"response": []
+				},
+				{
+					"name": "VP Challenge Add",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6b0b445c-c19d-4118-be3c-df9246996105",
+								"exec": [
+									"tests[\"response code is 201\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}/challenge/{{SimpleChallengeID1}}/add",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{VPProjectID}}",
+								"challenge",
+								"{{SimpleChallengeID1}}",
+								"add"
+							]
+						},
+						"description": "Creates the most basic challenge with the least set of options in the body json"
+					},
+					"response": []
+				},
+				{
+					"name": "Project List",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b990bc5d-5b6a-4f0b-ab1f-73ed847db742",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"Body matches name\"] = responseBody.has(\"VPProject\");",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/projects?limit=-1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"projects"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "-1"
+								}
+							]
+						},
+						"description": "Lists all the projects in the system"
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project Read",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"name\"] = jsonData.name === \"VPProject\";",
+									"tests[\"isVirtual\"] = jsonData.isVirtual === true;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{VPProjectID}}"
+							]
+						},
+						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project Children",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "6bc048ac-0af1-4d72-9b76-18cb706e8cda",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"jsonData.name === \"VPProject\";",
+									"tests[\"name\"] = jsonData.children[0].name === \"SimpleChallenge1\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}/children",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{VPProjectID}}",
+								"children"
+							]
+						},
+						"description": "Gets the children of the project"
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project Summary",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/data/project/summary?projectList={{VPProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"data",
+								"project",
+								"summary"
+							],
+							"query": [
+								{
+									"key": "projectList",
+									"value": "{{VPProjectID}}"
+								}
+							]
+						},
+						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
+					},
+					"response": [
+						{
+							"name": "VP Project Summary",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "apiKey",
+										"value": "test"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "http://localhost:9000/api/v2/data/project/summary?projectList={{VPProjectID}}",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "9000",
+									"path": [
+										"api",
+										"v2",
+										"data",
+										"project",
+										"summary"
+									],
+									"query": [
+										{
+											"key": "projectList",
+											"value": "{{VPProjectID}}"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Vary",
+									"value": "Accept-Encoding,Origin"
+								},
+								{
+									"key": "Content-Encoding",
+									"value": "gzip"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 23 May 2019 15:01:15 GMT"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Content-Length",
+									"value": "28"
+								}
+							],
+							"cookie": [],
+							"body": "[]"
+						}
+					]
+				},
+				{
+					"name": "VP Project Leaderboard",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/data/user/leaderboard?projectIds={{VPProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"data",
+								"user",
+								"leaderboard"
+							],
+							"query": [
+								{
+									"key": "projectIds",
+									"value": "{{VPProjectID}}"
+								}
+							]
+						},
+						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project Activity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/data/project/activity?projectList={{VPProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"data",
+								"project",
+								"activity"
+							],
+							"query": [
+								{
+									"key": "projectList",
+									"value": "{{VPProjectID}}"
+								}
+							]
+						},
+						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project User Summary",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/data/user/summary?projectList={{VPProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"data",
+								"user",
+								"summary"
+							],
+							"query": [
+								{
+									"key": "projectList",
+									"value": "{{VPProjectID}}"
+								}
+							]
+						},
+						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project Raw Activity",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"pm.test(\"Body is correct\", function () {",
+									"    pm.response.to.have.body(\"[]\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/data/raw/activity?projectIds={{VPProjectID}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"data",
+								"raw",
+								"activity"
+							],
+							"query": [
+								{
+									"key": "projectIds",
+									"value": "{{VPProjectID}}"
+								}
+							]
+						},
+						"description": "Gets the project from the supplied ID. Will need to modify the ID based on the ID returned from the creation API."
+					},
+					"response": []
+				},
+				{
+					"name": "VP Challenge Remove",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bb86b48d-e330-49e5-a4da-d098b2136260",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}/challenge/{{SimpleChallengeID1}}/remove",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{VPProjectID}}",
+								"challenge",
+								"{{SimpleChallengeID1}}",
+								"remove"
+							]
+						},
+						"description": "Creates the most basic challenge with the least set of options in the body json"
+					},
+					"response": []
+				},
+				{
+					"name": "Project Children",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ded06c13-b45a-4536-9b8c-08232a15a1ca",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"name\"] = jsonData[0].name === \"SimpleChallenge1\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID1}}/challenges",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID1}}",
+								"challenges"
+							]
+						},
+						"description": "Gets the children of the project"
+					},
+					"response": []
+				},
+				{
+					"name": "Project Deletion",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1257b0e9-25a3-4843-a7c2-1e366be2cf94",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"Status\"] = jsonData.status === \"OK\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID1}}?immediate=true",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{SimpleProjectID1}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true"
+								}
+							]
+						},
+						"description": "Deletes the project created by the project creation. Would need to modify the supplied ID."
+					},
+					"response": []
+				},
+				{
+					"name": "VP Project Deletion",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9dd6dd4b-9180-42aa-9d47-50b8eccc0771",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"Status\"] = jsonData.status === \"OK\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}?immediate=true",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{VPProjectID}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true"
+								}
+							]
+						},
+						"description": "Deletes the project created by the project creation. Would need to modify the supplied ID."
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "tag",
 			"item": [
 				{


### PR DESCRIPTION
* Support for Virtual Projects (#550) (#551)

* Create evolution to add virtual project_challenge join table
  and project.is_virtual column

* Create virtual project controller/dal to handle add/remove challenges

* Modify project and challenge queries to use new join table

* Add timestamp column to user_leaderboard (#558)

* Add timestamp column 'created' to user_leaderboard

* In api return created field in json

* Bug where only reviewers can contest their rejected tasks (#557)

* Allow users to contest their rejected tasks even if they
  aren't a reviewer

* Fix review status not updating in cache in setTaskStatus (#556)

* Add virtual projects to challenges listing project filter (#555)

* Prevent task loop at priority boundary (#554)

* Always include check to prevent randomly serving up tasks that the
user has recently worked on, rather than only performing the check when
requesting proximate tasks, as the same sort of task loop can occur when
a user is skipping the last task at a priority level

* Add additional support for virtual projects in data methods (#553)

* Also add Postman tests for virtual projects to ensure methods
  run without errors.

* Deprecated method getChallengeSummaries as it is not used
  and does not support virtual projects.

* Add support for all reviewed tasks (#564)

* CSV export bug -- reviewer column was wrong (#563)

* Allow project name in extendedFind search (#562)

* Support project name (`ps`) in extendedFind challenge searches to
further narrow down challenge results

* Change project-name search to use display_name instead of name

* Fix missing space if project-name search clause was added to an
existing WHERE clause

* Fix created column not present in non-prebuilt leaderboard queries (#561)

* Delete tasks asynchronously and in batches (#559)

* Add new DELETING_TASKS challenge status

* Change the `DELETE /challenge/:id/tasks` API endpoint to delete tasks
asynchronously and to change the challenge status to DELETING_TASKS
while the delete operation is ongoing

* Change `ChallengeDal.deleteTasks` to work in small batches

* Add guard conditions to ChallengeController to prevent bulk task
deletion or challenge rebuilds while a deletion or rebuild is already in
progress

* Change getChallengeGeometry to inclue task info. (#565)

* Add additional geoJSON properties field "maproulette"
  which includes additional MR related task info

* Fixed query when using status filter

* Added additional filter 'reviewStatus' and 'priority'