### PR TITLE
Include extra details in notification emails

### DIFF
--- a/app/org/maproulette/models/UserNotification.scala
+++ b/app/org/maproulette/models/UserNotification.scala
@@ -78,6 +78,7 @@ object NotificationSubscriptions {
 case class UserNotificationEmail(val id: Long,
                                  val userId: Long,
                                  val notificationType: Int,
+                                 val extra: Option[String],
                                  val created: DateTime,
                                  val emailStatus: Int)
 

--- a/app/org/maproulette/provider/EmailProvider.scala
+++ b/app/org/maproulette/provider/EmailProvider.scala
@@ -23,10 +23,16 @@ class EmailProvider @Inject() (mailerClient: MailerClient, config: Config) {
   def emailNotification(toAddress: String, notification: UserNotificationEmail) = {
     val notificationName = UserNotification.notificationTypeMap.get(notification.notificationType).get
     val emailSubject = s"New MapRoulette notification: ${notificationName}"
+    val notificationDetails = notification.extra match {
+      case Some(details) => s"\n${details}"
+      case None => ""
+    }
+
     val emailBody = s"""
       |You have received a new MapRoulette notification:
       |
       |${notificationName}
+      |${notificationDetails}
       |${this.notificationFooter}""".stripMargin
 
     val email = Email(emailSubject, config.getEmailFrom.get, Seq(toAddress), bodyText = Some(emailBody))


### PR DESCRIPTION
* Include data from "extra" notification field in emails sent to
notification recipients

* Add name of challenge and parent project to "extra" portion of
challenge-completion notifications so that they'll be included in
notification emails