### PR TITLE
Update modified date in cache in setTaskStatus

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -645,10 +645,12 @@ class TaskDAL @Inject()(override val db: Database,
     if (reviewNeeded) {
       this.cacheManager.withOptionCaching { () => Some(task.copy(status = Some(status),
                                                  reviewStatus = Some(Task.REVIEW_STATUS_REQUESTED),
-                                                 reviewRequestedBy = Some(user.id))) }
+                                                 reviewRequestedBy = Some(user.id),
+                                                 modified = new DateTime())) }
     }
     else {
-      this.cacheManager.withOptionCaching { () => Some(task.copy(status = Some(status))) }
+      this.cacheManager.withOptionCaching { () => Some(task.copy(status = Some(status),
+                                                                 modified = new DateTime()))}
     }
     this.challengeDAL.get().updateFinishedStatus()(task.parent)
 
@@ -1354,7 +1356,7 @@ class TaskDAL @Inject()(override val db: Database,
       if (taskIdList.nonEmpty) {
         this.appendInWhereClause(whereClause, s"task_id IN (${taskIdList.mkString(",")})")
       }
-            
+
       SQL(
         s"""
               SELECT * FROM task_comments tc


### PR DESCRIPTION
Modified date does get updated during setTaskStatus but the new timestamp isn't updated in the cache so a subsequent call to get the task details does not correctly show an updated modified time.
