### PR TITLE
Add API for refreshing task locks

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -61,6 +61,8 @@ class Config @Inject()(implicit val configuration: Configuration) {
     Duration(this.config.getOptional[String](Config.KEY_CHANGESET_TIME_LIMIT).getOrElse(Config.DEFAULT_CHANGESET_HOUR_LIMIT))
   lazy val changeSetEnabled: Boolean =
     this.config.getOptional[Boolean](Config.KEY_CHANGESET_ENABLED).getOrElse(Config.DEFAULT_CHANGESET_ENABLED)
+  lazy val taskLockExpiry: String =
+    this.config.getOptional[String](Config.KEY_TASK_LOCK_EXPIRY).getOrElse(Config.DEFAULT_TASK_LOCK_EXPIRY)
   lazy val taskScoreFixed: Int =
     this.config.getOptional[Int](Config.KEY_TASK_SCORE_FIXED).getOrElse(Config.DEFAULT_TASK_SCORE_FIXED)
   lazy val taskScoreFalsePositive: Int =
@@ -180,6 +182,7 @@ object Config {
   val KEY_EMAIL_FROM = s"$GROUP_MAPROULETTE.emailFrom"
   val KEY_TASK_RESET = s"$GROUP_MAPROULETTE.task.reset"
   val KEY_SIGNIN = s"$GROUP_MAPROULETTE.signin"
+  val KEY_TASK_LOCK_EXPIRY = s"$GROUP_MAPROULETTE.task.lock.expiry"
   val KEY_TASK_SCORE_FIXED = s"$GROUP_MAPROULETTE.task.score.fixed"
   val KEY_TASK_SCORE_FALSE_POSITIVE = s"$GROUP_MAPROULETTE.task.score.falsePositive"
   val KEY_TASK_SCORE_ALREADY_FIXED = s"$GROUP_MAPROULETTE.task.score.alreadyFixed"
@@ -236,6 +239,7 @@ object Config {
   val KEY_OSM_QL_TIMEOUT = s"$GROUP_OSM.ql.timeout"
 
   val DEFAULT_SESSION_TIMEOUT = 3600000L
+  val DEFAULT_TASK_LOCK_EXPIRY = "1 hour"
   val DEFAULT_TASK_RESET = 7
   val DEFAULT_TASK_SCORE_FIXED = 5
   val DEFAULT_TASK_SCORE_FALSE_POSITIVE = 3

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -217,6 +217,24 @@ class TaskController @Inject()(override val sessionManager: SessionManager,
   }
 
   /**
+    * Refresh the active lock on the task, extending its allowed duration
+    *
+    * @param taskId    Id of the task on which the lock is to be refreshed
+    * @return
+    */
+  def refreshTaskLock(taskId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.dal.retrieveById(taskId) match {
+        case Some(t) =>
+          this.dal.refreshItemLock(user, t)
+          Ok(Json.toJson(t))
+        case None =>
+          throw new NotFoundException(s"Task with $taskId not found, unable to refresh lock.")
+      }
+    }
+  }
+
+  /**
     * Gets a random task(s) given the provided tags.
     *
     * @param projectSearch   Filter on the name of the project

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -73,7 +73,8 @@ class SchedulerActor @Inject()(config: Config,
   def cleanLocks(action: String): Unit = {
     logger.info(action)
     this.db.withTransaction { implicit c =>
-      val locksDeleted = SQL"""DELETE FROM locked WHERE AGE(NOW(), locked_time) > '1 hour'""".executeUpdate()
+      val query = s"DELETE FROM locked WHERE AGE(NOW(), locked_time) > '${config.taskLockExpiry}'"
+      val locksDeleted = SQL(query).executeUpdate()
       logger.info(s"$locksDeleted were found and deleted.")
     }
   }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2729,14 +2729,14 @@ GET     /task/:id/release                               @org.maproulette.control
 # produces: [ application/json ]
 # description: Refreshes an existing lock, extending its allowed duration, on the
 #              task with the supplied ID. The requesting user must already own an
-#              active lock on the task (i.e. via the task/:id/start API) or a 401
+#              active lock on the task (i.e. via the task/:id/start API) or a 403
 #              will be raised
 # responses:
 #   '200':
 #     description: The lock was successfully refreshed
 #     schema:
 #       $ref: '#/definitions/org.maproulette.models.Task'
-#   '401':
+#   '403':
 #     description: The user does not own a lock on the task
 #   '404':
 #     description: ID field supplied but no Task found matching the id

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2725,6 +2725,29 @@ GET     /task/:id/start                               @org.maproulette.controlle
 GET     /task/:id/release                               @org.maproulette.controllers.api.TaskController.releaseTask(id:Long)
 ###
 # tags: [ Task ]
+# summary: Refresh an existing lock on a Task
+# produces: [ application/json ]
+# description: Refreshes an existing lock, extending its allowed duration, on the
+#              task with the supplied ID. The requesting user must already own an
+#              active lock on the task (i.e. via the task/:id/start API) or a 401
+#              will be raised
+# responses:
+#   '200':
+#     description: The lock was successfully refreshed
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+#   '401':
+#     description: The user does not own a lock on the task
+#   '404':
+#     description: ID field supplied but no Task found matching the id
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Task on which the lock is to be refreshed
+###
+GET     /task/:id/refreshLock                           @org.maproulette.controllers.api.TaskController.refreshTaskLock(id:Long)
+###
+# tags: [ Task ]
 # summary: Retrieves an already existing Task
 # produces: [ application/json ]
 # description: Retrieves an already existing Task based on the name of the Task rather than an ID

--- a/conf/evolutions/default/46.sql
+++ b/conf/evolutions/default/46.sql
@@ -1,0 +1,13 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+
+-- To allow us to know how long a lock has been in existence once we allow lock
+-- times to be extended, add a created column to the "locked" table and update
+-- existing locks to match the creation timestamp with their current
+-- locked_time
+ALTER TABLE "locked" ADD COLUMN created timestamp without time zone DEFAULT NOW();;
+UPDATE locked set created=locked_time;
+
+# --- !Downs
+ALTER TABLE "locked" DROP COLUMN created;;

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7fe91afa-9b71-444c-93d8-52e899aa5b99",
+		"_postman_id": "e6c69530-3f40-47e3-bae4-416fa2ca9011",
 		"name": "maproulette2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1644,6 +1644,108 @@
 					"response": []
 				},
 				{
+					"name": "Start Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction UPDATE\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE\",\n    \"tags\": \"newupdatetasktag\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "Refresh Task Lock",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction UPDATE\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE\",\n    \"tags\": \"newupdatetasktag\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
 					"name": "UpdateTask",
 					"event": [
 						{
@@ -2220,6 +2322,57 @@
 								"{{NewTask}}",
 								"comment",
 								"{{NewComment}}"
+							]
+						},
+						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "Release Task",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"NewTask\";",
+									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction UPDATE\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"instruction\":\"NewTask instruction UPDATE\",\n    \"tags\": \"newupdatetasktag\"\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/task/{{NewTask}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"task",
+								"{{NewTask}}"
 							]
 						},
 						"description": "Creates a project with two children within the same request."


### PR DESCRIPTION
* Add `task/:id/refreshLock` API endpoint for refreshing an active
task lock, thereby extending its allowed duration

* Add `refreshItemLock` method to Locking trait that updates the lock's
`locked_time` to the current time

* Add evolution that adds `created` column to `locked` table for
tracking the creation time of the lock, allowing the total lock duration
to be tracked even if a lock is refreshed multiple times

* Add basic Postman tests for starting a task, refreshing the task lock,
and releasing the task lock