### PR TITLE
Revert "Filter out clustered points with no coordinates"

### DIFF
--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -97,21 +97,6 @@ case class Task(override val id: Long,
       List.empty
     }
   }
-
-  def hasValidCoordinates(): Boolean = {
-    val geojson = Json.parse(this.geometries)
-    val featureList = (geojson \ "features").asOpt[List[JsValue]]
-    if (featureList.isDefined) {
-      (featureList.get.head \ "geometry" \ "coordinates").asOpt[List[List[JsValue]]] match {
-        case Some(coords) =>
-          if (coords.isEmpty || coords.head.isEmpty) {
-            return false
-          }
-        case None => return false
-      }
-    }
-    true
-  }
 }
 
 object Task {

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -217,10 +217,7 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
         reviewStatus ~ reviewRequestedBy ~ reviewedBy ~ reviewedAt ~ reviewStartedAt =>
         val locationJSON = Json.parse(location)
         val coordinates = (locationJSON \ "coordinates").as[List[Double]]
-        var point = Point(-1,-1) // default point if we have a bad task with no coordinates
-        if (coordinates.length >= 2)
-          point = Point(coordinates(1), coordinates.head)
-
+        val point = Point(coordinates(1), coordinates.head)
         val pointReview = PointReview(reviewStatus, reviewRequestedBy, reviewedBy, reviewedAt, reviewStartedAt)
         ClusteredPoint(id, -1, "", name, parentId, parentName, point, JsString(""),
           instruction, DateTime.now(), -1, Actions.ITEM_TYPE_TASK, status, suggestedFix, mappedOn,
@@ -869,22 +866,10 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
             #$filter
             LIMIT #${sqlLimit(limit)}"""
         .as(this.pointParser.*)
-
-      // There was a bug where tasks with no coordinates were being created.
-      // This filters out those tasks to allow the challenge to still be displayed.
-      val filteredList = clusteredList.filter(cp => {
-        if (cp.point.lat == -1 && cp.point.lng == -1) {
-          false
-        }
-        else {
-          true
-        }
-      })
-
-      if (filteredList.isEmpty) {
+      if (clusteredList.isEmpty) {
         this.updateGeometry(challengeId)
       }
-      filteredList
+      clusteredList
     }
   }
 

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -236,14 +236,7 @@ class ChallengeProvider @Inject()(challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
     try {
       val createdTasks = featureList.flatMap { value =>
         if (!single) {
-          (value \ "geometry").asOpt[JsObject] match {
-            case Some(geometry) =>
-              this.createNewTask(user, taskNameFromJsValue(value), parent, geometry, Utils.getProperties(value, "properties"))
-            case None =>
-              logger.error("Skipping task creation. No geometry provided when creating task for Challenge: " +
-                         parent.id + " in json: " + jsonData.toString())
-              None // skip task if no geometry
-          }
+          this.createNewTask(user, taskNameFromJsValue(value), parent, (value \ "geometry").as[JsObject], Utils.getProperties(value, "properties"))
         } else {
           None
         }
@@ -372,14 +365,7 @@ class ChallengeProvider @Inject()(challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
 
   private def _createNewTask(user: User, name: String, parent: Challenge, newTask: Task): Option[Task] = {
     try {
-      if (newTask.hasValidCoordinates) {
-        this.taskDAL.mergeUpdate(newTask, user)(newTask.id)
-      }
-      else {
-        logger.error("Invalid task coordinates provided when creating Challenge " +
-                     parent.id + " in json: " + newTask.geometries)
-        None
-      }
+      this.taskDAL.mergeUpdate(newTask, user)(newTask.id)
     } catch {
       // this task could fail on unique key violation, we need to ignore them
       case e: Exception =>


### PR DESCRIPTION
* Recently-added check for empty task geometry was too aggressive, causing creation of some valid challenges to fail, so simply `git revert` that commit for now -- we can revisit the missing-geometry checks at another time

* This reverts commit f98aebae400d31eb973f81233eabf3f130f72541