### PR TITLE
Add support for 'lastTaskId' on nextTaskReview

### DIFF
--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -85,10 +85,11 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     *
     * @return Task
     */
-  def nextTaskReview(onlySaved: Boolean=false, sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
+  def nextTaskReview(onlySaved: Boolean=false, sort:String, order:String, lastTaskId:Long = -1) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
-        val result = this.taskReviewDAL.nextTaskReview(user, params, onlySaved, sort, order)
+        val result = this.taskReviewDAL.nextTaskReview(user, params, onlySaved, sort, order,
+                                                       (if (lastTaskId == -1) None else Some(lastTaskId)))
         val nextTask = result match {
           case Some(task) =>
             Ok(Json.toJson(this.taskReviewDAL.startTaskReview(user, task)))

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -707,6 +707,9 @@ GET     /tasks/reviewed                          @org.maproulette.controllers.ap
 #   - name: order
 #     in: query
 #     description: Sort order direction. Either ASC or DESC. Default is "ASC" (ascending)
+#   - name: lastTaskId
+#     in: query
+#     description: Fetch the next task after the lastTaskId. (so if you want to 'skip' a task you can get the next one)
 #   - name: cs
 #     in: query
 #     description: The search string used to match the Challenge names. Default value is empty string, ie. will match all challenges.
@@ -717,7 +720,7 @@ GET     /tasks/reviewed                          @org.maproulette.controllers.ap
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/review/next                       @org.maproulette.controllers.api.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/review/next                       @org.maproulette.controllers.api.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastTaskId:Long ?= -1)
 ###
 # summary: Retrieves tasks that need review
 # produces: [ application/json ]


### PR DESCRIPTION
 When requesting nextTaskReview add support for providing the
  last task seen so that the task following that one will be
  served up next. (Thus allowing for 'skipping')