### PR TITLE
Notify challenge managers when challenge completed

### DIFF
--- a/app/org/maproulette/models/UserNotification.scala
+++ b/app/org/maproulette/models/UserNotification.scala
@@ -44,12 +44,15 @@ object UserNotification {
   val NOTIFICATION_TYPE_REVIEW_REJECTED_NAME = "Revision Requested"
   val NOTIFICATION_TYPE_REVIEW_AGAIN = 4
   val NOTIFICATION_TYPE_REVIEW_AGAIN_NAME = "Review Requested"
+  val NOTIFICATION_TYPE_CHALLENGE_COMPLETED = 5
+  val NOTIFICATION_TYPE_CHALLENGE_COMPLETED_NAME = "Challenge Completed"
   val notificationTypeMap = Map(
     NOTIFICATION_TYPE_SYSTEM -> NOTIFICATION_TYPE_SYSTEM_NAME,
     NOTIFICATION_TYPE_MENTION -> NOTIFICATION_TYPE_MENTION_NAME,
     NOTIFICATION_TYPE_REVIEW_APPROVED -> NOTIFICATION_TYPE_REVIEW_APPROVED_NAME,
     NOTIFICATION_TYPE_REVIEW_REJECTED -> NOTIFICATION_TYPE_REVIEW_REJECTED_NAME,
     NOTIFICATION_TYPE_REVIEW_AGAIN -> NOTIFICATION_TYPE_REVIEW_AGAIN_NAME,
+    NOTIFICATION_TYPE_CHALLENGE_COMPLETED -> NOTIFICATION_TYPE_CHALLENGE_COMPLETED_NAME,
   )
 
   val NOTIFICATION_IGNORE = 0          // ignore notification
@@ -65,7 +68,8 @@ case class NotificationSubscriptions(val id: Long,
                                      val mention: Int,
                                      val reviewApproved: Int,
                                      val reviewRejected: Int,
-                                     val reviewAgain: Int)
+                                     val reviewAgain: Int,
+                                     val challengeCompleted: Int)
 object NotificationSubscriptions {
   implicit val notificationSubscriptionReads: Reads[NotificationSubscriptions] = Json.reads[NotificationSubscriptions]
   implicit val notificationSubscriptionWrites: Writes[NotificationSubscriptions] = Json.writes[NotificationSubscriptions]

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -35,6 +35,7 @@ import scala.concurrent.Future
 class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                              override val tagDAL: TagDAL,
                              projectDAL: Provider[ProjectDAL],
+                             notificationDAL: Provider[NotificationDAL],
                              override val permission: Permission,
                              config: Config)
   extends ParentDAL[Long, Challenge, Task] with TagDALMixin[Challenge] with OwnerMixin[Challenge] {
@@ -990,6 +991,8 @@ class ChallengeDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
 
               SQL(updateStatusQuery).as(this.parser.*).headOption
             }
+
+            this.notificationDAL.get().createChallengeCompletionNotification(challenge)
             Option(challenge)
           }
         case None =>

--- a/app/org/maproulette/models/dal/SurveyDAL.scala
+++ b/app/org/maproulette/models/dal/SurveyDAL.scala
@@ -22,9 +22,10 @@ import play.api.libs.json.JsValue
 class SurveyDAL @Inject()(override val db: Database, taskDAL: TaskDAL,
                           override val tagDAL: TagDAL,
                           projectDAL: Provider[ProjectDAL],
+                          notificationDAL: Provider[NotificationDAL],
                           override val permission: Permission,
                           config:Config)
-  extends ChallengeDAL(db, taskDAL, tagDAL, projectDAL, permission, config) {
+  extends ChallengeDAL(db, taskDAL, tagDAL, projectDAL, notificationDAL, permission, config) {
 
   private val answerParser: RowParser[Answer] = {
     get[Long]("answers.id") ~

--- a/app/org/maproulette/session/User.scala
+++ b/app/org/maproulette/session/User.scala
@@ -70,12 +70,14 @@ case class UserSearchResult(osmId: Long,
   * a few basic fields about the user, and their group types for the project.
   *
   * @param projectId   The project id
+  * @param userId      The user's MapRoulette id
   * @param osmId       The user's osm id
   * @param displayName The display name for the osm user
   * @param avatarURL   The avatar URL to enabling displaying of their avatar
   * @param groupTypes  List of the user's group types for the project
   */
 case class ProjectManager(projectId: Long,
+                          userId: Long,
                           osmId: Long,
                           displayName: String,
                           avatarURL: String,

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -121,12 +121,13 @@ class UserDAL @Inject()(override val db: Database,
   // The anorm row parser to convert user records to project manager
   val projectManagerParser: RowParser[ProjectManager] = {
     get[Long]("project_id") ~
+      get[Long]("users.id") ~
       get[Long]("users.osm_id") ~
       get[String]("users.name") ~
       get[Option[String]]("users.avatar_url") ~
       get[List[Int]]("group_types") map {
-      case projectId ~ osmId ~ displayName ~ avatarURL ~ groupTypes =>
-        ProjectManager(projectId, osmId, displayName, avatarURL.getOrElse(""), groupTypes)
+      case projectId ~ userId ~ osmId ~ displayName ~ avatarURL ~ groupTypes =>
+        ProjectManager(projectId, userId, osmId, displayName, avatarURL.getOrElse(""), groupTypes)
     }
   }
 

--- a/conf/evolutions/default/47.sql
+++ b/conf/evolutions/default/47.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+-- Add subscription option for challenge completion notifications
+ALTER TABLE IF EXISTS user_notification_subscriptions ADD COLUMN challenge_completed integer NOT NULL DEFAULT 1;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS user_notification_subscriptions DROP COLUMN challenge_completed;;


### PR DESCRIPTION
* Add new challenge_completed notification type and generate the
notification for all subscribed managers of a challenge when the
challenge is completed

* Enhance ProjectManager to include a userId in addition to the osmId