### PR TITLE
Add new task status 'disabled'

### DIFF
--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -140,6 +140,8 @@ object Task {
   val STATUS_ANSWERED_NAME = "Answered"
   val STATUS_VALIDATED = 8
   val STATUS_VALIDATED_NAME = "Validated"
+  val STATUS_DISABLED = 9
+  val STATUS_DISABLED_NAME = "Disabled"
   val statusMap = Map(
     STATUS_CREATED -> STATUS_CREATED_NAME,
     STATUS_FIXED -> STATUS_FIXED_NAME,
@@ -149,7 +151,8 @@ object Task {
     STATUS_ALREADY_FIXED -> STATUS_ALREADY_FIXED_NAME,
     STATUS_TOO_HARD -> STATUS_TOO_HARD_NAME,
     STATUS_ANSWERED -> STATUS_ANSWERED_NAME,
-    STATUS_VALIDATED -> STATUS_VALIDATED_NAME
+    STATUS_VALIDATED -> STATUS_VALIDATED_NAME,
+    STATUS_DISABLED -> STATUS_DISABLED_NAME
   )
 
 
@@ -198,7 +201,7 @@ object Task {
     * @return True if the status can be set without violating any of the above rules
     */
   def isValidStatusProgression(current: Int, toSet: Int): Boolean = {
-    if (current == toSet || toSet == STATUS_DELETED) {
+    if (current == toSet || toSet == STATUS_DELETED || toSet == STATUS_DISABLED) {
       true
     } else {
       current match {
@@ -212,6 +215,7 @@ object Task {
         case STATUS_ALREADY_FIXED => false
         case STATUS_ANSWERED => false
         case STATUS_VALIDATED => false
+        case STATUS_DISABLED => toSet == STATUS_CREATED
       }
     }
   }

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -735,6 +735,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                                             WHEN t.tstatus = #${Task.STATUS_TOO_HARD} THEN ${Task.STATUS_TOO_HARD_NAME}
                                             WHEN t.tstatus = #${Task.STATUS_ANSWERED} THEN ${Task.STATUS_ANSWERED_NAME}
                                             WHEN t.tstatus = #${Task.STATUS_VALIDATED} THEN ${Task.STATUS_VALIDATED_NAME}
+                                            WHEN t.tstatus = #${Task.STATUS_DISABLED} THEN ${Task.STATUS_DISABLED_NAME}
                                            END)) ||
                                         hstore('mr_taskPriority',
                                           (CASE

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -469,7 +469,7 @@ class TaskDAL @Inject()(override val db: Database,
     val reviewNeeded = requestReview match {
       case Some(r) => r
       case None => user.settings.needsReview.getOrElse(config.defaultNeedsReview) != User.REVIEW_NOT_NEEDED &&
-        status != Task.STATUS_SKIPPED && status != Task.STATUS_DELETED
+        status != Task.STATUS_SKIPPED && status != Task.STATUS_DELETED && status != Task.STATUS_DISABLED
     }
 
     val oldStatus = task.status


### PR DESCRIPTION
New 'Disabled' status mimics delete but are for those tasks that are not to be worked on right now but may be relevant in the future.