### PR TITLE
Adjust handling of task tags in API

### DIFF
--- a/app/org/maproulette/controllers/api/TagsMixin.scala
+++ b/app/org/maproulette/controllers/api/TagsMixin.scala
@@ -112,12 +112,17 @@ trait TagsMixin[T <: BaseObject[Long]] {
     * @param user          the user executing the request
     */
   def extractTags(body: JsValue, createdObject: T, user: User, completeList: Boolean = false): Unit = {
-    val tags: List[Tag] = body \ "tags" match {
+    val tags: Option[List[Tag]] = body \ "tags" match {
       case tags: JsDefined =>
         // this case is for a comma separated list, either of ints or strings
         if (!tags.isEmpty) {
           try {
-            tags.as[String].split(",").toList.map(tag => {
+            val tagList = tags.validate[List[String]] match {
+              case s: JsSuccess[List[String]] => tags.as[List[String]]
+              case e: JsError => tags.as[String].split(",").toList
+            }
+
+            Some(tagList.map(tag => {
               try {
                 Tag(tag.toLong, "")
               } catch {
@@ -130,34 +135,39 @@ trait TagsMixin[T <: BaseObject[Long]] {
                       Tag(-1, tag, tagType = this.dal.tableName)
                   }
               }
-            })
+            }))
           } catch {
             case e: Throwable =>
-              List.empty
+              None
           }
         }
         else {
-          List.empty
+          Some(List.empty)
         }
       case tags: JsUndefined =>
         (body \ "fulltags").asOpt[List[JsValue]] match {
           case Some(tagList) =>
-            tagList.map(value => {
+            Some(tagList.map(value => {
               val identifier = (value \ "id").asOpt[Long].getOrElse(-1L)
               val name = (value \ "name").asOpt[String].getOrElse("")
               val description = (value \ "description").asOpt[String]
               Tag(identifier, name, description)
-            })
-          case None => List.empty
+            }))
+          case None => None
         }
-      case _ => List.empty
+      case _ => None
     }
-    val tagIds = this.tagDAL.updateTagList(tags, user).map(_.id)
 
-    if (tagIds.nonEmpty || completeList) {
-      // now we have the ids for the supplied tags, then lets map them to the item created
-      this.dalWithTags.updateItemTags(createdObject.id, tagIds, user, completeList)
-      this.actionManager.setAction(Some(user), this.itemType.convertToItem(createdObject.id), TagAdded(), tagIds.mkString(","))
+    tags match {
+      case Some(tagList) =>
+        val tagIds = this.tagDAL.updateTagList(tagList, user).map(_.id)
+
+        if (tagIds.nonEmpty || completeList) {
+          // now we have the ids for the supplied tags, then lets map them to the item created
+          this.dalWithTags.updateItemTags(createdObject.id, tagIds, user, completeList)
+          this.actionManager.setAction(Some(user), this.itemType.convertToItem(createdObject.id), TagAdded(), tagIds.mkString(","))
+        }
+      case _ => return
     }
   }
 

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -259,6 +259,8 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
     * @return A Json representation of the object
     */
   override def inject(obj: Task)(implicit request: Request[Any]): JsValue = {
+    var taskToReturn = obj
+
     val serverInfo = config.getMapillaryServerInfo
     if (serverInfo.clientId.nonEmpty) {
       if (request.getQueryString("mapillary").getOrElse("false").toBoolean) {
@@ -289,10 +291,12 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
             s"https://d1cuyjsrcm0gby.cloudfront.net/$key/thumb-1024.jpg",
             s"https://d1cuyjsrcm0gby.cloudfront.net/$key/thumb-2048.jpg")
         })
-        return super.inject(obj.copy(mapillaryImages = Some(images)))
+        taskToReturn = obj.copy(mapillaryImages = Some(images))
       }
     }
-    super.inject(obj)
+
+    val tags = tagDAL.listByTask(taskToReturn.id)
+    return Utils.insertIntoJson(Json.toJson(taskToReturn), Tag.KEY, Json.toJson(tags.map(_.name)))
   }
 
   /**

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -1674,7 +1674,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE\",\n    \"tags\":\"newUpdateTaskTag\"\n}"
+							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE\",\n    \"tags\": \"newupdatetasktag\"\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
@@ -1688,6 +1688,254 @@
 								"v2",
 								"task",
 								"{{NewTask}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateTask Tags - Array",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"tags\"] = jsonData.tags.length === 2;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"tags\": [\"newupdatetasktag\", \"taskTag2\"]\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateTask - No Tags (remain unchanged)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction UPDATE2\";",
+									"tests[\"tags\"] = jsonData.tags.length === 2;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE2\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "Read Task Tags",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e7c6af8f-c978-41d6-adb2-6853cfcbb476",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"tagname\"] = jsonData[0].name === \"newupdatetasktag\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/tags",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}",
+								"tags"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "UpdateTask - Delete all Tags",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction UPDATE2\";",
+									"tests[\"tags\"] = jsonData.tags.length === 2;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE2\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "Read Task Tags Empty",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e7c6af8f-c978-41d6-adb2-6853cfcbb476",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"tagname\"] = jsonData[0].name === \"newupdatetasktag\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}/tags",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}",
+								"tags"
 							]
 						},
 						"description": "Creates a project with two children within the same request."


### PR DESCRIPTION
* Task tags are now included in JSON response when fetching tasks

* When updating a task, if no tags are specified then the existing tags will be
left as-is instead of being deleted

* When updating a task, if tags are explicitly specified then those tags will
overwrite existing tags

* When updating a task, if empty tags are explicitly specified (as opposed to
omitted entirely from the JSON body) then any existing tags will be removed

* When updating a task, tags can now be provided as either an array of strings
or as a single string of comma-separated tags

* Add additional postman tests