### PR TITLE
Add support for nested task property searches

### DIFF
--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -11,7 +11,7 @@ import org.maproulette.data.{ActionManager, TaskViewed, VirtualChallengeType}
 import org.maproulette.exception.NotFoundException
 import org.maproulette.models.dal.{TaskDAL, VirtualChallengeDAL}
 import org.maproulette.models.{ClusteredPoint, Task, VirtualChallenge}
-import org.maproulette.session.{SearchLocation, SearchParameters, SearchChallengeParameters, SessionManager, User}
+import org.maproulette.session.{SearchLocation, SearchParameters, SearchChallengeParameters, SessionManager, User, TaskPropertySearch}
 import org.maproulette.utils.Utils
 import play.api.libs.json._
 import play.api.mvc._
@@ -40,6 +40,8 @@ class VirtualChallengeController @Inject()(override val sessionManager: SessionM
   //reads and writes for Search Parameters
   implicit val locationWrites = Json.writes[SearchLocation]
   implicit val locationReads = Json.reads[SearchLocation]
+  implicit val taskPropertySearchWrites = Json.writes[TaskPropertySearch]
+  implicit val taskPropertySearchReads = Json.reads[TaskPropertySearch]
   implicit val challengeParamsWrites = Json.writes[SearchChallengeParameters]
   implicit val challengeParamsReads = Json.reads[SearchChallengeParameters]
   implicit val paramsWrites = Json.writes[SearchParameters]

--- a/app/org/maproulette/session/TaskPropertySearch.scala
+++ b/app/org/maproulette/session/TaskPropertySearch.scala
@@ -1,0 +1,150 @@
+// Copyright (C) 2019 MapRoulette contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.maproulette.session
+
+import java.net.URLDecoder
+
+import org.maproulette.utils.Utils
+import play.api.mvc.{AnyContent, Request}
+import play.api.data.format.Formats
+import play.api.libs.json._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+import org.maproulette.exception.InvalidException
+
+
+/**
+  * This holds the task property search parameters that are used for doing
+  * complex nested task property searches on tasks.
+  *
+  * @author krotstan
+  */
+
+case class TaskPropertySearch(key: Option[String] = None,
+                              value: Option[String] = None,
+                              valueType: Option[String] = None,
+                              searchType: Option[String] = None,  // contains/not_equals/equals
+                              operationType: Option[String] = None,  // and/or
+                              left: Option[TaskPropertySearch] = None,
+                              right: Option[TaskPropertySearch] = None) {
+  def toSQL:String = {
+    this.validate
+
+    val where = new StringBuilder
+    left match {
+      case Some(l) => where ++= "(" + l.toSQL + ") " + operationType.get
+      case None => // do nothing
+    }
+
+    right match {
+      case Some(r) => where ++= " (" + r.toSQL + ")"
+      case None => // do nothing
+    }
+
+    valueType.getOrElse("") match {
+      case SearchParameters.TASK_PROP_VALUE_TYPE_NUMBER =>
+        where ++= s" CAST(features->'properties'->>'${key.get}' AS DOUBLE PRECISION)" +
+                   getSearchTypeSQL + value.getOrElse(0)
+      case SearchParameters.TASK_PROP_VALUE_TYPE_STRING => {
+        where ++= s" features->'properties'->>'${key.get.replaceAll("\'", "\'\'")}' " + getSearchTypeSQL
+        searchType.get match {
+          case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS =>
+            where ++= "'%" + value.getOrElse("").replaceAll("\'", "\'\'") + "%' "
+          case _ =>
+            where ++= " '" + value.getOrElse("").replaceAll("\'", "\'\'") + "'"
+        }
+      }
+      case _ => // do nothing
+    }
+
+    where.toString
+  }
+
+  def getSearchTypeSQL:String = {
+    searchType.getOrElse("") match {
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS => "="
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL => "!="
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS => " LIKE "
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_LESS_THAN => "<"
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_GREATER_THAN => ">"
+      case e => throw new InvalidException("Search Type: '" + e + "' not supported.")
+    }
+  }
+
+
+
+ /**
+  * Validates the TaskPropertySearch
+  *
+  * To be valid:
+  * left/right/operationtype must all be present
+  * OR key/value/searchType must be present
+  * operation type must be "or" or "and"
+  * search type must be "contains"/"equals"/"not_equal"/"less_than"/"greater_than"
+  * key must not contain weird characters (')
+  * value must not contain weird characters (')
+  * value type must be "string"/"number"
+  * value must be a number if value type is "number"
+  * TASK_PROP_SEARCH_TYPE_CONTAINS only ok for value type "string"
+  * TASK_PROP_SEARCH_TYPE_LESS_THAN or TASK_PROP_SEARCH_TYPE_GREATER_THAN ok for value type "number"
+  */
+  def validate:Unit = {
+    var valid:Boolean =
+      left match {
+        case Some(l) => {
+          l.validate
+          right match {
+            case Some(r) => {
+              r.validate
+              operationType match {
+                case Some(SearchParameters.TASK_PROP_OPERATION_TYPE_AND) => true
+                case Some(SearchParameters.TASK_PROP_OPERATION_TYPE_OR) => true
+                case _ => throw new InvalidException("TaskPropertySearch: A valid OperationType of 'or' or 'and' must be provided.")
+              }
+            }
+            case None => throw new InvalidException("TaskPropertySearch: Both a right and left side must be provided.")
+          }
+        }
+        case None => true
+      }
+
+    if (right != None && left == None) {
+      throw new InvalidException("TaskPropertySearch: Both a right and left side must be provided.")
+    }
+
+    valid = valid &&
+      (key match {
+        case Some(k) => {
+          (valueType.getOrElse("") match {
+            case SearchParameters.TASK_PROP_VALUE_TYPE_NUMBER => {
+              if (!scala.util.Try(value.getOrElse("").toDouble).isSuccess)
+                throw new InvalidException("TaskPropertySearch: Value " + value.getOrElse("") + " is not a number.")
+
+              searchType.getOrElse("") match {
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_LESS_THAN => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_GREATER_THAN => true
+                case e => throw new InvalidException("Search Type: '" + e + "' not supported when comparing numerics.")
+              }
+            }
+            case SearchParameters.TASK_PROP_VALUE_TYPE_STRING => {
+              searchType.getOrElse("") match {
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS => true
+                case e => throw new InvalidException("Search Type: '" + e + "' not supported when comparing strings.")
+              }
+            }
+            case _ => throw new InvalidException("TaskPropertySearch: A valid ValueType of 'string' or 'number' must be provided.")
+          })
+        }
+        case None => {
+          if (left == None) throw new InvalidException("TaskPropertySearch: A key must be specified when not providing a right and left.")
+          else true
+        }
+      })
+
+    if (!valid) throw new InvalidException("Invalid task property search.")
+  }
+}

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -2984,7 +2984,8 @@ GET     /tasks/random                               @org.maproulette.controllers
 # description: Retrieves tasks within a given bounding box.
 # responses:
 #   '200':
-#     description: The list of clusteredPoints representing Tasks that match the search criteria within the bounding box
+#     description: The list of clusteredPoints representing Tasks that match the search criteria within the bounding box.
+#                  To specify a json body of a taskPropertySearch, use the PUT method.
 #     schema:
 #       type: array
 #       items:
@@ -3014,6 +3015,7 @@ GET     /tasks/random                               @org.maproulette.controllers
 #     description: Optional flag to have geometries data returned for each task.
 ###
 GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false)
+PUT     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false)
 ###
 # tags: [ Task ]
 # summary: Update Task Changeset
@@ -3183,7 +3185,8 @@ PUT     /taskBundle/:id/review/:status                     @org.maproulette.cont
 # description: Retrieves task clusters that contain the centroid location for a group of tasks
 # responses:
 #   '200':
-#     description: An array of task clusters that represents clusters of tasks for a challenge. If none found will return an empty list
+#     description: An array of task clusters that represents clusters of tasks for a challenge. If none found will return an empty list.
+#                  To specify a json body of a taskPropertySearch, use the PUT method.
 #     schema:
 #       type: array
 #       items:
@@ -3195,6 +3198,7 @@ PUT     /taskBundle/:id/review/:status                     @org.maproulette.cont
 #     description: The number of clusters that you want returned
 ###
 GET     /taskCluster                                @org.maproulette.controllers.api.TaskController.getTaskClusters(points:Int ?= 100)
+PUT     /taskCluster                                @org.maproulette.controllers.api.TaskController.getTaskClusters(points:Int ?= 100)
 ###
 # tags: [ TaskReview ]
 # summary: Retrieves task review clusters

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -1408,7 +1408,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "efbb42af-bda5-4229-bf7d-49e8e5d44038",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestChallenge\", jsonData.id);",
@@ -1416,7 +1416,8 @@
 									"tests[\"name\"] = jsonData.name === \"TestChallenge\";",
 									"tests[\"description\"] = jsonData.description === \"TestChallenge description\";",
 									"tests[\"instruction\"] = jsonData.instruction === \"TestChallenge instruction\";"
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1434,7 +1435,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"TestChallenge\",\n    \"parent\": {{TestProject}},\n    \"description\":\"TestChallenge description\",\n    \"instruction\":\"TestChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        },\n        {\n            \"name\":\"Task 2\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n        }\n    ]\n}"
+							"raw": "{\n    \"name\":\"TestChallenge\",\n    \"parent\": {{TestProject}},\n    \"description\":\"TestChallenge description\",\n    \"instruction\":\"TestChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test1\"}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        },\n        {\n            \"name\":\"Task 2\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103,1.5]},\"properties\":{\"id\": \"test2\", \"version\": 1}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[103.1,1.6]},\"properties\":{}}]}\n        }\n    ]\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge",
@@ -1450,6 +1451,72 @@
 							]
 						},
 						"description": "Creates a project with two children within the same request."
+					},
+					"response": []
+				},
+				{
+					"name": "Tasks in Bounding Box",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"pm.test(\"Body matches string\", function () {",
+									"    pm.expect(pm.response.text()).to.include(\"Task 1\");",
+									"    pm.expect(pm.response.text()).to.include(\"Task 2\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"taskPropertySearch\": {\n\t\t\"operationType\": \"or\",\n\t\t\"left\": {\n\t\t\t\"key\": \"id\",\n\t\t\t\"value\": \"test1\",\n\t\t\t\"valueType\": \"string\",\n\t\t\t\"searchType\": \"equals\"\n\t\t},\n\t\t\"right\": {\n\t\t\t\"operationType\": \"and\",\n\t\t\t\"left\": {\n\t\t\t\t\"key\": \"id\",\n\t\t\t\t\"value\": \"test2\",\n\t\t\t\t\"valueType\": \"string\",\n\t\t\t\t\"searchType\": \"contains\"\n\t\t\t},\n\t\t\t\"right\": {\n\t\t\t\t\"key\": \"version\",\n\t\t\t\t\"value\": \"0\",\n\t\t\t\t\"valueType\": \"number\",\n\t\t\t\t\"searchType\": \"greater_than\"\n\t\t\t}\n\t\t}\n\t}\n}\n"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/tasks/box/-180/-90/180/90?cid={{TestChallenge}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"tasks",
+								"box",
+								"-180",
+								"-90",
+								"180",
+								"90"
+							],
+							"query": [
+								{
+									"key": "cid",
+									"value": "{{TestChallenge}}"
+								}
+							]
+						},
+						"description": "Gets the challenge for the provided ID"
 					},
 					"response": []
 				},


### PR DESCRIPTION
* Add search parameter for json taskPropertySearch to do complex
  task property searches

* Add PUT methods for taskCluster and tasksInBoundingBox to support
  providing a JSON body.

* Example taskPropertySearch format:
`
{
	"taskPropertySearch": {
		"operationType": "or",
		"left": {
			"key": "id",
			"value": "test1''",
			"valueType": "string",
			"searchType": "equals"
		},
		"right": {
			"operationType": "and",
			"left": {
				"key": "id",
				"value": "test",
				"valueType": "string",
				"searchType": "contains"
			},
			"right": {
				"key": "version",
				"value": "0",
				"valueType": "number",
				"searchType": "greater_than"
			}
		}
	}
}
`

    will produce SQL like:
    `("id" = "test1") OR ("id" LIKE "%test%" AND "version" > 0)`