### PR TITLE
Add flag to exclude tasks done by other reviewers from review requested tasks

### DIFF
--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -85,11 +85,12 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     *
     * @return Task
     */
-  def nextTaskReview(onlySaved: Boolean=false, sort:String, order:String, lastTaskId:Long = -1) : Action[AnyContent] = Action.async { implicit request =>
+  def nextTaskReview(onlySaved: Boolean=false, sort:String, order:String, lastTaskId:Long = -1,
+                     excludeOtherReviewers: Boolean = false) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         val result = this.taskReviewDAL.nextTaskReview(user, params, onlySaved, sort, order,
-                                                       (if (lastTaskId == -1) None else Some(lastTaskId)))
+                                                       (if (lastTaskId == -1) None else Some(lastTaskId)), excludeOtherReviewers)
         val nextTask = result match {
           case Some(task) =>
             Ok(Json.toJson(this.taskReviewDAL.startTaskReview(user, task)))
@@ -111,17 +112,19 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param page The page number for the results
     * @param sort The column to sort
     * @param order The order direction to sort
+    * @param excludeOtherReviewers exclude tasks that have been reviewed by someone else
     * @return
     */
   def getReviewRequestedTasks(startDate: String=null, endDate: String=null, onlySaved: Boolean=false,
-                              limit:Int, page:Int, sort:String, order:String) : Action[AnyContent] = Action.async { implicit request =>
+                              limit:Int, page:Int, sort:String, order:String,
+                              excludeOtherReviewers: Boolean = false) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         //cs => "my challenge name"
         //o => "mapper's name"
         //r => "reviewer's name"
         val (count, result) = this.taskReviewDAL.getReviewRequestedTasks(User.userOrMocked(user), params,
-           startDate, endDate, onlySaved, limit, page, sort, order)
+           startDate, endDate, onlySaved, limit, page, sort, order, true, excludeOtherReviewers)
         Ok(Json.obj("total" -> count, "tasks" -> _insertExtraJSON(result)))
       }
     }
@@ -204,16 +207,18 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param reviewTasksType - 1: To Be Reviewed 2: User's reviewed Tasks 3: All reviewed by users
     * @param startDate Optional start date to filter by reviewedAt date
     * @param endDate Optional end date to filter by reviewedAt date
+    * @param onlySaved Only include saved challenges
+    * @param excludeOtherReviewers exclude tasks that have been reviewed by someone else
     * @return
     */
   def getReviewMetrics(reviewTasksType: Int, mappers: String="", reviewers: String="", priorities: String="",
                        startDate: String=null, endDate: String=null,
-                       onlySaved: Boolean=false) : Action[AnyContent] = Action.async { implicit request =>
+                       onlySaved: Boolean=false, excludeOtherReviewers: Boolean=false) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         val result = this.taskReviewDAL.getReviewMetrics(User.userOrMocked(user),
                        reviewTasksType, params, Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
-                       Utils.toIntList(priorities), startDate, endDate, onlySaved)
+                       Utils.toIntList(priorities), startDate, endDate, onlySaved, excludeOtherReviewers)
         Ok(Json.toJson(result))
       }
     }
@@ -226,13 +231,17 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @param numberOfPoints Number of clustered points you wish to have returned
     * @param startDate Optional start date to filter by reviewedAt date
     * @param endDate Optional end date to filter by reviewedAt date
+    * @param Only include challenges that have been saved
+    * @param excludeOtherReviewers exclude tasks that have been reviewed by someone else
+    *
     * @return A list of ClusteredPoint's that represent clusters of tasks
     */
   def getReviewTaskClusters(reviewTasksType: Int, numberOfPoints: Int, startDate: String=null, endDate: String=null,
-                            onlySaved: Boolean=false): Action[AnyContent] = Action.async { implicit request =>
+                            onlySaved: Boolean=false, excludeOtherReviewers: Boolean=false): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
-        Ok(Json.toJson(this.taskReviewDAL.getReviewTaskClusters(User.userOrMocked(user), reviewTasksType, params, numberOfPoints, startDate, endDate, onlySaved)))
+        Ok(Json.toJson(this.taskReviewDAL.getReviewTaskClusters(User.userOrMocked(user), reviewTasksType, params,
+                       numberOfPoints, startDate, endDate, onlySaved, excludeOtherReviewers)))
       }
     }
   }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -618,6 +618,9 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #         type: object
 #         $ref: '#/definitions/org.maproulette.models.Task'
 # parameters:
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
 #   - name: startDate
 #     in: query
 #     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
@@ -633,6 +636,9 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #   - name: order
 #     in: query
 #     description: Sort order direction. Either ASC or DESC. Default is "ASC" (ascending)
+#   - name: excludeOtherReviewers
+#     in: query
+#     description: exclude tasks that have been reviewed by someone else
 #   - name: cs
 #     in: query
 #     description: The search string used to match the Challenge names. Default value is empty string, ie. will match all challenges.
@@ -640,7 +646,7 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #     in: query
 #     description: The search string used to match the name of the person requesting the review. (review_requested_by)
 ###
-GET     /tasks/review                          @org.maproulette.controllers.api.TaskReviewController.getReviewRequestedTasks(startDate: String ?= null, endDate: String ?= null, onlySaved: Boolean ?= false, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/review                          @org.maproulette.controllers.api.TaskReviewController.getReviewRequestedTasks(startDate: String ?= null, endDate: String ?= null, onlySaved: Boolean ?= false, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", excludeOtherReviewers: Boolean ?= false)
 ###
 # summary: Retrieves reviewed tasks that have been reviewed either by this user or where the user requested
 #          the review.
@@ -701,12 +707,18 @@ GET     /tasks/reviewed                          @org.maproulette.controllers.ap
 #       type: object
 #       $ref: '#/definitions/org.maproulette.models.Task'
 # parameters:
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
 #   - name: sort
 #     in: query
 #     description: Sorts the results retuned in the response. Parameter is optional, if not provided then results will not be sorted.
 #   - name: order
 #     in: query
 #     description: Sort order direction. Either ASC or DESC. Default is "ASC" (ascending)
+#   - name: excludeOtherReviewers
+#     in: query
+#     description: exclude tasks that have been reviewed by someone else
 #   - name: lastTaskId
 #     in: query
 #     description: Fetch the next task after the lastTaskId. (so if you want to 'skip' a task you can get the next one)
@@ -720,7 +732,7 @@ GET     /tasks/reviewed                          @org.maproulette.controllers.ap
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
 ###
-GET     /tasks/review/next                       @org.maproulette.controllers.api.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastTaskId:Long ?= -1)
+GET     /tasks/review/next                       @org.maproulette.controllers.api.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastTaskId:Long ?= -1, excludeOtherReviewers:Boolean ?= false)
 ###
 # summary: Retrieves tasks that need review
 # produces: [ application/json ]
@@ -752,8 +764,14 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #   - name: endDate
 #     in: query
 #     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
+#   - name: excludeOtherReviewers
+#     in: query
+#     description: exclude tasks that have been reviewed by someone else
 ###
-GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
+GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers: Boolean ?= false)
 ###
 # tags: [ Project ]
 # summary: Retrieves clustered challenge points
@@ -3228,8 +3246,14 @@ PUT     /taskCluster                                @org.maproulette.controllers
 #   - name: endDate
 #     in: query
 #     description: The end date to search within
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
+#   - name: excludeOtherReviewers
+#     in: query
+#     description: exclude tasks that have been reviewed by someone else
 ###
-GET     /taskCluster/review                                @org.maproulette.controllers.api.TaskReviewController.getReviewTaskClusters(reviewTasksType:Int, points:Int ?= 100, startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
+GET     /taskCluster/review                                @org.maproulette.controllers.api.TaskReviewController.getReviewTaskClusters(reviewTasksType:Int, points:Int ?= 100, startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers:Boolean ?= false)
 ###
 # tags: [ Challenge ]
 # summary: Retrieves tasks in a cluster


### PR DESCRIPTION
* Add excludeOtherReviewers flag when fetching reviewRequestedTasks (default is false). This
  include: metrics, clusters, getReviewRequested, and nextTaskReview

* Fix duplicating of review tasks in results when not a super user
  but project contains multiple administrators.