### PR TITLE
Filter out clustered points with no coordinates to prevent exception.

### DIFF
--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -97,6 +97,21 @@ case class Task(override val id: Long,
       List.empty
     }
   }
+
+  def hasValidCoordinates(): Boolean = {
+    val geojson = Json.parse(this.geometries)
+    val featureList = (geojson \ "features").asOpt[List[JsValue]]
+    if (featureList.isDefined) {
+      (featureList.get.head \ "geometry" \ "coordinates").asOpt[List[List[JsValue]]] match {
+        case Some(coords) =>
+          if (coords.isEmpty || coords.head.isEmpty) {
+            return false
+          }
+        case None => return false
+      }
+    }
+    true
+  }
 }
 
 object Task {

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -212,7 +212,10 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
         reviewStatus ~ reviewRequestedBy ~ reviewedBy ~ reviewedAt ~ reviewStartedAt =>
         val locationJSON = Json.parse(location)
         val coordinates = (locationJSON \ "coordinates").as[List[Double]]
-        val point = Point(coordinates(1), coordinates.head)
+        var point = Point(-1,-1) // default point if we have a bad task with no coordinates
+        if (coordinates.length >= 2)
+          point = Point(coordinates(1), coordinates.head)
+
         val pointReview = PointReview(reviewStatus, reviewRequestedBy, reviewedBy, reviewedAt, reviewStartedAt)
         ClusteredPoint(id, -1, "", name, parentId, parentName, point, JsString(""),
           instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status, suggestedFix, mappedOn,
@@ -856,10 +859,22 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
             #$filter
             LIMIT #${sqlLimit(limit)}"""
         .as(this.pointParser.*)
-      if (clusteredList.isEmpty) {
+
+      // There was a bug where tasks with no coordinates were being created.
+      // This filters out those tasks to allow the challenge to still be displayed.
+      val filteredList = clusteredList.filter(cp => {
+        if (cp.point.lat == -1 && cp.point.lng == -1) {
+          false
+        }
+        else {
+          true
+        }
+      })
+
+      if (filteredList.isEmpty) {
         this.updateGeometry(challengeId)
       }
-      clusteredList
+      filteredList
     }
   }
 


### PR DESCRIPTION
Error was reported that some challenges were throwing an exception when fetching the clustered tasks. This was caused by bad data. Fixed by 1. filtering out these bad tasks and 2. when a challenge is created skipping creating tasks that have empty coordinates.