### PR TITLE
Add flag for challenge URL inclusion.

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -90,7 +90,8 @@ case class ChallengeExtra(defaultZoom: Int = Challenge.DEFAULT_ZOOM,
                           defaultBasemap: Option[Int] = None,
                           defaultBasemapId: Option[String] = None,
                           customBasemap: Option[String] = None,
-                          updateTasks: Boolean = false) extends DefaultWrites
+                          updateTasks: Boolean = false,
+                          includeCheckinURL: Boolean = false) extends DefaultWrites
 
 case class ChallengeListing(id: Long,
                             parent: Long,

--- a/conf/evolutions/default/39.sql
+++ b/conf/evolutions/default/39.sql
@@ -1,0 +1,9 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Column to keep track of whether changeset/checkin comments should have the
+-- challenge URL appended to them.
+SELECT add_drop_column('challenges', 'include_checkin_url', 'BOOLEAN DEFAULT(false)');
+
+# --- !Downs
+--SELECT add_drop_column('challenges', 'include_checkin_url', '', false);

--- a/docs/challenge_api.md
+++ b/docs/challenge_api.md
@@ -68,6 +68,7 @@ As shown in the example there are 3 basic options that are required to create a 
 - **defaultBasemap** - 
 - **customBasemap** - URL for a custom basemap to be applied to the map for a specific challenge.
 - **updateTasks** - Whether to update the tasks on a periodic basis. This will also delete stale tasks.
+- **includeCheckinURL** - Whether to append the URL of the challenge to the changeset comment. Boolean, defaults to false.
 
 #### Manually Building a Task
 


### PR DESCRIPTION
This adds a flag to the Challenge type and database. When true, the URL of the challenge can be appended to the changeset comment, which is useful for easier traceability of changesets back to the challenge intent and instructions.

This is optional, defaulted to false for the moment. There are corresponding changes to the React UI which allow it to be toggled at challenge creation time. In contrast to the hashtag, which is added before the challenge is created, the URL needs to know the challenge ID and so must be added later. Rather than have the UI read back the new ID and re-save the challenge, it seemed cleaner to store the flag.

Refs https://github.com/osmlab/maproulette3/issues/178