### PR TITLE
Improve performance of retrieveTaskSummary query

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -495,7 +495,7 @@ class ChallengeController @Inject()(override val childController: TaskController
         Some(Utils.split(priorityFilter).map(_.toInt))
       }
 
-      val tasks = this.dalManager.task.retrieveTaskSummaries(challengeId, limit, page, status, reviewStatus, priority)
+      val (tasks, allComments) = this.dalManager.task.retrieveTaskSummaries(challengeId, limit, page, status, reviewStatus, priority)
 
       // Setup all exportable properties
       var propsToExportHeaders = ""
@@ -579,7 +579,7 @@ class ChallengeController @Inject()(override val childController: TaskController
               }
           }
 
-          var comments = task.comments.getOrElse("").replaceAll("\"", "\"\"")
+          var comments = allComments(task.taskId).replaceAll("\"", "\"\"")
 
           s"""${task.taskId},$challengeId,"${task.name}","${Task.statusMap.get(task.status).get}",""" +
           s""""${Challenge.priorityMap.get(task.priority).get}",${task.mappedOn.getOrElse("")},""" +


### PR DESCRIPTION
Improve performance of retrieveTaskSummary query by performing comments fetch as a separate query with comments returned as a separate map instead of as part of the TaskSummary object.

(Sample query on 6k tasks went from 38s to 2s by removing comments)

This should address issue: https://github.com/osmlab/maproulette3/issues/970