### PR TITLE
Remove hour wait for tasks in created status when fetching next

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1079,11 +1079,12 @@ class TaskDAL @Inject()(override val db: Database,
         // boundary when there is only one task remaining that they're trying
         // to skip, and also prevents the user from getting bounced between a
         // small number of nearby skipped tasks when loading by proximity
+        // Unless a status is created then ignore this check.
         appendInWhereClause(whereClause,
-          s"""NOT tasks.id IN (
+          s"""NOT (tasks.status != ${Task.STATUS_CREATED} AND tasks.id IN (
              |SELECT task_id FROM status_actions
              |WHERE osm_user_id IN (${user.osmProfile.id})
-             |  AND created >= NOW() - '1 hour'::INTERVAL)""".stripMargin)
+             |  AND created >= NOW() - '1 hour'::INTERVAL))""".stripMargin)
 
         priority match {
           case Some(p) => appendInWhereClause(whereClause, s"tasks.priority = $p")


### PR DESCRIPTION
When fetching next tasks to work on, we only return tasks that
the user has not worked on in the last hour. If the task's
status is reset back to created this limit still applies. Do
not require an hour wait limit if the task is in a created
status so it can be worked on right away in this instance.