### PR TITLE
Support additional search parameters when fetching task clusters

### DIFF
--- a/app/org/maproulette/models/TaskCluster.scala
+++ b/app/org/maproulette/models/TaskCluster.scala
@@ -13,7 +13,8 @@ import play.api.libs.json._
 case class TaskCluster(clusterId: Int, numberOfPoints: Int, taskId: Option[Long],
                        taskStatus: Option[Int], taskPriority: Option[Int],
                        params: SearchParameters, point: Point,
-                       bounding: JsValue = Json.toJson("{}")) extends DefaultWrites
+                       bounding: JsValue = Json.toJson("{}"),
+                       challengeIds: List[Long]) extends DefaultWrites
 
 object TaskCluster {
   implicit val pointWrites: Writes[Point] = Json.writes[Point]

--- a/app/org/maproulette/models/dal/TaskReviewDal.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDal.scala
@@ -570,7 +570,7 @@ class TaskReviewDAL @Inject()(override val db: Database,
           val locationJSON = Json.parse(geom)
           val coordinates = (locationJSON \ "coordinates").as[List[Double]]
           val point = Point(coordinates(1), coordinates.head)
-          TaskCluster(kmeans, totalPoints, None, None, None, params, point, Json.parse(bounding))
+          TaskCluster(kmeans, totalPoints, None, None, None, params, point, Json.parse(bounding), List())
       }
 
       val fetchBy = if (reviewTasksType == 2) "task_review.reviewed_by" else "task_review.review_requested_by"

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -206,7 +206,7 @@ trait DALHelper {
               }
             case _ => // we can ignore this
           }
-          this.appendInWhereClause(whereClause, this.enabled(params.projectEnabled.getOrElse(false), "p")(None))
+          this.appendInWhereClause(whereClause, this.enabled(params.projectEnabled.getOrElse(false), projectPrefix)(None))
       }
     }
 
@@ -225,6 +225,7 @@ trait DALHelper {
             }
           case _ => // ignore
         }
+        this.appendInWhereClause(whereClause, this.enabled(params.challengeParams.challengeEnabled.getOrElse(false), challengePrefix)(None))
     }
 
     parameters


### PR DESCRIPTION
* Support searching by challenge difficulty, challenge status,
  project/challenge enabled and deleted.

* Return in task clusters challengeIds for the tasks represented
  by the points in the cluster.