### PR TITLE
Decode task property filter keys/values

### DIFF
--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -246,7 +246,7 @@ object SearchParameters {
         case Some(v) => Utils.toIntList(v)
         case None => params.taskReviewStatus
       },
-      //taskProperties
+      //taskProperties (base 64 encoded key:value comma separated)
       request.getQueryString("tProps") match {
         case Some(v) => Utils.toMap(v)
         case None => params.taskProperties
@@ -261,7 +261,7 @@ object SearchParameters {
       },
       //taskPriority
       this.getIntParameter(request.getQueryString("tp"), params.priority),
-      //taskBoundingBox for Challenge Location
+      //taskBoundingBox for tasks found in bounding Box
       request.getQueryString("tbb") match {
         case Some(v) if v.nonEmpty =>
           v.split(",") match {
@@ -270,7 +270,7 @@ object SearchParameters {
           }
         case _ => params.location
       },
-      //taskBoundingBox for Challenge location
+      //boundingBox for Challenges bounds contained in bounding box
       request.getQueryString("bb") match {
         case Some(v) if v.nonEmpty =>
           v.split(",") match {

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -213,7 +213,8 @@ object Utils extends DefaultWrites {
     val resultMap = scala.collection.mutable.Map[String, String]()
     stringMap.split(",").foreach { r => {
       val pair = r.split(":")
-      resultMap += pair(0) -> pair(1)
+      resultMap += new String(java.util.Base64.getDecoder.decode(pair(0))) ->
+                    new String(java.util.Base64.getDecoder.decode(pair(1)))
     }}
     Some(resultMap.toMap)
   }


### PR DESCRIPTION
As the separator for property filter keys/values is a ':' and
property key names can contain ':'s -- now require these values
to be Base64 encoded.