### PR TITLE
Add support for task bundles (Mulit-task Completion)

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -180,21 +180,21 @@ class ChallengeController @Inject()(override val childController: TaskController
       Json.toJson(List[JsValue]())
     } else {
       val mappers = Some(this.dalManager.user.retrieveListById(-1, 0)(tasks.map(
-        t => t.reviewRequestedBy.getOrElse(0).toLong)).map(u =>
+        t => t.pointReview.reviewRequestedBy.getOrElse(0).toLong)).map(u =>
           u.id -> Json.obj("username" -> u.name, "id" -> u.id)).toMap)
 
       val reviewers = Some(this.dalManager.user.retrieveListById(-1, 0)(tasks.map(
-        t => t.reviewedBy.getOrElse(0).toLong)).map(u =>
+        t => t.pointReview.reviewedBy.getOrElse(0).toLong)).map(u =>
           u.id -> Json.obj("username" -> u.name, "id" -> u.id)).toMap)
 
       val jsonList = tasks.map { task =>
         var updated = Json.toJson(task)
-        if (task.reviewRequestedBy.getOrElse(0) != 0) {
-          val mapperJson = Json.toJson(mappers.get(task.reviewRequestedBy.get.toLong)).as[JsObject]
+        if (task.pointReview.reviewRequestedBy.getOrElse(0) != 0) {
+          val mapperJson = Json.toJson(mappers.get(task.pointReview.reviewRequestedBy.get.toLong)).as[JsObject]
           updated = Utils.insertIntoJson(updated, "reviewRequestedBy", mapperJson, true)
         }
-        if (task.reviewedBy.getOrElse(0) != 0) {
-          val reviewerJson = Json.toJson(reviewers.get(task.reviewedBy.get.toLong)).as[JsObject]
+        if (task.pointReview.reviewedBy.getOrElse(0) != 0) {
+          val reviewerJson = Json.toJson(reviewers.get(task.pointReview.reviewedBy.get.toLong)).as[JsObject]
           updated = Utils.insertIntoJson(updated, "reviewedBy", reviewerJson, true)
         }
 

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -262,12 +262,13 @@ class ChallengeController @Inject()(override val childController: TaskController
     *
     * @param challengeId  The challenge id that is the parent of the tasks that you would be searching for
     * @param proximityId  Id of task for which nearby tasks are desired
+    * @param excludeSelfLocked Also exclude tasks locked by requesting user
     * @param limit        The maximum number of nearby tasks to return
     * @return
     */
-  def getNearbyTasks(challengeId: Long, proximityId: Long, limit: Int): Action[AnyContent] = Action.async { implicit request =>
+  def getNearbyTasks(challengeId: Long, proximityId: Long, excludeSelfLocked: Boolean, limit: Int): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      val results = this.dalManager.task.getNearbyTasks(User.userOrMocked(user), challengeId, proximityId, limit)
+      val results = this.dalManager.task.getNearbyTasks(User.userOrMocked(user), challengeId, proximityId, excludeSelfLocked, limit)
       Ok(Json.toJson(results))
     }
   }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -65,6 +65,8 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
   implicit val tagChangeResultWrites = ChangeObjects.tagChangeResultWrites
   implicit val tagChangeSubmissionReads = ChangeObjects.tagChangeSubmissionReads
 
+  implicit val taskBundleWrites: Writes[TaskBundle] = TaskBundle.taskBundleWrites
+
   override def dalWithTags: TagDALMixin[Task] = dal
 
   /**
@@ -330,8 +332,57 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     }
   }
 
-  def customTaskStatus(taskId:Long, actionType: ActionType, user:User, comment:String="", tags: String= "",
-                       requestReview:Option[Boolean] = None, completionResponses:Option[JsValue] = None) = {
+  /**
+    * This performs setTaskStatus on a bundle of tasks.
+    *
+    * @param bundleId     The id of the task bundle
+    * @param primaryId    The id of the primary task for this bundle
+    * @param status The status id to set the task's status to
+    * @param comment An optional comment to add to the task
+    * @param tags Optional tags to add to the task
+    * @return 400 BadRequest if status id is invalid or task with supplied id not found.
+    *         If successful then 200 NoContent
+    */
+  def setBundleTaskStatus(bundleId: Long, primaryId: Long, status: Int, comment: String = "", tags: String = ""): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val requestReview = request.getQueryString("requestReview") match {
+        case Some(v) => Some(v.toBoolean)
+        case None => None
+      }
+
+      val tasks = this.dal.getTaskBundle(user, bundleId).tasks match {
+        case Some(t) => t
+        case None => throw new InvalidException("No tasks found in this bundle.")
+      }
+
+      val completionResponses = request.body.asJson
+      this.dal.setTaskStatus(tasks, status, user, requestReview, Some(bundleId), Some(primaryId), completionResponses)
+
+      for (task <- tasks) {
+        val action = this.actionManager.setAction(Some(user), new TaskItem(task.id), TaskStatusSet(status), task.name)
+        // add comment to each task if any provided
+        if (comment.nonEmpty) {
+          val actionId = action match {
+            case Some(a) => Some(a.id)
+            case None => None
+          }
+          this.dal.addComment(user, task, comment, actionId)
+        }
+
+        // Add tags to each task
+        val tagList = tags.split(",").toList
+        if (tagList.nonEmpty) {
+          this.addTagstoItem(task.id, tagList.map(new Tag(-1, _, tagType = this.dal.tableName)), user)
+        }
+      }
+
+      // Refetch to get updated data
+      Ok(Json.toJson(this.dal.getTaskBundle(user, bundleId)))
+    }
+  }
+
+  def customTaskStatus(taskId:Long, actionType: ActionType, user:User, comment:String="",
+                       tags: String= "",requestReview:Option[Boolean] = None, completionResponses:Option[JsValue] = None) = {
     val status = actionType match {
       case t: TaskStatusSet => t.status
       case q: QuestionAnswered => Task.STATUS_ANSWERED
@@ -345,7 +396,9 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
       case Some(t) => t
       case None => throw new NotFoundException(s"Task with $taskId not found, can not set status.")
     }
-    this.dal.setTaskStatus(task, status, user, requestReview, completionResponses)
+
+    this.dal.setTaskStatus(List(task), status, user, requestReview, completionResponses)
+    
     val action = this.actionManager.setAction(Some(user), new TaskItem(task.id), actionType, task.name)
     // add comment if any provided
     if (comment.nonEmpty) {
@@ -395,6 +448,45 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
       }
 
       NoContent
+    }
+  }
+
+  /**
+    * This function sets the task review status.
+    * Must be authenticated to perform operation and marked as a reviewer.
+    *
+    * @param id The id of the task
+    * @param reviewStatus The review status id to set the task's review status to
+    * @param comment An optional comment to add to the task
+    * @param tags Optional tags to add to the task
+    * @return 400 BadRequest if task with supplied id not found.
+    *         If successful then 200 NoContent
+    */
+  def setBundleTaskReviewStatus(id: Long, reviewStatus: Int, comment:String="", tags: String= "") : Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val tasks = this.dal.getTaskBundle(user, id).tasks match {
+        case Some(t) => t
+        case None => throw new InvalidException("No tasks found in this bundle.")
+      }
+
+      for (task <- tasks) {
+        val action = this.actionManager.setAction(Some(user), new TaskItem(task.id),
+                       TaskReviewStatusSet(reviewStatus), task.name)
+        val actionId = action match {
+          case Some(a) => Some(a.id)
+          case None => None
+        }
+
+        this.dal.setTaskReviewStatus(task, reviewStatus, user, actionId, comment)
+
+        val tagList = tags.split(",").toList
+        if (tagList.nonEmpty) {
+          this.addTagstoItem(id, tagList.map(new Tag(-1, _, tagType = this.dal.tableName)), user)
+        }
+      }
+
+      // Refetch to get updated data
+      Ok(Json.toJson(this.dal.getTaskBundle(user, id)))
     }
   }
 
@@ -461,6 +553,29 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
         case None => throw new NotFoundException(s"Task with $taskId not found, can not add comment.")
       }
       Created(Json.toJson(this.dal.addComment(user, task, URLDecoder.decode(comment, "UTF-8"), actionId)))
+    }
+  }
+
+  /**
+    * Adds a comment for tasks in a bundle
+    *
+    * @param bundleId   The id for the bundle
+    * @param comment  The comment the user is leaving
+    * @param actionId The action if any associated with the comment
+    * @return Ok if successful.
+    */
+  def addCommentToBundleTasks(bundleId: Long, comment: String, actionId: Option[Long]): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val tasks = this.dal.getTaskBundle(user, bundleId).tasks match {
+        case Some(t) => t
+        case None => throw new InvalidException("No tasks found in this bundle.")
+      }
+
+      for (task <- tasks) {
+        this.dal.addComment(user, task, URLDecoder.decode(comment, "UTF-8"), actionId)
+      }
+
+      Ok(Json.toJson(this.dal.getTaskBundle(user, bundleId)))
     }
   }
 
@@ -559,4 +674,60 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     }
   }
 
+  /**
+    * Creates a new task bundle with the task ids in the json body, assigning
+    * ownership of the bundle to the logged-in user
+    *
+    * @return A TaskBundle representing the new bundle
+    */
+  def createTaskBundle(): Action[JsValue] = Action.async(bodyParsers.json) { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val name = (request.body \ "name").asOpt[String].getOrElse("")
+      val taskIds = (request.body \ "taskIds").asOpt[List[Long]] match {
+        case Some(tasks) => tasks
+        case None => throw new InvalidException("No task ids provided for task bundle")
+      }
+      val bundle = dal.createTaskBundle(user, name, taskIds)
+      Created(Json.toJson(bundle))
+    }
+  }
+
+  /**
+    * Gets the tasks in the given Bundle
+    *
+    * @param id
+    * @return Task Bundle
+    */
+  def getTaskBundle(id: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.dal.getTaskBundle(user, id)))
+    }
+  }
+
+  /**
+    * Remove tasks from a bundle.
+    *
+    * @param id
+    * @param taskIds List of task ids to remove
+    * @return Task Bundle
+    */
+  def unbundleTasks(id: Long, taskIds: List[Long]): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.dal.unbundleTasks(user, id, taskIds)
+      Ok(Json.toJson(this.dal.getTaskBundle(user, id)))
+    }
+  }
+
+  /**
+    * Delete bundle.
+    *
+    * @param id
+    * @param primaryId optional task id to no unlcok after deleting this bundle
+    */
+  def deleteTaskBundle(id: Long, primaryId: Option[Long] = None): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.dal.deleteTaskBundle(user, id, primaryId)
+      Ok
+    }
+  }
 }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -356,7 +356,7 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
       }
 
       val completionResponses = request.body.asJson
-      this.dal.setTaskStatus(tasks, status, user, requestReview, Some(bundleId), Some(primaryId), completionResponses)
+      this.dal.setTaskStatus(tasks, status, user, requestReview, completionResponses, Some(bundleId), Some(primaryId))
 
       for (task <- tasks) {
         val action = this.actionManager.setAction(Some(user), new TaskItem(task.id), TaskStatusSet(status), task.name)
@@ -398,7 +398,7 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     }
 
     this.dal.setTaskStatus(List(task), status, user, requestReview, completionResponses)
-    
+
     val action = this.actionManager.setAction(Some(user), new TaskItem(task.id), actionType, task.name)
     // add comment if any provided
     if (comment.nonEmpty) {

--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -170,22 +170,22 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
                                    "parent" -> Json.toJson(projects.get(c.general.parent)).as[JsObject])).toMap)
 
       val mappers = Some(this.dalManager.user.retrieveListById(-1, 0)(tasks.map(
-        t => t.reviewRequestedBy.getOrElse(0L))).map(u =>
+        t => t.review.reviewRequestedBy.getOrElse(0L))).map(u =>
           u.id -> Json.obj("username" -> u.name, "id" -> u.id)).toMap)
 
       val reviewers = Some(this.dalManager.user.retrieveListById(-1, 0)(tasks.map(
-        t => t.reviewedBy.getOrElse(0L))).map(u =>
+        t => t.review.reviewedBy.getOrElse(0L))).map(u =>
           u.id -> Json.obj("username" -> u.name, "id" -> u.id)).toMap)
 
       val jsonList = tasks.map { task =>
         val challengeJson = Json.toJson(challenges.get(task.parent)).as[JsObject]
         var updated = Utils.insertIntoJson(Json.toJson(task), Challenge.KEY_PARENT, challengeJson, true)
-        if (task.reviewRequestedBy.getOrElse(0) != 0) {
-          val mapperJson = Json.toJson(mappers.get(task.reviewRequestedBy.get)).as[JsObject]
+        if (task.review.reviewRequestedBy.getOrElse(0) != 0) {
+          val mapperJson = Json.toJson(mappers.get(task.review.reviewRequestedBy.get)).as[JsObject]
           updated = Utils.insertIntoJson(updated, "reviewRequestedBy", mapperJson, true)
         }
-        if (task.reviewedBy.getOrElse(0) != 0) {
-          val reviewerJson = Json.toJson(reviewers.get(task.reviewedBy.get)).as[JsObject]
+        if (task.review.reviewedBy.getOrElse(0) != 0) {
+          val reviewerJson = Json.toJson(reviewers.get(task.review.reviewedBy.get)).as[JsObject]
           updated = Utils.insertIntoJson(updated, "reviewedBy", reviewerJson, true)
         }
 

--- a/app/org/maproulette/data/Actions.scala
+++ b/app/org/maproulette/data/Actions.scala
@@ -40,6 +40,7 @@ class ItemType(id: Int) {
       case u: UserType => new UserItem(itemId)
       case s: SurveyType => new SurveyItem(itemId)
       case vc: VirtualChallengeType => new VirtualChallengeItem(itemId)
+      case b: BundleType => new BundleItem(itemId)
     }
   }
 }
@@ -64,6 +65,8 @@ case class GroupType() extends ItemType(Actions.ITEM_TYPE_GROUP)
 
 case class VirtualChallengeType() extends ItemType(Actions.ITEM_TYPE_VIRTUAL_CHALLENGE)
 
+case class BundleType() extends ItemType(Actions.ITEM_TYPE_BUNDLE)
+
 class ProjectItem(override val itemId: Long) extends ProjectType with Item
 
 class ChallengeItem(override val itemId: Long) extends ChallengeType with Item
@@ -77,6 +80,8 @@ class UserItem(override val itemId: Long) extends UserType with Item
 class SurveyItem(override val itemId: Long) extends SurveyType with Item
 
 class VirtualChallengeItem(override val itemId: Long) extends VirtualChallengeType with Item
+
+class BundleItem(override val itemId: Long) extends BundleType with Item
 
 case class Updated() extends ActionType(Actions.ACTION_TYPE_UPDATED, Actions.ACTION_LEVEL_2)
 
@@ -117,6 +122,8 @@ object Actions {
   val ITEM_TYPE_GROUP_NAME = "Group"
   val ITEM_TYPE_VIRTUAL_CHALLENGE = 7
   val ITEM_TYPE_VIRTUAL_CHALLENGE_NAME = "VirtualChallenge"
+  val ITEM_TYPE_BUNDLE = 8
+  val ITEM_TYPE_BUNDLE_NAME = "Bundle"
   val itemIDMap = Map(
     ITEM_TYPE_PROJECT -> (ITEM_TYPE_PROJECT_NAME, ProjectType()),
     ITEM_TYPE_CHALLENGE -> (ITEM_TYPE_CHALLENGE_NAME, ChallengeType()),
@@ -125,7 +132,8 @@ object Actions {
     ITEM_TYPE_SURVEY -> (ITEM_TYPE_SURVEY_NAME, SurveyType()),
     ITEM_TYPE_USER -> (ITEM_TYPE_USER_NAME, UserType()),
     ITEM_TYPE_GROUP -> (ITEM_TYPE_GROUP_NAME, GroupType()),
-    ITEM_TYPE_VIRTUAL_CHALLENGE -> (ITEM_TYPE_VIRTUAL_CHALLENGE_NAME, VirtualChallengeType())
+    ITEM_TYPE_VIRTUAL_CHALLENGE -> (ITEM_TYPE_VIRTUAL_CHALLENGE_NAME, VirtualChallengeType()),
+    ITEM_TYPE_BUNDLE -> (ITEM_TYPE_BUNDLE_NAME, BundleType())
   )
 
   val ACTION_TYPE_UPDATED = 0

--- a/app/org/maproulette/models/Bundle.scala
+++ b/app/org/maproulette/models/Bundle.scala
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 MapRoulette contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.maproulette.models
+
+import org.joda.time.DateTime
+import org.maproulette.data.{ItemType, BundleType}
+import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+import play.api.libs.json._
+
+
+case class Bundle(override val id: Long,
+                  val owner: Long,
+                  override val name: String = "",
+                  override val description: Option[String] = None,
+                  override val created: DateTime = DateTime.now(),
+                  override val modified: DateTime = DateTime.now()) extends BaseObject[Long] {
+  override val itemType: ItemType = BundleType()
+}
+
+object Bundle {
+  implicit val bundleWrites: Writes[Bundle] = Json.writes[Bundle]
+  implicit val bundleReads: Reads[Bundle] = Json.reads[Bundle]
+
+  val KEY = "bundles"
+}
+
+/**
+  * TaskBundles serve as a simple, arbitrary grouping mechanism for tasks
+  *
+  * @author nrotstan
+  */
+case class TaskBundle(bundleId: Long, ownerId: Long, taskIds: List[Long], tasks:Option[List[Task]]) extends DefaultWrites
+object TaskBundle {
+  implicit val taskBundleWrites: Writes[TaskBundle] = Json.writes[TaskBundle]
+  implicit val taskBundleReads: Reads[TaskBundle] = Json.reads[TaskBundle]
+}

--- a/app/org/maproulette/models/ClusteredPoint.scala
+++ b/app/org/maproulette/models/ClusteredPoint.scala
@@ -12,6 +12,9 @@ import play.api.libs.json.JodaReads._
   */
 case class Point(lat: Double, lng: Double)
 
+case class PointReview(reviewStatus: Option[Int], reviewRequestedBy: Option[Int], reviewedBy: Option[Int],
+                       reviewedAt: Option[DateTime], reviewStartedAt: Option[DateTime])
+
 /**
   * This is the clustered point that will be displayed on the map. The popup will contain the title
   * of object with a blurb or description of said object. If the object is a challenge then below
@@ -30,20 +33,21 @@ case class Point(lat: Double, lng: Double)
   * @param type       The type of this ClusteredPoint
   * @param status     The status of the task, only used for task points, ie. not challenge points
   * @param mappedOn   The date this task was mapped
-  * @param reviewStatus  The reviewStatus of the task, only used for task points, ie. not challenge points
-  # @param reviewRequestedBy only used for task points, ie. not challenge points
-  # @param reviewedBy only used for task points, ie. not challenge points
-  # @param reviewdAt  only used for task points, ie. not challenge points
+  * @param pointReview a PointReview instance with review data
+  * @param bundleId id of bundle task is member of, if any
+  * @param isBundlePrimary whether task is primary task in bundle (if a member of a bundle)
   */
 case class ClusteredPoint(id: Long, owner: Long, ownerName: String, title: String, parentId: Long, parentName: String,
                           point: Point, bounding: JsValue, blurb: String, modified: DateTime, difficulty: Int,
                           `type`: Int, status: Int, suggestedFix: Option[String] = None, mappedOn: Option[DateTime],
-                          reviewStatus: Option[Int], reviewRequestedBy: Option[Int], reviewedBy: Option[Int],
-                          reviewedAt: Option[DateTime], reviewStartedAt: Option[DateTime], priority: Int)
+                          pointReview: PointReview, priority: Int,
+                          bundleId: Option[Long]=None, isBundlePrimary: Option[Boolean]=None)
 
 object ClusteredPoint {
   implicit val pointWrites: Writes[Point] = Json.writes[Point]
   implicit val pointReads: Reads[Point] = Json.reads[Point]
+  implicit val pointReviewWrites: Writes[PointReview] = Json.writes[PointReview]
+  implicit val pointReviewReads: Reads[PointReview] = Json.reads[PointReview]
   implicit val clusteredPointWrites: Writes[ClusteredPoint] = Json.writes[ClusteredPoint]
   implicit val clusteredPointReads: Reads[ClusteredPoint] = Json.reads[ClusteredPoint]
 }

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -50,6 +50,8 @@ case class Task(override val id: Long,
                 priority: Int=Challenge.PRIORITY_HIGH,
                 changesetId: Option[Long] = None,
                 completionResponses: Option[String]=None,
+                bundleId: Option[Long] = None,
+                isBundlePrimary: Option[Boolean] = None,
                 mapillaryImages: Option[List[MapillaryImage]]=None) extends BaseObject[Long] with DefaultReads with LowPriorityDefaultReads {
   override val itemType: ItemType = TaskType()
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -818,7 +818,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                         (implicit c: Option[Connection] = None): List[ClusteredPoint] = {
     this.withMRConnection { implicit c =>
       val filter = statusFilter match {
-        case Some(s) => s"AND status IN (${s.mkString(",")}"
+        case Some(s) => s"AND t.status IN (${s.mkString(",")})"
         case None => ""
       }
       val clusteredList = SQL"""SELECT t.id, t.name, t.instruction, t.status, t.mapped_on,

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -311,7 +311,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                                       instruction, enabled, challenge_type, featured, checkin_comment, checkin_source,
                                       overpass_ql, remote_geo_json, status, status_message, default_priority, high_priority_rule,
                                       medium_priority_rule, low_priority_rule, default_zoom, min_zoom,
-                                      max_zoom, default_basemap, default_basemap_id, custom_basemap, updatetasks, exportableProperties)
+                                      max_zoom, default_basemap, default_basemap_id, custom_basemap, updatetasks, exportable_properties)
               VALUES (${challenge.name}, ${challenge.general.owner}, ${challenge.general.parent}, ${challenge.general.difficulty},
                       ${challenge.description}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
                       ${challenge.general.enabled}, ${challenge.general.challengeType}, ${challenge.general.featured},
@@ -507,8 +507,8 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
             reviewedBy ~ reviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~ priority =>
             val values = taskDAL.updateAndRetrieve(id, geometry, location, suggestedFix)
             Task(id, name, created, modified, parent_id, instruction, values._2,
-              values._1, values._3, status, mappedOn, reviewStatus, reviewRequestedBy,
-              reviewedBy, reviewedAt, reviewStartedAt, reviewClaimedBy, priority)
+              values._1, values._3, status, mappedOn, TaskReviewFields(reviewStatus, reviewRequestedBy,
+              reviewedBy, reviewedAt, reviewStartedAt, reviewClaimedBy), priority)
         }
       }
 

--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -79,9 +79,10 @@ class ProjectDAL @Inject()(override val db: Database,
         val locationJSON = Json.parse(location)
         val coordinates = (locationJSON \ "coordinates").as[List[Double]]
         val point = Point(coordinates(1), coordinates.head)
+        val pointReview = PointReview(None, None, None, None, None)
         val boundingJSON = Json.parse(bounding)
         ClusteredPoint(id, osm_id, username, name, parentId, parentName, point, boundingJSON, blurb.getOrElse(""), modified, difficulty, challengeType, -1,
-        None, None, None, None, None, None, None, -1)
+        None, None, pointReview, -1, None, None)
     }
   }
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -94,15 +94,18 @@ class TaskDAL @Inject()(override val db: Database,
       get[Int]("tasks.priority") ~
       get[Option[Long]]("tasks.changeset_id") ~
       get[Option[String]]("responses") map {
+      get[Option[Long]]("tasks.bundle_id") ~
+      get[Option[Boolean]]("tasks.is_bundle_primary") map {
       case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ geojson ~
         suggested_fix ~ mappedOn ~ reviewStatus ~ reviewRequestedBy ~ reviewedBy ~
-        reviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~ priority ~ changesetId ~ responses =>
+        reviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~ priority ~ changesetId ~ responses ~
+        bundleId ~ isBundlePrimary =>
 
         val values = this.updateAndRetrieve(id, geojson, location, suggested_fix)
         Task(id, name, created, modified, parent_id, instruction, values._2,
           values._1, values._3, status, mappedOn,
           reviewStatus, reviewRequestedBy, reviewedBy, reviewedAt, reviewStartedAt,
-          reviewClaimedBy, priority, changesetId, responses)
+          reviewClaimedBy, priority, changesetId, responses, bundleId, isBundlePrimary)
     }
   }
 
@@ -126,21 +129,23 @@ class TaskDAL @Inject()(override val db: Database,
       get[Option[Long]]("task_review.review_claimed_by") ~
       get[Int]("tasks.priority") ~
       get[Option[Long]]("tasks.changeset_id") ~
+      get[Option[Long]]("tasks.bundle_id") ~
+      get[Option[Boolean]]("tasks.is_bundle_primary") ~
       get[Option[String]]("challenge_name") ~
       get[Option[String]]("review_requested_by_username") ~
       get[Option[String]]("reviewed_by_username") ~
       get[Option[String]]("responses") map {
       case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ geojson ~
         suggestedFix ~ mappedOn ~ reviewStatus ~ reviewRequestedBy ~ reviewedBy ~ reviewedAt ~
-        reviewStartedAt ~ reviewClaimedBy ~ priority ~ changesetId ~ challengeName ~
-        reviewRequestedByUsername ~ reviewedByUsername ~ responses =>
+        reviewStartedAt ~ reviewClaimedBy ~ priority ~ changesetId ~ bundleId ~ isBundlePrimary ~
+        challengeName ~ reviewRequestedByUsername ~ reviewedByUsername ~ responses =>
 
         val values = this.updateAndRetrieve(id, geojson, location, suggestedFix)
         TaskWithReview(
           Task(id, name, created, modified, parent_id, instruction, values._2,
             values._1, values._3, status, mappedOn,
             reviewStatus, reviewRequestedBy, reviewedBy, reviewedAt, reviewStartedAt,
-            reviewClaimedBy, priority, changesetId, responses),
+            reviewClaimedBy, priority, changesetId, responses, bundleId, isBundlePrimary),
           TaskReview(-1, id, reviewStatus, challengeName, reviewRequestedBy, reviewRequestedByUsername,
             reviewedBy, reviewedByUsername, reviewedAt, reviewStartedAt, reviewClaimedBy, None, None)
         )
@@ -450,6 +455,35 @@ class TaskDAL @Inject()(override val db: Database,
   }
 
   /**
+    * Retrieves a list of objects from the supplied list of ids. Will check for any objects currently
+    * in the cache and those that aren't will be retrieved from the database
+    *
+    * @param limit  The limit on the number of objects returned. This is not entirely useful as a limit
+    *               could be set simply by how many ids you supplied in the list, but possibly useful
+    *               for paging
+    * @param offset For paging, ie. the page number starting at 0
+    * @param ids    The list of ids to be retrieved
+    * @return A list of objects, empty list if none found
+    */
+  override def retrieveListById(limit: Int = -1, offset: Int = 0)(implicit ids: List[Long], c: Option[Connection] = None): List[Task] = {
+    if (ids.isEmpty) {
+      List.empty
+    } else {
+      this.cacheManager.withIDListCaching { implicit uncachedIDs =>
+        this.withMRConnection { implicit c =>
+          val query =
+            s"""SELECT ${retrieveColumnsWithReview} FROM ${this.tableName}
+                LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
+                WHERE tasks.id IN ({inString})
+                LIMIT ${this.sqlLimit(limit)} OFFSET {offset}"""
+          SQL(query).on('inString -> ToParameterValue.apply[List[Long]](s = keyToSQL, p = keyToStatement).apply(uncachedIDs),
+            'offset -> offset).as(this.parser.*)
+        }
+      }
+    }
+  }
+
+  /**
     * Sets the task for a given user. The user cannot set the status of a task unless the object has
     * been locked by the same user before hand.
     * Will throw an InvalidException if the task status cannot be set due to the current task status
@@ -463,9 +497,35 @@ class TaskDAL @Inject()(override val db: Database,
     * @param completionRespones Optional json responses provided by user to task instruction questions
     * @return The number of rows updated, should only ever be 1
     */
+<<<<<<< HEAD
   def setTaskStatus(task: Task, status: Int, user: User, requestReview: Option[Boolean] = None,
                     completionResponses:Option[JsValue] = None)(implicit c: Connection = null): Int = {
     if (!Task.isValidStatusProgression(task.status.getOrElse(Task.STATUS_CREATED), status)) {
+=======
+  def setTaskStatus(tasks: List[Task], status: Int, user: User, requestReview: Option[Boolean] = None,
+                    bundleId: Option[Long] = None, primaryTaskId: Option[Long] = None)(implicit c: Connection = null): Int = {
+    if (tasks.length < 1) {
+      throw new InvalidException("Must be at least one task in list to setTaskStatus.")
+    }
+
+    var primaryTask = tasks.head
+    var bundleUpdate = ""
+
+    // Find primary task in bundle if we are using a bundle
+    bundleId match {
+      case Some(b) =>
+        bundleUpdate = ", bundle_id = " + b
+        for (task <- tasks) {
+          primaryTaskId match {
+            case Some(p) =>
+              if (task.id == p) primaryTask = task
+            case _ => // do nothing
+          }
+        }
+      case _ => // not a bundle
+    }
+
+    if (!Task.isValidStatusProgression(primaryTask.status.getOrElse(Task.STATUS_CREATED), status)) {
       throw new InvalidException("Invalid task status supplied.")
     } else if (user.guest) {
       throw new IllegalAccessException("Guest users cannot make edits to tasks.")
@@ -482,97 +542,110 @@ class TaskDAL @Inject()(override val db: Database,
       case None => null
     }
 
-    val oldStatus = task.status
-    val updatedRows = this.withMRTransaction { implicit c =>
-      val updatedRows =
-        SQL"""UPDATE tasks t SET status = $status, mapped_on = NOW(), completion_responses = ${responses}::JSONB
-                             WHERE t.id = (
-                                SELECT t2.id FROM tasks t2
-                                LEFT JOIN locked l on l.item_id = t2.id AND l.item_type = ${task.itemType.typeId}
-                                WHERE t2.id = ${task.id} AND (l.user_id = ${user.id} OR l.user_id IS NULL)
-                              )""".executeUpdate()
-      // if returning 0, then this is because the item is locked by a different user
-      if (updatedRows == 0) {
-        throw new IllegalAccessException(s"Current task [${task.id} is locked by another user, cannot update status at this time.")
-      }
+    val oldStatus = primaryTask.status
+    var updatedRows = 0
 
-      val startedLock = (SQL"""SELECT locked_time FROM locked l WHERE l.item_id = ${task.id} AND
-                                     l.item_type = ${task.itemType.typeId} AND l.user_id = ${user.id}
-                           """).as(SqlParser.scalar[DateTime].singleOpt)
-      this.statusActions.setStatusAction(user, task, status, startedLock)
-
-      if (reviewNeeded) {
-        task.reviewStatus match {
-          case Some(rs) =>
-            SQL"""UPDATE task_review tr
-                    SET review_status = ${Task.REVIEW_STATUS_REQUESTED}, review_requested_by = ${user.id}
-                    WHERE tr.task_id = ${task.id}
-               """.executeUpdate()
-          case None =>
-            SQL"""INSERT INTO task_review (task_id, review_status, review_requested_by)
-                    VALUES (${task.id}, ${Task.REVIEW_STATUS_REQUESTED}, ${user.id})""".executeUpdate()
+    this.withMRTransaction { implicit c =>
+      for (task <- tasks) {
+        updatedRows =
+          SQL"""UPDATE tasks t SET status = $status, mapped_on = NOW(), completion_responses = ${responses}::JSONB  #$bundleUpdate
+                               WHERE t.id = (
+                                  SELECT t2.id FROM tasks t2
+                                  LEFT JOIN locked l on l.item_id = t2.id AND l.item_type = ${task.itemType.typeId}
+                                  WHERE t2.id = ${task.id} AND (l.user_id = ${user.id} OR l.user_id IS NULL)
+                                )""".executeUpdate()
+        // if returning 0, then this is because the item is locked by a different user
+        if (updatedRows == 0) {
+          throw new IllegalAccessException(s"Current task [${task.id} is locked by another user, cannot update status at this time.")
         }
-      }
 
-      // if you set the status successfully on a task you will lose the lock of that task
-      try {
-        this.unlockItem(user, task)
-      } catch {
-        case e: Exception => logger.warn(e.getMessage)
-      }
-      if (config.changeSetEnabled) {
-        // try and match the current task with a changeset from the user
+        val startedLock = (SQL"""SELECT locked_time FROM locked l WHERE l.item_id = ${task.id} AND
+                                       l.item_type = ${task.itemType.typeId} AND l.user_id = ${user.id}
+                             """).as(SqlParser.scalar[DateTime].singleOpt)
+        this.statusActions.setStatusAction(user, task, status, startedLock)
+
+        if (reviewNeeded) {
+          task.reviewStatus match {
+            case Some(rs) =>
+              SQL"""UPDATE task_review tr
+                      SET review_status = ${Task.REVIEW_STATUS_REQUESTED}, review_requested_by = ${user.id}
+                      WHERE tr.task_id = ${task.id}
+                 """.executeUpdate()
+            case None =>
+              SQL"""INSERT INTO task_review (task_id, review_status, review_requested_by)
+                      VALUES (${task.id}, ${Task.REVIEW_STATUS_REQUESTED}, ${user.id})""".executeUpdate()
+          }
+        }
+
+        // if you set the status successfully on a task you will lose the lock of that task
+        try {
+          this.unlockItem(user, task)
+        } catch {
+          case e: Exception => logger.warn(e.getMessage)
+        }
+        if (config.changeSetEnabled) {
+          // try and match the current task with a changeset from the user
+          Future {
+            c.commit()
+            this.matchToOSMChangeSet(task.copy(status = Some(status)), user)
+          }
+        }
+
+        // Update the popularity score on the parent challenge
         Future {
-          c.commit()
-          this.matchToOSMChangeSet(task.copy(status = Some(status)), user)
+          this.challengeDAL.get().updatePopularity(Instant.now().getEpochSecond())(task.parent)
+        }
+
+        // Let's note in the task_review_history table that this task needs review
+        if (reviewNeeded) {
+          SQL"""INSERT INTO task_review_history (task_id, requested_by, review_status)
+                VALUES (${task.id}, ${user.id}, ${Task.REVIEW_STATUS_REQUESTED})""".executeUpdate()
+        }
+
+        if (reviewNeeded) {
+          this.cacheManager.withOptionCaching { () =>
+            Some(task.copy(status = Some(status),
+              reviewStatus = Some(Task.REVIEW_STATUS_REQUESTED),
+              reviewRequestedBy = Some(user.id),
+              modified = new DateTime(),
+              completionResponses = completionResponses match {
+                case Some(r) => Some(r.toString())
+                case None => None
+              },
+              bundleId = bundleId, isBundlePrimary = Some(task.id == primaryTask.id) ))
+          }
+        }
+        else {
+          this.cacheManager.withOptionCaching { () =>
+            Some(task.copy(status = Some(status),
+              modified = new DateTime(),
+              completionResponses = completionResponses match {
+                case Some(r) => Some(r.toString())
+                case None => None
+              },
+              bundleId = bundleId, isBundlePrimary = Some(task.id == primaryTask.id)))
+          }
+        }
+
+        // let's give the user credit for doing this task.
+        if (oldStatus.getOrElse(Task.STATUS_CREATED) != status) {
+          this.userDAL.get().updateUserScore(Option(status), None, false, false, user.id)
         }
       }
 
-      // Update the popularity score on the parent challenge
-      Future {
-        this.challengeDAL.get().updatePopularity(Instant.now().getEpochSecond())(task.parent)
+      // Mark the primary task id from the bundle, if any
+      bundleId match {
+        case Some(b) =>
+          SQL("UPDATE tasks SET is_bundle_primary = true WHERE id = " + primaryTask.id).executeUpdate()
+        case None => // not part of a bundle
       }
+    }
 
-      // Let's note in the task_review_history table that this task needs review
-      if (reviewNeeded) {
-        SQL"""INSERT INTO task_review_history (task_id, requested_by, review_status)
-              VALUES (${task.id}, ${user.id}, ${Task.REVIEW_STATUS_REQUESTED})""".executeUpdate()
-      }
-
-      updatedRows
-    }
-    if (reviewNeeded) {
-      this.cacheManager.withOptionCaching { () =>
-        Some(task.copy(status = Some(status),
-          reviewStatus = Some(Task.REVIEW_STATUS_REQUESTED),
-          reviewRequestedBy = Some(user.id),
-          modified = new DateTime(),
-          completionResponses = completionResponses match {
-            case Some(r) => Some(r.toString())
-            case None => None
-          }))
-      }
-    }
-    else {
-      this.cacheManager.withOptionCaching { () =>
-        Some(task.copy(status = Some(status),
-          modified = new DateTime(),
-          completionResponses = completionResponses match {
-            case Some(r) => Some(r.toString())
-            case None => None
-          }))
-      }
-    }
-    this.challengeDAL.get().updateFinishedStatus()(task.parent)
-
-    // let's give the user credit for doing this task.
-    if (oldStatus.getOrElse(Task.STATUS_CREATED) != status) {
-      this.userDAL.get().updateUserScore(Option(status), None, false, false, user.id)
-    }
+    this.challengeDAL.get().updateFinishedStatus()(primaryTask.parent)
 
     if (reviewNeeded) {
       webSocketProvider.sendMessage(WebSocketMessages.reviewNew(
-        WebSocketMessages.ReviewData(this.getTaskWithReview(task.id))
+        WebSocketMessages.ReviewData(this.getTaskWithReview(primaryTask.id))
       ))
     }
 
@@ -688,7 +761,7 @@ class TaskDAL @Inject()(override val db: Database,
     * @return The number of rows updated, should only ever be 1
     */
   def setTaskReviewStatus(task: Task, reviewStatus: Int, user: User, actionId: Option[Long], commentContent: String = "")(implicit c: Connection = null): Int = {
-    if (!user.settings.isReviewer.get && reviewStatus != Task.REVIEW_STATUS_REQUESTED &&
+    if (!user.isSuperUser && !user.settings.isReviewer.get && reviewStatus != Task.REVIEW_STATUS_REQUESTED &&
       reviewStatus != Task.REVIEW_STATUS_DISPUTED) {
       throw new IllegalAccessException("User must be a reviewer to edit task review status.")
     }
@@ -748,22 +821,26 @@ class TaskDAL @Inject()(override val db: Database,
         case false => None
       }
 
-      if (!isDisputed) {
-        if (needsReReview) {
-          // Let's note in the task_review_history table that this task needs review again
-          SQL"""INSERT INTO task_review_history
-                            (task_id, requested_by, reviewed_by, review_status, reviewed_at, review_started_at)
-                VALUES (${task.id}, ${user.id}, ${task.reviewedBy},
-                        ${reviewStatus}, ${now}, ${task.reviewStartedAt})""".executeUpdate()
-          this.notificationDAL.get().createReviewNotification(user, task.reviewedBy.getOrElse(-1), reviewStatus, task, comment)
-        }
-        else {
-          // Let's note in the task_review_history table that this task was reviewed
-          SQL"""INSERT INTO task_review_history
-                            (task_id, requested_by, reviewed_by, review_status, reviewed_at, review_started_at)
-                VALUES (${task.id}, ${task.reviewRequestedBy}, ${user.id},
-                        ${reviewStatus}, ${now}, ${task.reviewStartedAt})""".executeUpdate()
-          this.notificationDAL.get().createReviewNotification(user, task.reviewRequestedBy.getOrElse(-1), reviewStatus, task, comment)
+      // Don't send a notification for every task in a task bundle, only the
+      // primary task
+      if (task.bundleId == None || task.isBundlePrimary.getOrElse(false)) {
+        if (!isDisputed) {
+          if (needsReReview) {
+            // Let's note in the task_review_history table that this task needs review again
+            SQL"""INSERT INTO task_review_history
+                              (task_id, requested_by, reviewed_by, review_status, reviewed_at, review_started_at)
+                  VALUES (${task.id}, ${user.id}, ${task.reviewedBy},
+                          ${reviewStatus}, ${now}, ${task.reviewStartedAt})""".executeUpdate()
+            this.notificationDAL.get().createReviewNotification(user, task.reviewedBy.getOrElse(-1), reviewStatus, task, comment)
+          }
+          else {
+            // Let's note in the task_review_history table that this task was reviewed
+            SQL"""INSERT INTO task_review_history
+                              (task_id, requested_by, reviewed_by, review_status, reviewed_at, review_started_at)
+                  VALUES (${task.id}, ${task.reviewRequestedBy}, ${user.id},
+                          ${reviewStatus}, ${now}, ${task.reviewStartedAt})""".executeUpdate()
+            this.notificationDAL.get().createReviewNotification(user, task.reviewRequestedBy.getOrElse(-1), reviewStatus, task, comment)
+          }
         }
       }
 
@@ -1100,15 +1177,20 @@ class TaskDAL @Inject()(override val db: Database,
     * given challenge. Ignores tasks that are complete, locked by other users,
     * or that the current user has worked on in the last hour
     */
-  def getNearbyTasks(user: User, challengeId: Long, proximityId: Long, limit: Int = 5)
+  def getNearbyTasks(user: User, challengeId: Long, proximityId: Long, excludeSelfLocked: Boolean = false, limit: Int = 5)
                     (implicit c: Option[Connection] = None): List[Task] = {
+    var selfLockedClause = ""
+    if (!excludeSelfLocked) {
+      selfLockedClause = s"OR l.user_id = ${user.id}"
+    }
+
     val query =
       s"""SELECT tasks.$retrieveColumnsWithReview FROM tasks
       LEFT JOIN locked l ON l.item_id = tasks.id
       LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
       WHERE tasks.id <> $proximityId AND
             tasks.parent_id = $challengeId AND
-            (l.id IS NULL OR l.user_id = ${user.id}) AND
+            (l.id IS NULL ${selfLockedClause}) AND
             tasks.status IN (0, 3, 6) AND
             NOT tasks.id IN (
                 SELECT task_id FROM status_actions
@@ -1506,6 +1588,130 @@ class TaskDAL @Inject()(override val db: Database,
         case None =>
           throw new NotFoundException("Task was not found.")
       }
+    }
+  }
+
+  /**
+    * Creates a new task bundle with the given tasks, assigning ownership of
+    * the bundle to the given user
+    *
+    * @param user    The user who is to own the bundle
+    * @param name    The name of the task bundle
+    * @param taskIds The tasks to be added to the bundle
+    */
+  def createTaskBundle(user: User, name: String, taskIds: List[Long])(implicit c: Connection = null): TaskBundle = {
+    this.withMRTransaction { implicit c =>
+      val lockedTasks = this.withListLocking(user, Some(TaskType())) { () =>
+        this.retrieveListById(-1, 0)(taskIds)
+      }
+
+      val rowId = SQL"""INSERT INTO bundles (owner_id, name) VALUES (${user.id}, ${name})""".executeInsert()
+      rowId match {
+        case Some(bundleId) =>
+          val sqlQuery = s"""INSERT INTO task_bundles (task_id, bundle_id) VALUES ({taskId}, $bundleId)"""
+          val parameters = lockedTasks.map(task => {
+            Seq[NamedParameter]("taskId" -> task.id)
+          })
+          BatchSql(sqlQuery, parameters.head, parameters.tail: _*).execute()
+          TaskBundle(bundleId, user.id, lockedTasks.map(task => { task.id }), Some(lockedTasks))
+        case None =>
+          throw new Exception("Bundle creation failed")
+      }
+    }
+  }
+
+  /**
+    * Fetches a list of tasks associated with the given bundle id.
+    *
+    * @param bundleId    The id of the bundle
+    */
+  def getTaskBundle(user: User, bundleId: Long)(implicit c: Connection = null): TaskBundle = {
+    this.withMRConnection { implicit c =>
+      val query =
+        s"""SELECT ${retrieveColumnsWithReview} FROM ${this.tableName}
+            INNER JOIN task_bundles tb on tasks.id = tb.task_id
+            LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
+            WHERE tb.bundle_id = {bundleId}"""
+      val tasks = SQL(query).on('bundleId -> bundleId).as(this.parser.*)
+      TaskBundle(bundleId, user.id, tasks.map(task => { task.id }), Some(tasks))
+    }
+  }
+
+  /**
+    * Deletes a task bundle.
+    *
+    * @param bundleId    The id of the bundle
+    */
+  def deleteTaskBundle(user: User, bundleId: Long, primaryTaskId: Option[Long] = None)(implicit c: Connection = null): Unit = {
+    this.withMRConnection { implicit c =>
+      val bundle = this.getTaskBundle(user, bundleId)
+      if (!user.isSuperUser && bundle.ownerId != user.id) {
+        throw new IllegalAccessException("Only a super user or the original user can delete this bundle.")
+      }
+
+      SQL("UPDATE tasks SET bundle_id = NULL, is_bundle_primary = NULL WHERE bundle_id = {bundleId}").on('bundleId -> bundleId).executeUpdate()
+
+      // unlock tasks (everything but the primary task id)
+      val tasks = this.getTaskBundle(user, bundleId).tasks match {
+        case Some(t) =>
+          for (task <- t) {
+            if (task.id != primaryTaskId.getOrElse(0)) {
+              try {
+                this.unlockItem(user, task)
+              } catch {
+                case e: Exception => logger.warn(e.getMessage)
+              }
+            }
+          }
+        case None => // no tasks in bundle
+      }
+
+      SQL("DELETE FROM bundles WHERE id = {bundleId}").on('bundleId -> bundleId).executeUpdate()
+    }
+  }
+
+  /**
+    * Removes tasks from a bundle.
+    *
+    * @param bundleId    The id of the bundle
+    */
+  def unbundleTasks(user: User, bundleId: Long, taskIds: List[Long])(implicit c: Connection = null): TaskBundle = {
+    this.withMRConnection { implicit c =>
+      val bundle = this.getTaskBundle(user, bundleId)
+      if (!user.isSuperUser && bundle.ownerId != user.id) {
+        throw new IllegalAccessException("Only a super user or the original user can delete this bundle.")
+      }
+
+      // Unset any bundle_id on individual tasks (this is set when task is completed)
+      SQL(s"""UPDATE tasks SET bundle_id = NULL
+              WHERE bundle_id = {bundleId}
+              AND (is_bundle_primary != true OR is_bundle_primary is NULL)
+              AND id IN ({inList})""").on('bundleId -> bundleId,
+                'inList ->ToParameterValue.apply[List[Long]].apply(taskIds)).executeUpdate()
+
+      // Remove task from bundle join table.
+      val tasks = this.getTaskBundle(user, bundleId).tasks match {
+        case Some(t) =>
+          for (task <- t) {
+            if (!task.isBundlePrimary.getOrElse(false)) {
+              taskIds.find(id => id == task.id) match {
+                case Some(_) =>
+                  SQL(s"""DELETE FROM task_bundles
+                          WHERE bundle_id = ${bundleId} AND task_id = ${task.id}""").executeUpdate()
+
+                  try {
+                    this.unlockItem(user, task)
+                  } catch {
+                    case e: Exception => logger.warn(e.getMessage)
+                  }
+                case None => // do nothing
+              }
+            }
+          }
+        case None => // No tasks in bundle.
+      }
+
+      this.getTaskBundle(user, bundleId)
     }
   }
 

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -406,19 +406,22 @@ class VirtualChallengeDAL @Inject()(override val db: Database,
                         int("status") ~ get[Option[String]]("suggested_fix") ~ get[Option[DateTime]]("mapped_on") ~
                         get[Option[Int]]("review_status") ~ get[Option[Int]]("review_requested_by") ~
                         get[Option[Int]]("reviewed_by") ~ get[Option[DateTime]]("reviewed_at") ~
-                        get[Option[DateTime]]("review_started_at") ~ int("priority") map {
+                        get[Option[DateTime]]("review_started_at") ~ int("priority") ~
+                        get[Option[Long]]("bundle_id") ~ get[Option[Boolean]]("is_bundle_primary") map {
         case id ~ name ~ instruction ~ location ~ status ~ suggestedFix ~ mappedOn ~ reviewStatus ~ reviewRequestedBy ~
-             reviewedBy ~ reviewedAt ~ reviewStartedAt ~ priority =>
+             reviewedBy ~ reviewedAt ~ reviewStartedAt ~ priority ~ bundleId ~ isBundlePrimary =>
           val locationJSON = Json.parse(location)
           val coordinates = (locationJSON \ "coordinates").as[List[Double]]
           val point = Point(coordinates(1), coordinates.head)
+          val pointReview = PointReview(reviewStatus, reviewRequestedBy, reviewedBy, reviewedAt, reviewStartedAt)
           ClusteredPoint(id, -1, "", name, -1, "", point, JsString(""),
-            instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status, suggestedFix, mappedOn, reviewStatus,
-            reviewRequestedBy, reviewedBy, reviewedAt, reviewStartedAt, priority)
+            instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status, suggestedFix, mappedOn,
+            pointReview, priority, bundleId, isBundlePrimary)
       }
       SQL"""SELECT tasks.id, name, instruction, status, suggestedfix_geojson::TEXT as suggested_fix,
                    mapped_on, review_status, review_requested_by,
-                   reviewed_by, reviewed_at, review_started_at, ST_AsGeoJSON(location) AS location, priority
+                   reviewed_by, reviewed_at, review_started_at, ST_AsGeoJSON(location) AS location, priority,
+                   bundle_id, is_bundle_primary
               FROM tasks LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
               WHERE tasks.id IN
               (SELECT task_id FROM virtual_challenge_tasks

--- a/app/org/maproulette/permissions/Permission.scala
+++ b/app/org/maproulette/permissions/Permission.scala
@@ -84,6 +84,10 @@ class Permission @Inject()(dalManager: Provider[DALManager]) {
         case TagType() =>
         case GroupType() =>
           this.hasProjectTypeAccess(user, Group.TYPE_ADMIN)(obj.asInstanceOf[Group].projectId)
+        case BundleType() =>
+          if (obj.asInstanceOf[Bundle].owner != user.osmProfile.id) {
+            throw new IllegalAccessException(s"Only super users or the owner of the bundle can write to it.")
+          }
         case _ =>
           throw new IllegalAccessException(s"Unknown object type ${obj.itemType.toString}")
       }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1695,8 +1695,11 @@ GET     /challenge/:cid/tasks/randomTasks           @org.maproulette.controllers
 #   - name: proximity
 #     in: query
 #     description: Id of task around which geographically closest tasks are desired
+#   - name: excludeSelfLocked
+#     in: query
+#     description: exclude tasks this user has locked (always excludes tasks locked by others)
 ###
-GET     /challenge/:cid/tasksNearby/:proximityId           @org.maproulette.controllers.api.ChallengeController.getNearbyTasks(cid:Long, proximityId:Long, limit:Int ?= 5)
+GET     /challenge/:cid/tasksNearby/:proximityId           @org.maproulette.controllers.api.ChallengeController.getNearbyTasks(cid:Long, proximityId:Long, excludeSelfLocked:Boolean ?=false, limit:Int ?= 5)
 ###
 # tags: [ Challenge ]
 # summary: Retrieves prioritized random Task
@@ -3030,11 +3033,48 @@ PUT     /task/:id/changeset                         @org.maproulette.controllers
 PUT     /task/:id/:status                           @org.maproulette.controllers.api.TaskController.setTaskStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="")
 ###
 # tags: [ Task ]
+# summary: Update Bundle Task Status
+# produces: [ application/json ]
+# description: Will update a Bundled list of Tasks statuses to one of the following. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
+# responses:
+#   '200':
+#     description: TaskBundle
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: The bundle or primary task was not found with the supplied Id.
+# parameters:
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: bundleId
+#     in: path
+#     description: The ID of the bundle
+#   - name: primaryId
+#     in: path
+#     description: The primary ID of the task for this bundle
+#   - name: status
+#     in: path
+#     description: The status to update the Task too. Following status Integers can be used. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
+#   - name: comment
+#     in: query
+#     description: Any comment that is provided by the user when setting the status
+#   - name: requestReview
+#     in: query
+#     description: Boolean indicating if a review is requested on this task. (Will override user settings if provided)
+#   - name: tags
+#     description: Optional tags to associate with this task
+###
+PUT     /taskBundle/:bundleId/:status                           @org.maproulette.controllers.api.TaskController.setBundleTaskStatus(bundleId:Long, primaryId:Long, status:Int, comment:String ?= "", tags:String ?="")
+###
+# tags: [ Task ]
 # summary: Update Task Review Status
 # produces: [ application/json ]
 # description: Will update a Tasks review status to one of the following. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted
 # responses:
-#   '304':
+#   '200':
 #     description: No Content, update successful
 #   '401':
 #     description: The user is not authorized to make this request
@@ -3059,6 +3099,37 @@ PUT     /task/:id/:status                           @org.maproulette.controllers
 #     description: Optional tags to associate with this task
 ###
 PUT     /task/:id/review/:status                           @org.maproulette.controllers.api.TaskController.setTaskReviewStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="")
+###
+# tags: [ Task ]
+# summary: Update Task Review Status for a Bundle
+# produces: [ application/json ]
+# description: Will update a Tasks review status to one of the following. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted
+# responses:
+#   '200':
+#     description: Task Bundle
+#   '401':
+#     description: The user is not authorized to make this request
+#   '404':
+#     description: The task with the supplied ID was not found.
+# parameters:
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: id
+#     in: path
+#     description: The ID of the bundle
+#   - name: status
+#     in: path
+#     description: The status to update the Task to. Following status Integers can be used. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted
+#   - name: comment
+#     in: query
+#     description: Any comment that is provided by the user when setting the review status
+#   - name: tags
+#     description: Optional tags to associate with this task
+###
+PUT     /taskBundle/:id/review/:status                     @org.maproulette.controllers.api.TaskController.setBundleTaskReviewStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves task clusters
@@ -3193,6 +3264,27 @@ GET     /task/:id/comments                          @org.maproulette.controllers
 #     description: An optional action ID that may be associated with the comment
 ###
 POST    /task/:id/comment                           @org.maproulette.controllers.api.TaskController.addComment(id:Long, comment:String, actionId:Option[Long])
+###
+# tags: [ Comment ]
+# summary: Adds comment to each Task in a Task Bundle
+# description: Adds a comment to each Task in Bundle
+# responses:
+#   '201':
+#     description: The task bundle
+#   '404':
+#     description: If the bundle is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the bundle
+#   - name: comment
+#     in: query
+#     description: A URLEncoded comment for the Task
+#   - name: actionId
+#     in: query
+#     description: An optional action ID that may be associated with the comment
+###
+POST    /taskBundle/:id/comment                     @org.maproulette.controllers.api.TaskController.addCommentToBundleTasks(id:Long, comment:String, actionId:Option[Long])
 ###
 # tags: [ Comment ]
 # summary: Update comment on Task
@@ -4210,6 +4302,40 @@ POST    /change/tag/test                            @org.maproulette.controllers
 #       $ref: '#/definitions/org.maproulette.services.osm.ChangeObjects.TagChangeSubmission'
 ###
 POST    /task/:taskId/fix/apply                     @org.maproulette.controllers.api.TaskController.applyTagFix(taskId:Long, comment:String ?= "", tags:String ?= "")
+
+###
+# tags: [ Bundle ]
+# summary: Create a task bundle
+# consumes: [ application/json ]
+# produces: [ application/json ]
+# description: Create a new task bundle with the task ids in the supplied JSON body.
+# responses:
+#   '200':
+#     description: The newly created bundle with a unique id.
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.TaskBundle'
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
+#   - name: body
+#     in: body
+#     description: The JSON structure for the bundle body.
+#     required: true
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.TaskBundle'
+###
+POST    /taskBundle                                 @org.maproulette.controllers.api.TaskController.createTaskBundle
+### NoDocs ###
+GET     /taskBundle/:id                             @org.maproulette.controllers.api.TaskController.getTaskBundle(id:Long)
+### NoDocs ###
+DELETE     /taskBundle/:id                          @org.maproulette.controllers.api.TaskController.deleteTaskBundle(id:Long, primaryId:Option[Long])
+### NoDocs ###
+GET        /taskBundle/:id/unbundle                 @org.maproulette.controllers.api.TaskController.unbundleTasks(id:Long, taskIds:List[Long])
 ### NoDocs ###
 POST    /*path                                      @org.maproulette.controllers.api.APIController.invalidAPIPath(path)
 ### NoDocs ###

--- a/conf/evolutions/default/43.sql
+++ b/conf/evolutions/default/43.sql
@@ -1,0 +1,42 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- New table for bundles
+CREATE TABLE IF NOT EXISTS bundles
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  owner_id integer NOT NULL,
+  name character varying NULL,
+  description character varying NULL,
+  created timestamp without time zone DEFAULT NOW(),
+  modified timestamp without time zone DEFAULT NOW(),
+  CONSTRAINT bundles_owner_id FOREIGN KEY (owner_id)
+    REFERENCES users(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE
+);;
+
+-- New table for task bundles
+CREATE TABLE IF NOT EXISTS task_bundles
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  task_id integer NOT NULL,
+  bundle_id integer NOT NULL,
+  CONSTRAINT task_bundles_task_id FOREIGN KEY (task_id)
+    REFERENCES tasks(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT task_bundles_bundle_id FOREIGN KEY (bundle_id)
+    REFERENCES bundles(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE
+);;
+
+ALTER TABLE tasks ADD COLUMN bundle_id integer NULL;;
+ALTER TABLE tasks ADD COLUMN is_bundle_primary boolean;;
+
+SELECT create_index_if_not_exists('task_bundles', 'bundle_id', '(bundle_id)');;
+
+# --- !Downs
+ALTER TABLE tasks DROP COLUMN bundle_id;;
+ALTER TABLE tasks DROP COLUMN is_bundle_primary;;
+
+DROP TABLE IF EXISTS task_bundles;;
+DROP TABLE IF EXISTS bundles;;

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -5944,6 +5944,867 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "taskBundles",
+			"item": [
+				{
+					"name": "Setup Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b66704e2-4a0d-469b-b3ea-b8178853b754",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"TestBundleProject\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"TestBundleProject\";",
+									"tests[\"description\"] = jsonData.description === \"Test project.\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"TestBundleProject\",\n    \"description\":\"Test project.\",\n    \"enabled\":false\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Setup Challenge",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "c38e2230-0f76-4588-80f6-6cc7772d1ff4",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"TestBundleChallenge\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"TestBundleChallenge\";",
+									"tests[\"description\"] = jsonData.description === \"TestChallenge description\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"TestChallenge instruction\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"TestBundleChallenge\",\n    \"parent\": {{TestBundleProject}},\n    \"description\":\"TestChallenge description\",\n    \"instruction\":\"TestChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        },\n        {\n            \"name\":\"Task 2\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/challenge",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"challenge"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create new Task1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "95f07c63-a41d-410d-ad61-2617d001c8fb",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"NewTask1\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"NewTask1\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask1 instruction\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"NewTask1\",\n    \"parent\": {{TestBundleChallenge}},\n    \"instruction\":\"NewTask1 instruction\",\n    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{ \"identifier\":{\"value\":1111} }}]}\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create new Task2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ecdd7063-cdcc-4607-bcae-a32874ce4b04",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"NewTask2\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"NewTask2\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask2 instruction\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"NewTask2\",\n    \"parent\": {{TestBundleChallenge}},\n    \"instruction\":\"NewTask2 instruction\",\n    \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[105.1,1.6]},\"properties\":{\"id\": \"test3\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[105.2,1.7]},\"properties\":{ \"identifier\":{\"value\":1111} }}]}\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create new Bundle",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "705b2416-7628-4ad0-acbf-81bf9c0c477b",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"NewBundle\", jsonData.bundleId);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"New Bundle\",\n    \"taskIds\": [{{NewTask1}},{{NewTask2}}]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add Bundle Tasks Comments",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d0bacf4b-7616-4d8a-ae40-205f8ee5d7c1",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"NewComment\", jsonData.id);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}/comment?comment=This%20is%20a%20comment",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle",
+								"{{NewBundle}}",
+								"comment"
+							],
+							"query": [
+								{
+									"key": "comment",
+									"value": "This%20is%20a%20comment"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setTaskBundleStatus",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}/2?primaryId={{NewTask1}}&comment=SomeComment&requestReview=true",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle",
+								"{{NewBundle}}",
+								"2"
+							],
+							"query": [
+								{
+									"key": "primaryId",
+									"value": "{{NewTask1}}"
+								},
+								{
+									"key": "comment",
+									"value": "SomeComment"
+								},
+								{
+									"key": "requestReview",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Read Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask1\";",
+									"tests[\"status\"] = jsonData.status === 2;",
+									"tests[\"bundlePrimary\"] = jsonData.isBundlePrimary === true;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask1}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Start Task Review",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask1\";",
+									"tests[\"reviewStatus\"] = jsonData.reviewStatus === 0;",
+									"tests[\"reviewClaimedBy\"] = jsonData.reviewClaimedBy === -999;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}/review/start",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask1}}",
+								"review",
+								"start"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Read Other Bundle Task (after start review)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask2\";",
+									"tests[\"status\"] = jsonData.status === 2;",
+									"tests[\"bundlePrimary\"] = jsonData.isBundlePrimary !== false;",
+									"tests[\"reviewClaimedBy\"] = jsonData.reviewClaimedBy === -999;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask2}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask2}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "setBundleTaskReviewStatus",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}/review/1?comment=SomeReviewCommet&reviewStatus=1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle",
+								"{{NewBundle}}",
+								"review",
+								"1"
+							],
+							"query": [
+								{
+									"key": "comment",
+									"value": "SomeReviewCommet"
+								},
+								{
+									"key": "reviewStatus",
+									"value": "1"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Read Task After Review",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask1\";",
+									"tests[\"status\"] = jsonData.status === 2;",
+									"tests[\"bundlePrimary\"] = jsonData.isBundlePrimary === true;",
+									"tests[\"reviewStatus\"] = jsonData.reviewStatus === 1;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask1}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Fetch Bundle",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "3bb07589-1294-4a38-8299-caa0e8cfa152",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"taskName1\"] = jsonData.tasks[0].name === \"NewTask1\"",
+									"tests[\"taskStatus1\"] = jsonData.tasks[0].status === 2",
+									"tests[\"taskName2\"] = jsonData.tasks[1].name === \"NewTask2\"",
+									"tests[\"taskStatus2\"] = jsonData.tasks[1].status === 2"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle",
+								"{{NewBundle}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "unbundleTasks",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"tasksLength\"] = Object.keys(jsonData.tasks).length === 1",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}/unbundle?taskIds={{NewTask2}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle",
+								"{{NewBundle}}",
+								"unbundle"
+							],
+							"query": [
+								{
+									"key": "taskIds",
+									"value": "{{NewTask2}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Bundle",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5b81c410-0935-4d7b-89fc-f6bba888a7e4",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}?primaryId={{NewTask1}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"taskBundle",
+								"{{NewBundle}}"
+							],
+							"query": [
+								{
+									"key": "primaryId",
+									"value": "{{NewTask1}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Teardown",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5b81c410-0935-4d7b-89fc-f6bba888a7e4",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"Status\"] = jsonData.status === \"OK\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{TestBundleProject}}?immediate=true",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{TestBundleProject}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
* Add createTaskBundle

* Add setTaskBundleStatus which takes in bundleId and primaryId and
  runs through all tasks in bundle to setTaskStatus

* Add getTaskBundle returns a TaskBundle with associated tasks

* Task now returns bundldId and isBundlePrimary properties

* Add setBundleTaskReview which will loop through each task and
  call setTaskReview

* Review queries will only return the primary task in a bundle

* addCommentToBundleTasks - adds comments to each task
  in bundle

* deleteTaskBundle - will delete task bundle and unlock
  all tasks but primary task id

* unbundleTasks - removes and unlocks tasks from bundle

* Support a new optional flag allowing tasks locked by the requesting
user to be excluded from the results of the nearby-tasks API (tasks
locked by others are always excluded)

* Change startTaskReview to claim all tasks in bundle

* Found BUG where "unlockItem" was being called on task
  instead of "lockItem" in startTaskReview
