### PR TITLE
Include task geometry in task clusters of 1 task

### DIFF
--- a/app/org/maproulette/models/TaskCluster.scala
+++ b/app/org/maproulette/models/TaskCluster.scala
@@ -14,7 +14,7 @@ case class TaskCluster(clusterId: Int, numberOfPoints: Int, taskId: Option[Long]
                        taskStatus: Option[Int], taskPriority: Option[Int],
                        params: SearchParameters, point: Point,
                        bounding: JsValue = Json.toJson("{}"),
-                       challengeIds: List[Long]) extends DefaultWrites
+                       challengeIds: List[Long], geometries: Option[JsValue]=None) extends DefaultWrites
 
 object TaskCluster {
   implicit val pointWrites: Writes[Point] = Json.writes[Point]


### PR DESCRIPTION
* Include task geometry in task clusters that represent a single task

* Support task geometries in results of getReviewTaskClusters

* Refactor TaskDal.getTaskClusters and
TaskReviewDal.getReviewTaskClusters to share query and parser