### PR TITLE
Add taskProperty search and make cluster fetch use parameters

### DIFF
--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -351,4 +351,10 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
       ))
     }
   }
+
+  def getPropertyKeys(challengeId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(Json.toJson(Map("keys" -> dataManager.getPropertyKeys(challengeId))))
+    }
+  }
 }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -13,7 +13,7 @@ import org.maproulette.data._
 import org.maproulette.models.dal.{TagDAL, TagDALMixin, TaskDAL, DALManager}
 import org.maproulette.models._
 import org.maproulette.exception.{InvalidException, NotFoundException, StatusMessage}
-import org.maproulette.session.{SearchLocation, SearchParameters, SessionManager, User}
+import org.maproulette.session.{SearchLocation, SearchParameters, SearchChallengeParameters, SessionManager, User}
 import org.maproulette.utils.Utils
 import org.maproulette.services.osm._
 import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
@@ -236,8 +236,9 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     this.sessionManager.userAwareRequest { implicit user =>
       val params = SearchParameters(
         projectSearch = Some(projectSearch),
-        challengeSearch = Some(challengeSearch),
-        challengeTags = Some(challengeTags.split(",").toList),
+        challengeParams = SearchChallengeParameters(
+          challengeSearch = Some(challengeSearch),
+          challengeTags = Some(challengeTags.split(",").toList)),
         taskTags = Some(tags.split(",").toList),
         taskSearch = Some(taskSearch)
       )
@@ -306,11 +307,18 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     * @return
     */
   def getTasksInBoundingBox(left: Double, bottom: Double, right: Double, top: Double, limit: Int,
-                            offset: Int, excludeLocked: Boolean): Action[AnyContent] = Action.async { implicit request =>
+                            offset: Int, excludeLocked: Boolean, sort: String= "", order: String= "ASC",
+                            includeTotal: Boolean= false): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { p =>
         val params = p.copy(location = Some(SearchLocation(left, bottom, right, top)))
-        Ok(Json.toJson(this.dal.getTasksInBoundingBox(User.userOrMocked(user), params, limit, offset, excludeLocked)))
+        val (count, result) = this.dal.getTasksInBoundingBox(User.userOrMocked(user), params, limit, offset, excludeLocked, sort, order)
+        if (includeTotal) {
+          Ok(Json.obj("total" -> count, "tasks" -> result))
+        }
+        else {
+          Ok(Json.toJson(result))
+        }
       }
     }
   }
@@ -390,7 +398,7 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     }
   }
 
-  def customTaskStatus(taskId:Long, actionType: ActionType, user:User, comment:String="",
+  def customTaskStatus(taskId:Long, actionType: ActionType, user:User, comment:String= "",
                        tags: String= "",requestReview:Option[Boolean] = None, completionResponses:Option[JsValue] = None) = {
     val status = actionType match {
       case t: TaskStatusSet => t.status
@@ -435,7 +443,7 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     * @return 400 BadRequest if task with supplied id not found.
     *         If successful then 200 NoContent
     */
-  def setTaskReviewStatus(id: Long, reviewStatus: Int, comment:String="", tags: String= "") : Action[AnyContent] = Action.async { implicit request =>
+  def setTaskReviewStatus(id: Long, reviewStatus: Int, comment:String= "", tags: String= "") : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       val task = this.dal.retrieveById(id) match {
         case Some(t) => t
@@ -471,7 +479,7 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     * @return 400 BadRequest if task with supplied id not found.
     *         If successful then 200 NoContent
     */
-  def setBundleTaskReviewStatus(id: Long, reviewStatus: Int, comment:String="", tags: String= "") : Action[AnyContent] = Action.async { implicit request =>
+  def setBundleTaskReviewStatus(id: Long, reviewStatus: Int, comment:String= "", tags: String= "") : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       val tasks = this.dal.getTaskBundle(user, id).tasks match {
         case Some(t) => t

--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -11,7 +11,7 @@ import org.maproulette.data.{ActionManager, TaskViewed, VirtualChallengeType}
 import org.maproulette.exception.NotFoundException
 import org.maproulette.models.dal.{TaskDAL, VirtualChallengeDAL}
 import org.maproulette.models.{ClusteredPoint, Task, VirtualChallenge}
-import org.maproulette.session.{SearchLocation, SearchParameters, SessionManager, User}
+import org.maproulette.session.{SearchLocation, SearchParameters, SearchChallengeParameters, SessionManager, User}
 import org.maproulette.utils.Utils
 import play.api.libs.json._
 import play.api.mvc._
@@ -40,6 +40,8 @@ class VirtualChallengeController @Inject()(override val sessionManager: SessionM
   //reads and writes for Search Parameters
   implicit val locationWrites = Json.writes[SearchLocation]
   implicit val locationReads = Json.reads[SearchLocation]
+  implicit val challengeParamsWrites = Json.writes[SearchChallengeParameters]
+  implicit val challengeParamsReads = Json.reads[SearchChallengeParameters]
   implicit val paramsWrites = Json.writes[SearchParameters]
   implicit val paramsReads = Json.reads[SearchParameters]
 

--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -1060,6 +1060,19 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
       """.as(parser.*)
     }
   }
+
+  def getPropertyKeys(challengeId: Long): List[String] = {
+    db.withConnection { implicit c =>
+      val parser = for {
+        key <- get[String]("key")
+      } yield key
+
+      SQL"""SELECT DISTINCT json_object_keys((features->>'properties')::JSON) as key
+          FROM tasks, jsonb_array_elements(geojson->'features') features
+          WHERE parent_id=#${challengeId}
+       """.as(parser.*)
+    }
+  }
 }
 
 object DataManager {

--- a/app/org/maproulette/models/TaskCluster.scala
+++ b/app/org/maproulette/models/TaskCluster.scala
@@ -10,7 +10,10 @@ import play.api.libs.json._
   *
   * @author mcuthbert
   */
-case class TaskCluster(clusterId: Int, numberOfPoints: Int, params: SearchParameters, point: Point, bounding: JsValue = Json.toJson("{}")) extends DefaultWrites
+case class TaskCluster(clusterId: Int, numberOfPoints: Int, taskId: Option[Long],
+                       taskStatus: Option[Int], taskPriority: Option[Int],
+                       params: SearchParameters, point: Point,
+                       bounding: JsValue = Json.toJson("{}")) extends DefaultWrites
 
 object TaskCluster {
   implicit val pointWrites: Writes[Point] = Json.writes[Point]

--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -326,11 +326,11 @@ class ProjectDAL @Inject()(override val db: Database,
     this.withMRConnection { implicit c =>
       val parameters = new ListBuffer[NamedParameter]()
       // the named parameter for the challenge name
-      parameters += ('cs -> this.search(params.challengeSearch.getOrElse("")))
+      parameters += ('cs -> this.search(params.challengeParams.challengeSearch.getOrElse("")))
       parameters += ('ps -> this.search(params.projectSearch.getOrElse("")))
       // search by tags if any
-      val challengeTags = if (params.challengeTags.isDefined && params.challengeTags.get.nonEmpty) {
-        val tags = params.challengeTags.get.zipWithIndex.map {
+      val challengeTags = if (params.challengeParams.challengeTags.isDefined && params.challengeParams.challengeTags.get.nonEmpty) {
+        val tags = params.challengeParams.challengeTags.get.zipWithIndex.map {
           case (v, i) =>
             parameters += (s"tag_$i" -> this.search(v))
             s"t.name LIKE {tag_$i}"

--- a/app/org/maproulette/models/dal/TaskReviewDal.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDal.scala
@@ -570,7 +570,7 @@ class TaskReviewDAL @Inject()(override val db: Database,
           val locationJSON = Json.parse(geom)
           val coordinates = (locationJSON \ "coordinates").as[List[Double]]
           val point = Point(coordinates(1), coordinates.head)
-          TaskCluster(kmeans, totalPoints, params, point, Json.parse(bounding))
+          TaskCluster(kmeans, totalPoints, None, None, None, params, point, Json.parse(bounding))
       }
 
       val fetchBy = if (reviewTasksType == 2) "task_review.reviewed_by" else "task_review.review_requested_by"

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -213,7 +213,7 @@ trait DALHelper {
     params.getChallengeIds match {
       case Some(c) if c.nonEmpty => this.appendInWhereClause(whereClause, s"$challengePrefix.id IN (${c.mkString(",")})")
       case _ =>
-        params.challengeSearch match {
+        params.challengeParams.challengeSearch match {
           case Some(cs) if cs.nonEmpty =>
             params.fuzzySearch match {
               case Some(x) =>
@@ -319,7 +319,7 @@ trait DALHelper {
                                      joinClause: StringBuilder, challengePrefix: String = "c"): ListBuffer[NamedParameter] = {
     val parameters = new ListBuffer[NamedParameter]()
 
-    params.challengeTags match {
+    params.challengeParams.challengeTags match {
       case Some(ct) if ct.nonEmpty =>
         joinClause ++=
           s"""

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -5,8 +5,12 @@ package org.maproulette.session
 import java.net.URLDecoder
 
 import org.maproulette.utils.Utils
-import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{AnyContent, Request}
+import play.api.data.format.Formats
+import play.api.libs.json._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+
 
 /**
   * This holds the search parameters that are used to define task sets for retrieving random tasks
@@ -18,22 +22,25 @@ import play.api.mvc.{AnyContent, Request}
   */
 case class SearchLocation(left: Double, bottom: Double, right: Double, top: Double)
 
+case class SearchChallengeParameters(challengeIds: Option[List[Long]] = None,
+                                     challengeTags: Option[List[String]] = None,
+                                     challengeTagConjunction: Option[Boolean] = None,
+                                     challengeSearch: Option[String] = None,
+                                     challengeEnabled: Option[Boolean] = None,
+                                     challengeDifficulty: Option[Int] = None,
+                                     challengeStatus: Option[List[Int]] = None)
+
 case class SearchParameters(projectIds: Option[List[Long]] = None,
                             projectSearch: Option[String] = None,
                             projectEnabled: Option[Boolean] = None,
-                            challengeIds: Option[List[Long]] = None,
-                            challengeTags: Option[List[String]] = None,
-                            challengeTagConjunction: Option[Boolean] = None,
-                            challengeSearch: Option[String] = None,
-                            challengeEnabled: Option[Boolean] = None,
-                            challengeDifficulty: Option[Int] = None,
-                            challengeStatus: Option[List[Int]] = None,
+                            challengeParams: SearchChallengeParameters = new SearchChallengeParameters(),
                             taskTags: Option[List[String]] = None,
                             taskTagConjunction: Option[Boolean] = None,
                             taskSearch: Option[String] = None,
                             taskStatus: Option[List[Int]] = None,
                             taskReviewStatus: Option[List[Int]] = None,
-                            props: Option[Map[String, String]] = None,
+                            taskProperties: Option[Map[String, String]] = None,
+                            taskPriorities: Option[List[Int]] = None,
                             priority: Option[Int] = None,
                             location: Option[SearchLocation] = None,
                             bounding: Option[SearchLocation] = None,
@@ -45,7 +52,7 @@ case class SearchParameters(projectIds: Option[List[Long]] = None,
     case None => None
   }
 
-  def getChallengeIds: Option[List[Long]] = challengeIds match {
+  def getChallengeIds: Option[List[Long]] = challengeParams.challengeIds match {
     case Some(v) => Some(v.filter(_ != -1))
     case None => None
   }
@@ -55,26 +62,110 @@ case class SearchParameters(projectIds: Option[List[Long]] = None,
     case _ => priority
   }
 
-  def getChallengeDifficulty: Option[Int] = challengeDifficulty match {
+  def getChallengeDifficulty: Option[Int] = challengeParams.challengeDifficulty match {
     case Some(v) if v == -1 => None
-    case _ => challengeDifficulty
+    case _ => challengeParams.challengeDifficulty
   }
 
   def hasTaskTags: Boolean = taskTags.getOrElse(List.empty).exists(tt => tt.nonEmpty)
 
-  def hasChallengeTags: Boolean = challengeTags.getOrElse(List.empty).exists(ct => ct.nonEmpty)
+  def hasChallengeTags: Boolean = challengeParams.challengeTags.getOrElse(List.empty).exists(ct => ct.nonEmpty)
 
   def enabledProject: Boolean = projectEnabled.getOrElse(true)
 
-  def enabledChallenge: Boolean = challengeEnabled.getOrElse(true)
+  def enabledChallenge: Boolean = challengeParams.challengeEnabled.getOrElse(true)
 }
 
 object SearchParameters {
-
   implicit val locationWrites = Json.writes[SearchLocation]
   implicit val locationReads = Json.reads[SearchLocation]
-  implicit val paramsWrites = Json.writes[SearchParameters]
-  implicit val paramsReads = Json.reads[SearchParameters]
+
+  implicit val challengeParamsWrites: Writes[SearchChallengeParameters] = Json.writes[SearchChallengeParameters]
+  implicit val challengeParamsReads: Reads[SearchChallengeParameters] = Json.reads[SearchChallengeParameters]
+  implicit val paramsWrites: Writes[SearchParameters] = Json.writes[SearchParameters]
+  implicit val paramsReads: Reads[SearchParameters] = Json.reads[SearchParameters]
+
+  implicit object SearchParametersFormat extends Format[SearchParameters] {
+    override def writes(o: SearchParameters): JsValue = {
+
+      var original = Json.toJson(o)(Json.writes[SearchParameters])
+      // Move challenge param fields up to top level
+      var updated = o.challengeParams.challengeIds match {
+        case Some(c) => Utils.insertIntoJson(original, "challengeIds", c, true)
+        case None => original
+      }
+      updated = o.challengeParams.challengeTags match {
+        case Some(c) => Utils.insertIntoJson(updated, "challengeTags", c, true)
+        case None => updated
+      }
+      updated = o.challengeParams.challengeTagConjunction match {
+        case Some(c) => Utils.insertIntoJson(updated, "challengeTagConjunction", c, true)
+        case None => updated
+      }
+      updated = o.challengeParams.challengeSearch match {
+        case Some(r) => Utils.insertIntoJson(updated, "challengeSearch", r, true)
+        case None => updated
+      }
+      updated = o.challengeParams.challengeEnabled match {
+        case Some(r) => Utils.insertIntoJson(updated, "challengeEnabled", r, true)
+        case None => updated
+      }
+      updated = o.challengeParams.challengeDifficulty match {
+        case Some(r) => Utils.insertIntoJson(updated, "challengeDifficulty", r, true)
+        case None => updated
+      }
+      updated = o.challengeParams.challengeStatus match {
+        case Some(r) => Utils.insertIntoJson(updated, "challengeStatus", r, true)
+        case None => updated
+      }
+
+      updated = updated.as[JsObject] - "challengeParams"
+      updated
+    }
+
+    override def reads(json: JsValue): JsResult[SearchParameters] = {
+      implicit val challengeParamsReads: Reads[SearchChallengeParameters] = Json.reads[SearchChallengeParameters]
+
+      var challengeParams = Map[String, JsValue]()
+      (json \ "challengeIds").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeIds" -> v)
+        case None => // do nothing
+      }
+
+      (json \ "challengeTags").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeTags" -> v)
+        case None => // do nothing
+      }
+
+      (json \ "challengeTagConjunction").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeTagConjunction" -> v)
+        case None => // do nothing
+      }
+
+      (json \ "challengeSearch").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeSearch" -> v)
+        case None => // do nothing
+      }
+
+      (json \ "challengeEnabled").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeEnabled" -> v)
+        case None => // do nothing
+      }
+
+      (json \ "challengeDifficulty").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeDifficulty" -> v)
+        case None => // do nothing
+      }
+
+      (json \ "challengeStatus").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("challengeStatus" -> v)
+        case None => // do nothing
+      }
+
+      val jsonWithChallengeParams = Utils.insertIntoJson(json, "challengeParams", challengeParams, false)
+      Json.fromJson[SearchParameters](jsonWithChallengeParams)(Json.reads[SearchParameters])
+    }
+  }
 
   /**
     * Retrieves the search cookie from the cookie list and creates a search parameter object
@@ -99,7 +190,7 @@ object SearchParameters {
 
     val challengeIds = request.getQueryString("cid") match {
       case Some(q) => Utils.toLongList(q)
-      case None => params.challengeIds
+      case None => params.challengeParams.challengeIds
     }
 
     block(SearchParameters(
@@ -109,26 +200,27 @@ object SearchParameters {
       this.getStringParameter(request.getQueryString("ps"), params.projectSearch),
       //projectEnabled
       this.getBooleanParameter(request.getQueryString("pe"), params.projectEnabled),
-      //challengeID
-      challengeIds,
-      //challengeTags
-      request.getQueryString("ct") match {
-        case Some(v) => Some(v.split(",").toList)
-        case None => params.challengeTags
-      },
-      //challengeTagConjunction
-      this.getBooleanParameter(request.getQueryString("ctc"), Some(params.challengeTagConjunction.getOrElse(false))),
-      //challengeSearch
-      this.getStringParameter(request.getQueryString("cs"), params.challengeSearch),
-      //challengeEnabled
-      this.getBooleanParameter(request.getQueryString("ce"), params.challengeEnabled),
-      //challengeDifficulty
-      this.getIntParameter(request.getQueryString("cd"), params.challengeDifficulty),
-      //challengeStatus
-      request.getQueryString("cStatus") match {
-        case Some(v) => Utils.toIntList(v)
-        case None => params.challengeStatus
-      },
+      new SearchChallengeParameters(
+        //challengeID
+        challengeIds,
+        //challengeTags
+        request.getQueryString("ct") match {
+          case Some(v) => Some(v.split(",").toList)
+          case None => params.challengeParams.challengeTags
+        },
+        //challengeTagConjunction
+        this.getBooleanParameter(request.getQueryString("ctc"), Some(params.challengeParams.challengeTagConjunction.getOrElse(false))),
+        //challengeSearch
+        this.getStringParameter(request.getQueryString("cs"), params.challengeParams.challengeSearch),
+        //challengeEnabled
+        this.getBooleanParameter(request.getQueryString("ce"), params.challengeParams.challengeEnabled),
+        //challengeDifficulty
+        this.getIntParameter(request.getQueryString("cd"), params.challengeParams.challengeDifficulty),
+        //challengeStatus
+        request.getQueryString("cStatus") match {
+          case Some(v) => Utils.toIntList(v)
+          case None => params.challengeParams.challengeStatus
+        }),
       //taskTags
       request.getQueryString("tt") match {
         case Some(v) => Some(v.split(",").toList)
@@ -148,7 +240,16 @@ object SearchParameters {
         case Some(v) => Utils.toIntList(v)
         case None => params.taskReviewStatus
       },
-      None,
+      //taskProperties
+      request.getQueryString("tProps") match {
+        case Some(v) => Utils.toMap(v)
+        case None => params.taskProperties
+      },
+      //taskPriorities
+      request.getQueryString("priorities") match {
+        case Some(v) => Utils.toIntList(v)
+        case None => params.taskPriorities
+      },
       //taskPriority
       this.getIntParameter(request.getQueryString("tp"), params.priority),
       //taskBoundingBox for Challenge Location

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -207,6 +207,17 @@ object Utils extends DefaultWrites {
     Some(stringList.split(",").toList.map(_.toInt))
   }
 
+  def toMap(stringMap: String): Option[Map[String, String]] = if (stringMap.isEmpty) {
+    None
+  } else {
+    val resultMap = scala.collection.mutable.Map[String, String]()
+    stringMap.split(",").foreach { r => {
+      val pair = r.split(":")
+      resultMap += pair(0) -> pair(1)
+    }}
+    Some(resultMap.toMap)
+  }
+
   def getDate(date: String): Option[DateTime] = if (StringUtils.isEmpty(date)) {
     None
   } else {

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2967,7 +2967,7 @@ GET     /tasks/random                               @org.maproulette.controllers
 #     in: query
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
-GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false)
+GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false)
 ###
 # tags: [ Task ]
 # summary: Update Task Changeset
@@ -3591,6 +3591,8 @@ GET     /data/status/activity                       @org.maproulette.controllers
 GET     /data/status/latestActivity                 @org.maproulette.controllers.api.DataController.getLatestChallengeActivity(projectIds:String ?= "", challengeIds:String ?= "", entries:Int ?= 1)
 ### NoDocs ###
 GET     /data/status/summary                        @org.maproulette.controllers.api.DataController.getStatusSummary(userIds:String ?= "", projectIds:String ?= "", challengeIds:String ?= "", start:String ?= "", end:String ?= "", limit:Int ?= 10, page:Int ?= 0)
+### NoDocs ###
+GET     /data/challenge/:challengeId/propertyKeys   @org.maproulette.controllers.api.DataController.getPropertyKeys(challengeId:Long)
 ###
 # tags: [ User ]
 # summary: Retrieves current user's JSON information

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -287,10 +287,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{SimpleChallengeID}}",
 							"protocol": "http",
@@ -447,10 +443,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
 							"protocol": "http",
@@ -500,10 +492,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
 							"protocol": "http",
@@ -556,10 +544,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks/random",
 							"protocol": "http",
@@ -608,10 +592,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/nextTask/{{TagsChallengeTask1ID}}",
 							"protocol": "http",
@@ -660,10 +640,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/previousTask/{{TagsChallengeTask2ID}}",
 							"protocol": "http",
@@ -763,10 +739,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
 							"protocol": "http",
@@ -818,10 +790,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasksNearby/{{TagsChallengeTask1ID}}?limit=2",
 							"protocol": "http",
@@ -876,10 +844,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags",
 							"protocol": "http",
@@ -980,10 +944,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tags",
 							"protocol": "http",
@@ -1193,12 +1153,8 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "http://localhost:9000/api/v2/keywords?type='tasks'",
+							"raw": "http://localhost:9000/api/v2/keywords?tagType=tasks&limit=1000",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -1211,8 +1167,12 @@
 							],
 							"query": [
 								{
-									"key": "type",
-									"value": "'tasks'"
+									"key": "tagType",
+									"value": "tasks"
+								},
+								{
+									"key": "limit",
+									"value": "1000"
 								}
 							]
 						},
@@ -1568,10 +1528,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TestChallenge}}/tasks",
 							"protocol": "http",
@@ -1669,10 +1625,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
 							"protocol": "http",
@@ -1921,10 +1873,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/comment/{{NewComment}}",
 							"protocol": "http",
@@ -1966,10 +1914,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/comments",
 							"protocol": "http",
@@ -2117,12 +2061,8 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
-							"raw": "http://localhost:9000/api/v2/keywords?type='tasks'",
+							"raw": "http://localhost:9000/api/v2/keywords?tagType=tasks&limit=1000",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -2135,8 +2075,12 @@
 							],
 							"query": [
 								{
-									"key": "type",
-									"value": "'tasks'"
+									"key": "tagType",
+									"value": "tasks"
+								},
+								{
+									"key": "limit",
+									"value": "1000"
 								}
 							]
 						},
@@ -2175,10 +2119,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}/tags/update?tags=sometag1,sometag2",
 							"protocol": "http",
@@ -2236,10 +2176,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}/tags",
 							"protocol": "http",
@@ -2453,10 +2389,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}",
 							"protocol": "http",
@@ -2503,10 +2435,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{TagsChallengeID}}/tasks",
 							"protocol": "http",
@@ -2599,10 +2527,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
 							"protocol": "http",
@@ -2644,10 +2568,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallengebyname/test",
 							"protocol": "http",
@@ -2738,10 +2658,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenges",
 							"protocol": "http",
@@ -2784,10 +2700,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/tasks",
 							"protocol": "http",
@@ -2829,10 +2741,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/task",
 							"protocol": "http",
@@ -2879,10 +2787,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/nextTask/{{VChallengeTask1ID}}",
 							"protocol": "http",
@@ -2931,10 +2835,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/previousTask/{{VChallengeTask2ID}}",
 							"protocol": "http",
@@ -2985,10 +2885,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}/tasksNearby/{{VChallengeTask2ID}}?limit=2",
 							"protocol": "http",
@@ -3038,10 +2934,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/view/{{VirtualChallengeID}}",
 							"protocol": "http",
@@ -3083,10 +2975,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/clustered/{{VirtualChallengeID}}",
 							"protocol": "http",
@@ -3129,10 +3017,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeID}}",
 							"protocol": "http",
@@ -3223,10 +3107,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeIDList}}/tasks",
 							"protocol": "http",
@@ -3269,10 +3149,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/{{VirtualChallengeIDList}}",
 							"protocol": "http",
@@ -3361,10 +3237,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/virtualchallenge/11",
 							"protocol": "http",
@@ -3452,10 +3324,6 @@
 								"value": "test"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/data/challenge/8953?priority=1",
 							"protocol": "http",
@@ -3616,10 +3484,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/challenges",
 							"protocol": "http",
@@ -3669,10 +3533,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/children",
 							"protocol": "http",
@@ -3719,10 +3579,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{ProjectWithChildren}}/tasks?cs=2&ts=2",
 							"protocol": "http",
@@ -3778,10 +3634,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/search/clustered?search=%7B%22challengeSearch%22%3A%22Challenge2%22%7D",
 							"protocol": "http",
@@ -3940,10 +3792,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID}}",
 							"protocol": "http",
@@ -3989,10 +3837,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/projects?limit=-1",
 							"protocol": "http",
@@ -4044,10 +3888,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/projects/find?q=SimpleProject",
 							"protocol": "http",
@@ -4100,10 +3940,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/projectByName/SimpleProject",
 							"protocol": "http",
@@ -4418,10 +4254,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/projects?limit=-1",
 							"protocol": "http",
@@ -4474,10 +4306,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}",
 							"protocol": "http",
@@ -4525,10 +4353,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{VPProjectID}}/children",
 							"protocol": "http",
@@ -4574,10 +4398,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/data/project/summary?projectList={{VPProjectID}}",
 							"protocol": "http",
@@ -4616,10 +4436,6 @@
 										"value": "application/json"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "http://localhost:9000/api/v2/data/project/summary?projectList={{VPProjectID}}",
 									"protocol": "http",
@@ -4699,10 +4515,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/data/user/leaderboard?projectIds={{VPProjectID}}",
 							"protocol": "http",
@@ -4755,10 +4567,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/data/project/activity?projectList={{VPProjectID}}",
 							"protocol": "http",
@@ -4811,10 +4619,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/data/user/summary?projectList={{VPProjectID}}",
 							"protocol": "http",
@@ -4869,10 +4673,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/data/raw/activity?projectIds={{VPProjectID}}",
 							"protocol": "http",
@@ -4978,10 +4778,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/project/{{SimpleProjectID1}}/challenges",
 							"protocol": "http",
@@ -5197,10 +4993,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/tag/{{TestTagID}}",
 							"protocol": "http",
@@ -5404,10 +5196,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/osmuser/SuperUser",
 							"protocol": "http",
@@ -5685,10 +5473,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge/{{SimpleChallengeID}}/tasks",
 							"protocol": "http",
@@ -5814,10 +5598,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{SFTagID}}",
 							"protocol": "http",
@@ -5865,10 +5645,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{SFTagID}}/tags",
 							"protocol": "http",
@@ -6344,10 +6120,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}",
 							"protocol": "http",
@@ -6503,10 +6275,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}/review/start",
 							"protocol": "http",
@@ -6557,10 +6325,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask2}}",
 							"protocol": "http",
@@ -6670,10 +6434,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask1}}",
 							"protocol": "http",
@@ -6722,10 +6482,6 @@
 								"value": "application/json"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/taskBundle/{{NewBundle}}",
 							"protocol": "http",


### PR DESCRIPTION
* Modify getTaskClusters to search by parameters

* Modify getTasksInBoundingBox to search by parameters

* Add new search property taskProperties which will search
  by the geojson task properties. Note: Since SearchParameters
  was reaching the Scala 22 parameter limit, challenge parameters
  were moved into their own subclass.

* Add API to get list of valid task proeprties for a challenge