### PR TITLE
Adding Lazy Load Migration

### DIFF
--- a/conf/evolutions/default/39.sql
+++ b/conf/evolutions/default/39.sql
@@ -3,12 +3,31 @@
 # --- !Ups
 -- THESE COMMENTED SCRIPTS NEED TO BE RUN BEFORE UPGRADING -------------------------------
 -- Add new geojson and geometries into the task table, migrate all the task geometry data to the task table and then drop the task_geometry table
---ALTER TABLE tasks ADD COLUMN geojson JSONB;;
---SELECT AddGeometryColumn('tasks', 'geom', 4326, 'GEOMETRY', 2);;
---ALTER TABLE tasks ADD COLUMN suggestedfix_geojson JSONB;;
+DO $$
+BEGIN
+  PERFORM column_name FROM information_schema.columns WHERE table_name = 'tasks' AND column_name = 'geojson';;
+  IF NOT FOUND THEN
+    ALTER TABLE tasks ADD COLUMN geojson JSONB;;
+  END IF;;
+END$$;;
+DO $$
+BEGIN
+  PERFORM column_name FROM information_schema.columns WHERE table_name = 'tasks' AND column_name = 'geom';;
+  IF NOT FOUND THEN
+    PERFORM AddGeometryColumn('tasks', 'geom', 4326, 'GEOMETRY', 2);;
+  END IF;;
+END$$;;
+DO $$
+BEGIN
+  PERFORM column_name FROM information_schema.columns WHERE table_name = 'tasks' AND column_name = 'geojson';;
+  IF NOT FOUND THEN
+    ALTER TABLE tasks ADD COLUMN suggestedfix_geojson JSONB;;
+  END IF;;
+END$$;;
 
 -- Migrate all the old geometries to the new structure
--- update the geojson columns
+-- update the geojson columns -- SEE 39_upgrade.py python script
+-- THIS PYTHON SCRIPT MUST BE RUN BEFORE UPGRADING
 --DO $$
 --    DECLARE identifier integer;;
 --BEGIN
@@ -42,7 +61,7 @@
 --                                      ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
 --                                      HSTORE_TO_JSON(lg.properties) AS properties
 --                              FROM task_suggested_fix AS lg
---                              WHERE task_id = $id
+--                              WHERE task_id = id
 --                        ) AS f
 --                )  AS fc) AS geoms;
 --    END LOOP;;
@@ -51,6 +70,38 @@
 --DROP TABLE task_geometries CASCADE;;
 --DROP TABLE task_suggested_fix CASCADE;;
 ----------------------------------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION update_challenge_geometry(challenge_identifier bigint)
+    RETURNS VOID AS $$
+DECLARE
+    identifier BIGINT;;
+BEGIN
+    FOR identifier IN SELECT id FROM tasks WHERE parent_id = challenge_identifier AND geojson IS NULL LOOP
+        PERFORM update_geometry(identifier);;
+     END LOOP;;
+END
+$$ LANGUAGE plpgsql VOLATILE;;
+
+CREATE OR REPLACE FUNCTION update_geometry(task_identifier bigint)
+	RETURNS TABLE(geo TEXT, loc TEXT, fix_geo TEXT) AS $$
+BEGIN
+    UPDATE tasks t SET geojson = geoms.geometries FROM (SELECT ROW_TO_JSON(fc)::JSONB AS geometries
+                      FROM ( SELECT 'FeatureCollection' AS type, ARRAY_TO_JSON(array_agg(f)) AS features
+                               FROM ( SELECT 'Feature' AS type,
+                                              ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
+                                              HSTORE_TO_JSON(lg.properties) AS properties
+                                      FROM task_geometries AS lg
+                                      WHERE task_id = task_identifier
+                                ) AS f
+                        )  AS fc) AS geoms WHERE id = task_identifier;;
+    -- Update the geometry and location columns
+    UPDATE tasks t SET geom = geoms.geometry, location = ST_CENTROID(geoms.geometry)
+    FROM (SELECT ST_COLLECT(ST_MAKEVALID(geom)) AS geometry FROM (
+            SELECT geom FROM task_geometries WHERE task_id = task_identifier
+         ) AS innerQuery) AS geoms WHERE id = task_identifier;;
+	 RETURN QUERY SELECT geojson::TEXT, ST_AsGeoJSON(location) AS geo_location, suggestedfix_geojson::TEXT FROM tasks
+	 WHERE id = task_identifier;;
+END
+$$ LANGUAGE plpgsql VOLATILE;;
 
 -- Creates or updates and task. Will also check if task status needs to be updated
 -- This change adds the mapped_on, review_status, review_requested_by, reviewed_by

--- a/scripts/39_upgrade.py
+++ b/scripts/39_upgrade.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+import psycopg2
+import sys
+import time
+
+hostname = 'localhost'
+port = 5433
+username = 'osm'
+password = 'osm'
+database = 'mr_07_11_19'
+
+def main():
+    conn = psycopg2.connect(host=hostname, user=username, password=password, dbname=database, port=port)
+    cur = conn.cursor()
+    cur.execute("SELECT id FROM tasks WHERE geojson IS NULL OR geom IS NULL")
+    counter=0
+    idList=[]
+    for row in cur:
+        idList.append(row[0])
+        counter = counter + 1
+        if counter % 25000 == 0:
+            stringIdList = ','.join(str(e) for e in idList)
+            start = time.time()
+            updateCursor = conn.cursor()
+            updateCursor.execute(f"""UPDATE tasks t SET geojson = geoms.geometries FROM (
+                                        SELECT task_id, ROW_TO_JSON(fc)::JSONB AS geometries
+                                        FROM ( SELECT task_id, 'FeatureCollection' AS type, ARRAY_TO_JSON(array_agg(f)) AS features
+                                                FROM ( SELECT task_id, 'Feature' AS type,
+                                                                ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
+                                                                HSTORE_TO_JSON(lg.properties) AS properties
+                                                        FROM task_geometries AS lg
+                                                        WHERE task_id IN ({stringIdList})
+                                                ) AS f GROUP BY task_id
+                                    )  AS fc) AS geoms WHERE id IN ({stringIdList}) AND id = geoms.task_id""")
+            updateCursor.execute(f"""
+                UPDATE tasks t SET geom = geoms.geometry, location = ST_CENTROID(geoms.geometry)
+                FROM (SELECT task_id, ST_COLLECT(ST_MAKEVALID(geom)) AS geometry FROM (
+                       SELECT task_id, geom FROM task_geometries WHERE task_id IN ({stringIdList})
+                    ) AS innerQuery GROUP BY task_id) AS geoms WHERE id IN ({stringIdList}) AND id = geoms.task_id
+            """)
+            conn.commit()
+            updateCursor.close()
+            end = time.time()
+            print(f"Updated: {counter} ({len(idList)} in {end - start})")
+            #print("For ids: ", stringIdList)
+            idList.clear()
+    cur.close()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/39_upgrade.sql
+++ b/scripts/39_upgrade.sql
@@ -1,0 +1,20 @@
+do $$
+	declare idlist int[];
+begin
+	select array(select id from tasks where geojson is null limit 1000000) into idlist;
+	UPDATE tasks t SET geojson = geoms.geometries FROM (
+		SELECT task_id, ROW_TO_JSON(fc)::JSONB AS geometries
+		FROM ( SELECT task_id, 'FeatureCollection' AS type, ARRAY_TO_JSON(array_agg(f)) AS features
+				FROM ( SELECT task_id, 'Feature' AS type,
+								ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
+								HSTORE_TO_JSON(lg.properties) AS properties
+						FROM task_geometries AS lg
+						WHERE task_id = ANY (idlist)
+				) AS f GROUP BY task_id
+	)  AS fc) AS geoms WHERE id = ANY (idlist) AND id = geoms.task_id;
+	UPDATE tasks t SET geom = geoms.geometry, location = ST_CENTROID(geoms.geometry)
+	FROM (SELECT task_id, ST_COLLECT(ST_MAKEVALID(geom)) AS geometry FROM (
+		   SELECT task_id, geom FROM task_geometries WHERE task_id = ANY (idlist)
+		) AS innerQuery GROUP BY task_id) AS geoms WHERE id = ANY (idlist) AND id = geoms.task_id;
+end $$;
+

--- a/test/org/maproulette/cache/CacheSpec.scala
+++ b/test/org/maproulette/cache/CacheSpec.scala
@@ -6,7 +6,7 @@ import org.maproulette.data.{ItemType, ProjectType}
 import org.maproulette.models.BaseObject
 import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
-import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.{DefaultWrites, JodaReads, JodaWrites, Json, Reads, Writes}
 
 /**
   * @author cuthbertm
@@ -18,7 +18,7 @@ case class TestBaseObject(override val id: Long,
   override val itemType: ItemType = ProjectType()
 }
 
-class CacheSpec extends PlaySpec {
+class CacheSpec extends PlaySpec with JodaWrites with JodaReads {
   implicit val groupWrites: Writes[TestBaseObject] = Json.writes[TestBaseObject]
   implicit val groupReads: Reads[TestBaseObject] = Json.reads[TestBaseObject]
   implicit val configuration = Configuration.from(Map(Config.KEY_CACHING_CACHE_LIMIT -> 6, Config.KEY_CACHING_CACHE_EXPIRY -> 5))


### PR DESCRIPTION
For the 3.6.0 release we are migrating geometry data from the task_geometries table to the tasks table. This turns out to be quite a long process, so to alleviate the pain of a major migration I had added lazy migration into the code. This will then migrate the geometry data as it is requested. Which for an individual task only takes a couple 100 milliseconds and only has to happen once. Even for challenges when requesting challenge geometry it will update the whole challenge in the background. This could potentially cause momentary performance degradation, but again it only has to happen once.