### PR TITLE
Add completion responses in instructions and exportable feature properties in CSV

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -91,7 +91,8 @@ case class ChallengeExtra(defaultZoom: Int = Challenge.DEFAULT_ZOOM,
                           defaultBasemap: Option[Int] = None,
                           defaultBasemapId: Option[String] = None,
                           customBasemap: Option[String] = None,
-                          updateTasks: Boolean = false) extends DefaultWrites
+                          updateTasks: Boolean = false,
+                          exportableProperties: Option[String] = None) extends DefaultWrites
 
 case class ChallengeListing(id: Long,
                             parent: Long,

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -49,6 +49,7 @@ case class Task(override val id: Long,
                 reviewClaimedBy: Option[Long] = None,
                 priority: Int=Challenge.PRIORITY_HIGH,
                 changesetId: Option[Long] = None,
+                completionResponses: Option[String]=None,
                 mapillaryImages: Option[List[MapillaryImage]]=None) extends BaseObject[Long] with DefaultReads with LowPriorityDefaultReads {
   override val itemType: ItemType = TaskType()
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -498,7 +498,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
           get[Option[DateTime]]("task_review.reviewed_at") ~
           get[Option[DateTime]]("task_review.review_started_at") ~
           get[Option[Long]]("task_review.review_claimed_by") ~
-          get[Int]("tasks.priority") map {
+          get[Int]("tasks.priority")  map {
           case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~
             geometry ~ suggestedFix ~ status ~ mappedOn ~ reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~ priority =>
@@ -762,7 +762,8 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                                         hstore('mr_reviewTimeSeconds', FLOOR(EXTRACT(EPOCH FROM (t.reviewed_at - t.review_started_at)))::text) ||
                                         hstore('mr_tags', (SELECT STRING_AGG(tg.name, ',') AS tags
                                                             FROM tags_on_tasks tot, tags tg
-                                                            WHERE tot.task_id=t.tid AND tg.id = tot.tag_id))
+                                                            WHERE tot.task_id=t.tid AND tg.id = tot.tag_id)) ||
+                                        hstore('mr_responses', t.completion_responses::text)                    
                                       ) AS properties
                           FROM (
                             SELECT *,

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1379,6 +1379,7 @@ class TaskDAL @Inject()(override val db: Database,
         name <- str("tasks.name")
         status <- int("tasks.status")
         priority <- int("tasks.priority")
+        geojson <- get[Option[String]]("geo_json")
         username <- get[Option[String]]("users.username")
         mappedOn <- get[Option[DateTime]]("mapped_on")
         reviewStatus <- get[Option[Int]]("task_review.review_status")
@@ -1391,7 +1392,7 @@ class TaskDAL @Inject()(override val db: Database,
         responses <- get[Option[String]]("responses")
       } yield TaskSummary(taskId, name, status, priority, username, mappedOn,
         reviewStatus, reviewRequestedBy, reviewedBy, reviewedAt,
-        reviewStartedAt, comments, tags, responses)
+        reviewStartedAt, comments, tags, responses, geojson)
 
       val status = statusFilter match {
         case Some(s) => s"AND t.status IN (${s.mkString(",")})"
@@ -1416,7 +1417,7 @@ class TaskDAL @Inject()(override val db: Database,
 
       val query =
         SQL"""SELECT t.id, t.name, t.status, t.priority, sa_outer.username, t.mapped_on,
-                   task_review.review_status,
+                   task_review.review_status, t.geojson::TEXT AS geo_json,
                    (SELECT name as reviewRequestedBy FROM users WHERE users.id = task_review.review_requested_by),
                    (SELECT name as reviewedBy FROM users WHERE users.id = task_review.reviewed_by),
                    task_review.reviewed_at, task_review.review_started_at,
@@ -1531,7 +1532,8 @@ class TaskDAL @Inject()(override val db: Database,
   case class TaskSummary(taskId: Long, name: String, status: Int, priority: Int, username: Option[String],
                          mappedOn: Option[DateTime], reviewStatus: Option[Int], reviewRequestedBy: Option[String],
                          reviewedBy: Option[String], reviewedAt: Option[DateTime], reviewStartedAt: Option[DateTime],
-                         comments: Option[String], tags: Option[String], completionResponses: Option[String])
+                         comments: Option[String], tags: Option[String], completionResponses: Option[String],
+                         geojson: Option[String])
 
 }
 

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -3021,7 +3021,11 @@ PUT     /task/:id/changeset                         @org.maproulette.controllers
 #     in: query
 #     description: Boolean indicating if a review is requested on this task. (Will override user settings if provided)
 #   - name: tags
+#     in: query
 #     description: Optional tags to associate with this task
+#   - name: completionResponses
+#     in: body
+#     description: Optional key/value json to be stored with this task.
 ###
 PUT     /task/:id/:status                           @org.maproulette.controllers.api.TaskController.setTaskStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="")
 ###

--- a/conf/evolutions/default/42.sql
+++ b/conf/evolutions/default/42.sql
@@ -1,0 +1,8 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Add completion_responses for tasks
+ALTER TABLE tasks ADD COLUMN completion_responses jsonb;;
+
+# --- !Downs
+ALTER TABLE tasks DROP COLUMN completion_responses;;

--- a/conf/evolutions/default/42.sql
+++ b/conf/evolutions/default/42.sql
@@ -3,6 +3,8 @@
 # --- !Ups
 -- Add completion_responses for tasks
 ALTER TABLE tasks ADD COLUMN completion_responses jsonb;;
+ALTER TABLE challenges ADD COLUMN exportable_properties text;;
 
 # --- !Downs
 ALTER TABLE tasks DROP COLUMN completion_responses;;
+ALTER TABLE challenges DROP COLUMN exportable_properties;;


### PR DESCRIPTION
Add support for addtional response data on completion.
* Add additional column to database to store "completion_responses"
* When setTaskStatus is called allow json key/value pairs to be passed in body and stored in new field
* Return completionResponses when asking for task data
* Exporting CSV and geojson to also include this new property

Add support for exportableProperties in CSV
* Add column for 'exportable_properties' as a comma separated list
* Any task feature properties that match will be exported in the CSV
