### PR TITLE
Fetch as reviewer metrics when fetching user metrics

### DIFF
--- a/app/org/maproulette/controllers/api/UserController.scala
+++ b/app/org/maproulette/controllers/api/UserController.scala
@@ -383,9 +383,9 @@ class UserController @Inject()(userDAL: UserDAL,
     }
   }
 
-  def getMetricsForUser(userId: Long, monthDuration:Int = -1, reviewDuration:Int = -1): Action[AnyContent] = Action.async { implicit request =>
+  def getMetricsForUser(userId: Long, monthDuration:Int = -1, reviewDuration:Int = -1, reviewerDuration:Int = -1): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      Ok(Json.toJson(this.userDAL.getMetricsForUser(userId, User.userOrMocked(user), monthDuration, reviewDuration)))
+      Ok(Json.toJson(this.userDAL.getMetricsForUser(userId, User.userOrMocked(user), monthDuration, reviewDuration, reviewerDuration)))
     }
   }
 }

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -891,6 +891,13 @@ class TaskDAL @Inject()(override val db: Database,
             this.notificationDAL.get().createReviewNotification(user, task.review.reviewRequestedBy.getOrElse(-1), reviewStatus, task, comment)
           }
         }
+        else {
+          // For disputed tasks.
+          SQL"""INSERT INTO task_review_history
+                            (task_id, requested_by, reviewed_by, review_status, reviewed_at, review_started_at)
+                VALUES (${task.id}, ${user.id}, ${task.review.reviewedBy},
+                        ${reviewStatus}, ${now}, ${task.review.reviewStartedAt})""".executeUpdate()
+        }
       }
 
       this.cacheManager.withOptionCaching { () =>

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -3653,7 +3653,7 @@ GET     /data/user/:userId/leaderboard              @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/user/:userId/topChallenges            @org.maproulette.controllers.api.DataController.getUserTopChallenges(userId:Long, projectIds:String ?= "", challengeIds:String ?= "", countryCodes:String ?= "", monthDuration:String ?= "", start:String ?= "", end:String ?= "", onlyEnabled:Boolean ?= true, limit:Int ?= 20, offset:Int ?= 0)
 ### NoDocs ###
-GET     /data/user/:userId/metrics                  @org.maproulette.controllers.api.UserController.getMetricsForUser(userId:Long, monthDuration:Int ?= -1, reviewDuration:Int ?= -1)
+GET     /data/user/:userId/metrics                  @org.maproulette.controllers.api.UserController.getMetricsForUser(userId:Long, monthDuration:Int ?= -1, reviewDuration:Int ?= -1, reviewerDuration:Int ?= -1)
 ### NoDocs ###
 GET     /data/project/activity                      @org.maproulette.controllers.api.DataController.getProjectActivity(projectList:String ?= "", start:String ?= "", end:String ?= "")
 ### NoDocs ###


### PR DESCRIPTION
* for fetchUserMetrics also return a break down of reviewed
  tasks where the user is the reviewer in new field "asReviewerTask"

* add new reviewerDuration to indicate what timeframe to fetch
  for the reviewer stats

* fixed when a task was disputed a record was not being entered in the
  task_review_history.