### PR TITLE
Add API for normal user to update task tags

### DIFF
--- a/app/org/maproulette/models/dal/TagDAL.scala
+++ b/app/org/maproulette/models/dal/TagDAL.scala
@@ -194,7 +194,6 @@ class TagDAL @Inject()(override val db: Database,
     */
   def updateTagList(tags: List[Tag], user: User)(implicit c: Option[Connection] = None): List[Tag] = {
     if (tags.nonEmpty) {
-      this.permission.hasSuperAccess(user)
       implicit val names = tags.filter(_.name.nonEmpty).map(_.name)
       this.cacheManager.withCacheNameDeletion { () =>
         this.withMRTransaction { implicit c =>

--- a/app/org/maproulette/models/dal/TagDALMixin.scala
+++ b/app/org/maproulette/models/dal/TagDALMixin.scala
@@ -99,7 +99,6 @@ trait TagDALMixin[T <: BaseObject[Long]] {
   def updateItemTags(id: Long, tags: List[Long], user: User, completeList: Boolean = false)(implicit c: Option[Connection] = None): Unit = {
     this.retrieveById(id) match {
       case Some(item) =>
-        this.permission.hasObjectWriteAccess(item, user)
         this.withMRTransaction { implicit c =>
           if (tags.nonEmpty) {
             if (completeList) {

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2841,6 +2841,32 @@ GET     /task/:id/tags                              @org.maproulette.controllers
 GET     /tasks/tags                                 @org.maproulette.controllers.api.TaskController.getItemsBasedOnTags(tags:String ?= "", limit:Int ?= 10, page:Int ?= 0)
 ###
 # tags: [ Task ]
+# summary: Updates Task Tags
+# description: Updates the tags on the Task
+# responses:
+#   '304':
+#     description: A basic 304 with NoContent will be returned on a successful delete
+#   '400':
+#     description: If no tags are supplied a BadRequest response will be returned
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID of the Task
+#   - name: tags
+#     in: query
+#     description: A complete comma separated list of tags. If empty, then all tags will be removed.
+#     required: true
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+###
+GET  /task/:id/tags/update                              @org.maproulette.controllers.api.TaskController.updateItemTags(id:Long, tags:String ?= "")
+###
+# tags: [ Task ]
 # summary: Delete Task Tags
 # description: Deletes all the supplied tags from the Task
 # responses:

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -5149,6 +5149,121 @@
 					"response": []
 				},
 				{
+					"name": "Task Tags Update",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "accfcc10-4c9d-432b-9798-e893f2cfd930",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"sometag1\");",
+									"    pm.expect(pm.response.text()).to.include(\"sometag2\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}/tags/update?tags=sometag1,sometag2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask1}}",
+								"tags",
+								"update"
+							],
+							"query": [
+								{
+									"key": "tags",
+									"value": "sometag1,sometag2"
+								}
+							]
+						},
+						"description": "Gets the tag"
+					},
+					"response": []
+				},
+				{
+					"name": "Read Task Tags",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "accfcc10-4c9d-432b-9798-e893f2cfd930",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"sometag1\");",
+									"    pm.expect(pm.response.text()).to.include(\"sometag2\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}/tags",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask1}}",
+								"tags"
+							]
+						},
+						"description": "Gets the tag"
+					},
+					"response": []
+				},
+				{
 					"name": "Teardown",
 					"event": [
 						{


### PR DESCRIPTION
Normal users need to be able to add/modify task tags. Add api to only modify tags (not full task or challenge)