### PR TITLE
Add flag to exclude locked tasks from cluster methods

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -160,14 +160,14 @@ class ChallengeController @Inject()(override val childController: TaskController
     * @param limit        limit the number of tasks returned
     * @return A list of ClusteredPoint's
     */
-  def getClusteredPoints(challengeId: Long, statusFilter: String, limit: Int): Action[AnyContent] = Action.async { implicit request =>
+  def getClusteredPoints(challengeId: Long, statusFilter: String, limit: Int, excludeLocked: Boolean): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       val filter = if (StringUtils.isEmpty(statusFilter)) {
         None
       } else {
         Some(Utils.split(statusFilter).map(_.toInt))
       }
-      val result = this.dal.getClusteredPoints(challengeId, filter, limit)
+      val result = this.dal.getClusteredPoints(User.userOrMocked(user), challengeId, filter, limit, excludeLocked)
       Ok(_insertReviewJSON(result))
     }
   }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -297,11 +297,12 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     * @param offset The offset used for paging
     * @return
     */
-  def getTasksInBoundingBox(left: Double, bottom: Double, right: Double, top: Double, limit: Int, offset: Int): Action[AnyContent] = Action.async { implicit request =>
+  def getTasksInBoundingBox(left: Double, bottom: Double, right: Double, top: Double, limit: Int,
+                            offset: Int, excludeLocked: Boolean): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { p =>
         val params = p.copy(location = Some(SearchLocation(left, bottom, right, top)))
-        Ok(Json.toJson(this.dal.getTasksInBoundingBox(params, limit, offset)))
+        Ok(Json.toJson(this.dal.getTasksInBoundingBox(User.userOrMocked(user), params, limit, offset, excludeLocked)))
       }
     }
   }

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -109,7 +109,7 @@ class VirtualChallengeDAL @Inject()(override val db: Database,
   def rebuildVirtualChallenge(id: Long, params: SearchParameters, user: User)(implicit c: Option[Connection] = None): Unit = {
     permission.hasWriteAccess(VirtualChallengeType(), user)(id)
     withMRTransaction { implicit c =>
-      this.taskDAL.getTasksInBoundingBox(params, -1, 0).grouped(config.virtualChallengeBatchSize).foreach(batch => {
+      this.taskDAL.getTasksInBoundingBox(user, params, -1, 0).grouped(config.virtualChallengeBatchSize).foreach(batch => {
         val insertRows = batch.map(point => s"(${point.id}, $id)").mkString(",")
         SQL"""
            INSERT INTO virtual_challenge_tasks (task_id, virtual_challenge_id) VALUES #$insertRows

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1822,7 +1822,7 @@ GET     /challenge/view/:id                         @org.maproulette.controllers
 #     in: query
 #     description: Can filter the Tasks returned by the status of the Task. 0 - Created, 1 - Fixed, 2 - False Positive, 3 - Skipped, 4 - Deleted, 5 - Already Fixed, 6 - Too Hard
 ###
-GET     /challenge/clustered/:id                    @org.maproulette.controllers.api.ChallengeController.getClusteredPoints(id:Long, filter:String ?= "", limit:Int ?= 2500)
+GET     /challenge/clustered/:id                    @org.maproulette.controllers.api.ChallengeController.getClusteredPoints(id:Long, filter:String ?= "", limit:Int ?= 2500, excludeLocked:Boolean ?= false)
 ###
 # tags: [ Challenge ]
 # summary: Update Task Priorities
@@ -2967,7 +2967,7 @@ GET     /tasks/random                               @org.maproulette.controllers
 #     in: query
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
-GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0)
+GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false)
 ###
 # tags: [ Task ]
 # summary: Update Task Changeset


### PR DESCRIPTION
Change challenge/getClusteredPoints and getTasksInBoundingBox to accept an option excludeLocked parameter that will exclude locked tasks from the tasks returned. By default
the flag is set to false thereby preserving current behavior.