### PR TITLE
Add support for including progress by priority.

### DIFF
--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import org.maproulette.Config
 import org.maproulette.data._
 import org.maproulette.models.Challenge
+import org.maproulette.models.Challenge
 import org.maproulette.models.dal.ChallengeDAL
 import org.maproulette.session.SessionManager
 import org.maproulette.session.SearchParameters
@@ -16,6 +17,7 @@ import play.api.mvc._
 import play.api.libs.json.JodaWrites._
 
 import scala.util.Try
+import scala.collection.mutable
 
 /**
   * @author cuthbertm
@@ -174,7 +176,7 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
     }
   }
 
-  def getChallengeSummary(id: Long, survey: Int, priority: String): Action[AnyContent] = Action.async { implicit request =>
+  def getChallengeSummary(id: Long, survey: Int, priority: String, includeByPriority: Boolean=false): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       if (survey == 1) {
         val priorityInt = this.getPriority( if (priority == "") -1 else priority.toInt)
@@ -183,19 +185,67 @@ class DataController @Inject()(sessionManager: SessionManager, challengeDAL: Cha
         ))
       } else {
         SearchParameters.withSearch { implicit params =>
-          Ok(Json.toJson(
-            this.dataManager.getChallengeSummary(challengeId = Some(id), priority = Utils.toIntList(priority), params = Some(params))
-          ))
+          val response = this.dataManager.getChallengeSummary(challengeId = Some(id), priority = Utils.toIntList(priority), params = Some(params))
+
+          if (includeByPriority) {
+            var prioritiesToFetch = List(Challenge.PRIORITY_HIGH, Challenge.PRIORITY_MEDIUM, Challenge.PRIORITY_LOW)
+
+            val priorityMap = mutable.Map[String, JsValue]()
+            prioritiesToFetch.foreach(p => {
+              val pResult = this.dataManager.getChallengeSummary(challengeId = Some(id),
+                                                                 priority = Some(List(p)),
+                                                                 params = Some(params))
+              if (pResult.length > 0) {
+                priorityMap.put(p.toString, Json.toJson(pResult.head.actions))
+              }
+              else {
+                priorityMap.put(p.toString, Json.toJson(ActionSummary(0,0,0,0,0,0,0,0,0)))
+              }
+            })
+
+            val updated = Utils.insertIntoJson(Json.toJson(response).as[JsArray].head.as[JsValue],
+                                               "priorityActions", Json.toJson(priorityMap), false)
+            Ok(Json.toJson(List(updated)))
+          }
+          else {
+            Ok(Json.toJson(response))
+          }
         }
       }
     }
   }
 
-  def getProjectSummary(projects: String, onlyEnabled: Boolean = true): Action[AnyContent] = Action.async { implicit request =>
+  def getProjectSummary(projects: String, onlyEnabled: Boolean = true, includeByPriority: Boolean = false): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      Ok(Json.toJson(
-        this.dataManager.getChallengeSummary(Utils.toLongList(projects), onlyEnabled = onlyEnabled)
-      ))
+      val response = this.dataManager.getChallengeSummary(Utils.toLongList(projects), onlyEnabled = onlyEnabled)
+
+      if (includeByPriority) {
+        var prioritiesToFetch = List(Challenge.PRIORITY_HIGH, Challenge.PRIORITY_MEDIUM, Challenge.PRIORITY_LOW)
+
+        //val updated = Json.toJson(response).as[JsArray]
+        val allUpdated =
+          response.map(challenge => {
+            val priorityMap = mutable.Map[String, JsValue]()
+            prioritiesToFetch.foreach(p => {
+              val pResult = this.dataManager.getChallengeSummary(challengeId = Some(challenge.id),
+                                                                 priority = Some(List(p)),
+                                                                 onlyEnabled = onlyEnabled)
+              if (pResult.length > 0) {
+                priorityMap.put(p.toString, Json.toJson(pResult.head.actions))
+              }
+              else {
+                priorityMap.put(p.toString, Json.toJson(ActionSummary(0,0,0,0,0,0,0,0,0)))
+              }
+            })
+
+            Utils.insertIntoJson(Json.toJson(challenge), "priorityActions", priorityMap, false)
+          })
+
+        Ok(Json.toJson(allUpdated))
+      }
+      else {
+        Ok(Json.toJson(response))
+      }
     }
   }
 

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -3635,7 +3635,7 @@ GET     /keywords                                   @org.maproulette.controllers
 ###
 GET     /tags                                       @org.maproulette.controllers.api.TagController.getTags(prefix: String ?= "", tagType: String ?= "", limit: Int ?= 10, page: Int ?= 0)
 ### NoDocs ###
-GET     /data/challenge/:challengeId                @org.maproulette.controllers.api.DataController.getChallengeSummary(challengeId:Long, survey:Int ?= -1, priority:String ?= "")
+GET     /data/challenge/:challengeId                @org.maproulette.controllers.api.DataController.getChallengeSummary(challengeId:Long, survey:Int ?= -1, priority:String ?= "", includeByPriority:Boolean ?= false)
 ### NoDocs ###
 GET     /data/challenge/:challengeId/users          @org.maproulette.controllers.api.DataController.getUserChallengeSummary(challengeId:Long, start:String ?= "", end:String ?= "", survey:Int ?= 0, priority:Int ?= -1)
 ###
@@ -3657,7 +3657,7 @@ GET     /data/user/:userId/metrics                  @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/project/activity                      @org.maproulette.controllers.api.DataController.getProjectActivity(projectList:String ?= "", start:String ?= "", end:String ?= "")
 ### NoDocs ###
-GET     /data/project/summary                       @org.maproulette.controllers.api.DataController.getProjectSummary(projectList:String ?= "", onlyEnabled:Boolean ?= true)
+GET     /data/project/summary                       @org.maproulette.controllers.api.DataController.getProjectSummary(projectList:String ?= "", onlyEnabled:Boolean ?= true, includeByPriority:Boolean ?= false)
 ### NoDocs ###
 GET     /data/challenge/:challengeId/activity       @org.maproulette.controllers.api.DataController.getChallengeActivity(challengeId:Long, start:String ?= "", end:String ?= "", survey:Int ?= 0, priority:Int ?= -1)
 ### NoDocs ###


### PR DESCRIPTION
* Add new flag to getProjectSummary called getChallengeSummary
  'includeByPriority' which will return a field 'priorityActions'
  that maps priority to the summarized actions just for that priority.

Example return:
  [{"name":"Winthrop Challenge",
      "id":4070,
       "actions": 
          {"total":110,
            "available":82,
            "fixed":8, etc.},
       "priorityActions": 
        {"2":
            {"total":0,
             "available":0,
              "fixed":0, etc.},
         "1":
            {"total":108,
             "available":81,
             "fixed":8, etc.},
         "0":
            {"total":2,
             "available":1, etc.}
        }
}]