### PR TITLE
Fix tag creation postman tests failing.

### DIFF
--- a/app/org/maproulette/controllers/api/TagsMixin.scala
+++ b/app/org/maproulette/controllers/api/TagsMixin.scala
@@ -116,20 +116,25 @@ trait TagsMixin[T <: BaseObject[Long]] {
       case tags: JsDefined =>
         // this case is for a comma separated list, either of ints or strings
         if (!tags.isEmpty) {
-          tags.as[String].split(",").toList.map(tag => {
-            try {
-              Tag(tag.toLong, "")
-            } catch {
-              case e: NumberFormatException =>
-                // this is the case where a name is supplied, so we will either search for a tag with
-                // the same name or create a new tag with the current name
-                this.tagDAL.retrieveByName(tag) match {
-                  case Some(t) => t.asInstanceOf[Tag]
-                  case None =>
-                    Tag(-1, tag, tagType = this.dal.tableName)
-                }
-            }
-          })
+          try {
+            tags.as[String].split(",").toList.map(tag => {
+              try {
+                Tag(tag.toLong, "")
+              } catch {
+                case e: NumberFormatException =>
+                  // this is the case where a name is supplied, so we will either search for a tag with
+                  // the same name or create a new tag with the current name
+                  this.tagDAL.retrieveByName(tag) match {
+                    case Some(t) => t.asInstanceOf[Tag]
+                    case None =>
+                      Tag(-1, tag, tagType = this.dal.tableName)
+                  }
+              }
+            })
+          } catch {
+            case e =>
+              List.empty
+          }
         }
         else {
           List.empty

--- a/app/org/maproulette/models/dal/TagDAL.scala
+++ b/app/org/maproulette/models/dal/TagDAL.scala
@@ -54,7 +54,7 @@ class TagDAL @Inject()(override val db: Database,
     this.permission.hasObjectWriteAccess(tag, user)
     this.cacheManager.withOptionCaching { () =>
       this.withMRTransaction { implicit c =>
-        SQL("INSERT INTO tags (name, description, tag_type) VALUES ({name}, {description}, {tagType}) ON CONFLICT(LOWER(name)) DO NOTHING RETURNING *")
+        SQL("INSERT INTO tags (name, description, tag_type) VALUES ({name}, {description}, {tagType}) ON CONFLICT(LOWER(name), tag_type) DO NOTHING RETURNING *")
           .on('name -> tag.name.toLowerCase, 'description -> tag.description,'tagType -> tag.tagType).as(this.parser.*).headOption
       }
     } match {


### PR DESCRIPTION
Changing the unique constraints introduced a bug which caused the postman tests to fail. Fix tag creation insert sql statement. 