### PR TITLE
Adjust rules for setting a challenge to FINISHED

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -305,7 +305,7 @@ class TaskDAL @Inject()(override val db: Database,
         priority = priority,
         changesetId = Some(changesetId)), user)
 
-      if (status == Task.STATUS_CREATED) {
+      if (status == Task.STATUS_CREATED || status == Task.STATUS_SKIPPED) {
         this.challengeDAL.get().updateReadyStatus()(parentId)
       }
       else {

--- a/conf/evolutions/default/45.sql
+++ b/conf/evolutions/default/45.sql
@@ -1,0 +1,19 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Update all challenges to STATUS_FINISHED (5) that have at least 1 task and
+-- have no tasks in CREATED (0) or SKIPPED (3) statuses
+--
+-- Update all challenges to STATUS_READY (3) that were set to STATUS_FINISHED
+-- but still have at least one task in CREATED (0) or SKIPPED (3) status
+UPDATE challenges c SET status=5 WHERE
+          0 < (SELECT COUNT(*) FROM tasks where tasks.parent_id=c.id) AND
+          0 = (SELECT COUNT(*) AS total FROM tasks
+          WHERE tasks.parent_id=c.id AND status IN (0, 3));;
+
+UPDATE challenges c SET status=3 WHERE
+          c.status = 5 AND
+          0 < (SELECT COUNT(*) AS total FROM tasks
+          WHERE tasks.parent_id=c.id AND status IN (0, 3));;
+
+# --- !Downs


### PR DESCRIPTION
* Set challenge to FINISHED status if it has tasks and no tasks are left
remaining in CREATED or SKIPPED statuses

* No longer require that challenge is in READY status to transition to
FINISHED, as many challenges created solely through the API never enter
READY status

* No longer allow challenge to be marked FINISHED if it contains SKIPPED
tasks

* No longer allow a challenge to be marked FINISHED if it contains no
tasks at all

* Add evolution that applies the new criteria to existing challenges