### PR TITLE
Emit websocket messages for task actions

### DIFF
--- a/app/org/maproulette/controllers/api/TaskHistoryController.scala
+++ b/app/org/maproulette/controllers/api/TaskHistoryController.scala
@@ -11,6 +11,7 @@ import org.maproulette.permissions.Permission
 import org.maproulette.session.{SessionManager, User}
 import org.maproulette.utils.Utils
 import org.maproulette.services.osm.ChangesetProvider
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -27,12 +28,13 @@ class TaskHistoryController @Inject()(override val sessionManager: SessionManage
                                taskHistoryDAL: TaskHistoryDAL,
                                dalManager: DALManager,
                                wsClient: WSClient,
+                               webSocketProvider: WebSocketProvider,
                                config: Config,
                                components: ControllerComponents,
                                changeService: ChangesetProvider,
                                override val bodyParsers: PlayBodyParsers)
   extends TaskController(sessionManager, actionManager, dal, tagDAL, dalManager,
-                         wsClient, config, components, changeService, bodyParsers) {
+                         wsClient, webSocketProvider, config, components, changeService, bodyParsers) {
 
   /**
     * Gets the history for a task. This includes commments, status_actions, and review_actions.

--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -9,6 +9,7 @@ import org.maproulette.models.dal._
 import org.maproulette.models.{Challenge, Task}
 import org.maproulette.permissions.Permission
 import org.maproulette.session.{SessionManager, SearchParameters, User}
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.utils.Utils
 import org.maproulette.services.osm.ChangesetProvider
@@ -29,12 +30,13 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
                                taskReviewDAL: TaskReviewDAL,
                                dalManager: DALManager,
                                wsClient: WSClient,
+                               webSocketProvider: WebSocketProvider,
                                config: Config,
                                components: ControllerComponents,
                                changeService: ChangesetProvider,
                                override val bodyParsers: PlayBodyParsers)
   extends TaskController(sessionManager, actionManager, dal, tagDAL, dalManager,
-                         wsClient, config, components, changeService, bodyParsers) {
+                         wsClient, webSocketProvider, config, components, changeService, bodyParsers) {
 
 
   /**

--- a/app/org/maproulette/provider/websockets/README.md
+++ b/app/org/maproulette/provider/websockets/README.md
@@ -52,3 +52,17 @@ code can use to easily send a message via the WebSocketPublisher without having
 to interact directly or be aware of the Akka actor system. Most server code
 will wish to use this method to send messages rather than trying to deal with
 the Akka actor system.
+
+
+## Adding a New Message Type
+
+1. Edit WebSocketMessages and add:
+  - case class for payload data
+  - case class for message
+  - helper method for generating message
+  - writes for data class
+  - writes for message class
+  - new subscription type if needed
+
+2. Edit WebSocketActor and add:
+  - match case for the new message type

--- a/app/org/maproulette/provider/websockets/WebSocketActor.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketActor.scala
@@ -53,6 +53,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
       out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.ReviewMessage =>
       out ! Json.toJson(serverMessage)
+    case serverMessage: WebSocketMessages.TaskMessage =>
+      out ! Json.toJson(serverMessage)
     case clientMessage: WebSocketMessages.ClientMessage =>
       clientMessage.messageType match {
         case "subscribe" =>

--- a/app/org/maproulette/provider/websockets/WebSocketMessages.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketMessages.scala
@@ -6,7 +6,9 @@ import org.joda.time.DateTime
 import play.api.libs.json._
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
+import org.maproulette.models.Task
 import org.maproulette.models.TaskWithReview
+import org.maproulette.session.User
 
 /**
  * Defines case classes representing the various kinds of messages to be
@@ -33,18 +35,28 @@ object WebSocketMessages {
 
   case class PongMessage(messageType: String, meta: ServerMeta) extends ServerMessage
 
+  case class UserSummary(userId: Long, displayName: String, avatarURL: String)
+
   case class NotificationData(userId: Long, notificationType: Int)
   case class NotificationMessage(messageType: String, data: NotificationData, meta: ServerMeta) extends ServerMessage
 
   case class ReviewData(taskWithReview: TaskWithReview)
   case class ReviewMessage(messageType: String, data: ReviewData, meta: ServerMeta) extends ServerMessage
 
-  // Public helper methods for creation of individual messages
+  case class TaskAction(task: Task, byUser: Option[UserSummary])
+  case class TaskMessage(messageType: String, data: TaskAction, meta: ServerMeta) extends ServerMessage
+
+  // Public helper methods for creation of individual messages and data objects
   def pong() = PongMessage("pong", ServerMeta(None))
   def notificationNew(data: NotificationData) = createNotificationMessage("notification-new", data)
   def reviewNew(data: ReviewData) = createReviewMessage("review-new", data)
   def reviewClaimed(data: ReviewData) = createReviewMessage("review-claimed", data)
   def reviewUpdate(data: ReviewData) = createReviewMessage("review-update", data)
+  def taskClaimed(taskData: Task, userData: Option[UserSummary]) = createTaskMessage("task-claimed", taskData, userData)
+  def taskReleased(taskData: Task, userData: Option[UserSummary]) = createTaskMessage("task-released", taskData, userData)
+  def taskUpdate(taskData: Task, userData: Option[UserSummary]) = createTaskMessage("task-update", taskData, userData)
+
+  def userSummary(user: User) = UserSummary(user.id, user.osmProfile.displayName, user.osmProfile.avatarURL)
 
   // private helper methods
   private def createNotificationMessage(messageType: String, data: NotificationData) = {
@@ -55,6 +67,21 @@ object WebSocketMessages {
     ReviewMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_REVIEWS)))
   }
 
+  private def createTaskMessage(messageType: String, taskData: Task, userData: Option[UserSummary]) = {
+    val data = TaskAction(taskData, userData)
+
+    // Create one message for subscribers to all tasks and one for subscribers
+    // to just challenge-specific tasks
+    List[WebSocketMessages.ServerMessage](
+      TaskMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_TASKS))),
+      TaskMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_CHALLENGE_TASKS + s"_${data.task.parent}")))
+    )
+  }
+
+  private def createChallengeTaskMessage(messageType: String, data: TaskAction) = {
+    TaskMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_CHALLENGE_TASKS + s"_${data.task.parent}")))
+  }
+
   // Reads for client messages
   implicit val clientMessageReads: Reads[ClientMessage] = Json.reads[ClientMessage]
   implicit val subscriptionDataReads: Reads[SubscriptionData] = Json.reads[SubscriptionData]
@@ -63,13 +90,18 @@ object WebSocketMessages {
   // Writes for server-generated messages
   implicit val serverMetaWrites: Writes[ServerMeta] = Json.writes[ServerMeta]
   implicit val pongMessageWrites: Writes[PongMessage] = Json.writes[PongMessage]
+  implicit val UserSummaryWrites: Writes[UserSummary] = Json.writes[UserSummary]
   implicit val notificationDataWrites: Writes[NotificationData] = Json.writes[NotificationData]
   implicit val notificationMessageWrites: Writes[NotificationMessage] = Json.writes[NotificationMessage]
   implicit val reviewDataWrites: Writes[ReviewData] = Json.writes[ReviewData]
   implicit val reviewMessageWrites: Writes[ReviewMessage] = Json.writes[ReviewMessage]
+  implicit val taskActionWrites: Writes[TaskAction] = Json.writes[TaskAction]
+  implicit val taskMessageWrites: Writes[TaskMessage] = Json.writes[TaskMessage]
 
   // Available subscription types
   val SUBSCRIPTION_USER = "user"        // expected to be accompanied by user id
   val SUBSCRIPTION_USERS = "users"
   val SUBSCRIPTION_REVIEWS = "reviews"
+  val SUBSCRIPTION_TASKS = "tasks"
+  val SUBSCRIPTION_CHALLENGE_TASKS = "challengeTasks" // expected to be accompanied by challenge id
 }

--- a/app/org/maproulette/provider/websockets/WebSocketProvider.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketProvider.scala
@@ -30,4 +30,8 @@ class WebSocketProvider @Inject()(implicit system: ActorSystem) {
   def sendMessage(message: WebSocketMessages.ServerMessage) = {
     publisher ! message
   }
+
+  def sendMessage(messages: List[WebSocketMessages.ServerMessage]) = {
+    messages.foreach { publisher ! _ }
+  }
 }


### PR DESCRIPTION
* Support new websocket messages for notifying subscribed clients when
tasks are claimed, released, or completed

* Clients can subscribe to messages for all tasks or to just tasks in a
specified challenge

* Enhance websocket system to allow multiple messages to be emitted
simultaneously from a single event, useful for supporting multiple
levels of client subscription granularity (e.g. all tasks plus tasks
specific to a challenge)

* Update websocket README with basic outline for adding a new message
type