### PR TITLE
Minor code updates and fixes.

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -943,7 +943,7 @@ class ChallengeController @Inject()(override val childController: TaskController
               throw new InvalidException("Challenge cannot be rebuilt while undergoing bulk task deletion")
             case Some(Challenge.STATUS_BUILDING) =>
               throw new InvalidException("Task build is already in progress for this challenge")
-            case None => // just ignore
+            case _ => // just ignore
           }
 
           challengeProvider.rebuildTasks(user, c, removeUnmatched)
@@ -963,7 +963,7 @@ class ChallengeController @Inject()(override val childController: TaskController
               throw new InvalidException("Tasks cannot be added while challenge is undergoing bulk task deletion")
             case Some(Challenge.STATUS_BUILDING) =>
               throw new InvalidException("Tasks cannot be added while challenge is being built")
-            case None => // just ignore
+            case _ => // just ignore
           }
 
           request.body.asText match {
@@ -997,7 +997,7 @@ class ChallengeController @Inject()(override val childController: TaskController
                 throw new InvalidException("Tasks cannot be added while challenge is undergoing bulk task deletion")
               case Some(Challenge.STATUS_BUILDING) =>
                 throw new InvalidException("Tasks cannot be added while challenge is being built")
-              case None => // just ignore
+              case _ => // just ignore
             }
 
             request.body.file("json") match {

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -197,28 +197,19 @@ class ChallengeProvider @Inject()(challengeDAL: ChallengeDAL, taskDAL: TaskDAL,
     if (featureList.isDefined) {
       taskNameFromJsValue(featureList.get.head) // Base name on first feature
     } else {
-      val name = (value \ "id").asOpt[String] match {
+      val nameKeys = List.apply("id", "@id", "osmid", "osm_id", "name")
+      nameKeys.collectFirst { case x if (value \ x).asOpt[String].isDefined => (value \ x).asOpt[String].get } match {
         case Some(n) => n
-        case None => (value \ "@id").asOpt[String] match {
-          case Some(na) => na
-          case None => (value \ "osmid").asOpt[String] match {
-            case Some(nb) => nb
-            case None => (value \ "name").asOpt[String] match {
-              case Some(nc) => nc
-              case None => (value \ "properties").asOpt[JsObject] match {
-                // See if we can find an id field on the feature properties
-                case Some(properties) => taskNameFromJsValue(properties)
-                case None =>
-                  // if we still don't find anything, create a UUID for it. The
-                  // caveat to this is that if you upload the same file again, it
-                  // will create duplicate tasks
-                  UUID.randomUUID().toString
-              }
-            }
-          }
+        case None => (value \ "properties").asOpt[JsObject] match {
+          // See if we can find an id field on the feature properties
+          case Some(properties) => taskNameFromJsValue(properties)
+          case None =>
+            // if we still don't find anything, create a UUID for it. The
+            // caveat to this is that if you upload the same file again, it
+            // will create duplicate tasks
+            UUID.randomUUID().toString
         }
       }
-      name
     }
   }
 

--- a/conf/evolutions/default/49.sql
+++ b/conf/evolutions/default/49.sql
@@ -1,0 +1,54 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change makes sure not to reset the task status if a task is disabled or declared a false positive
+CREATE OR REPLACE FUNCTION update_task(task_name text,
+                                         task_parent_id bigint,
+                                         task_instruction text,
+                                         task_status integer,
+                                         geo_json jsonb,
+                                         suggestedfix jsonb DEFAULT NULL,
+                                         task_id bigint DEFAULT -1,
+                                         task_priority integer DEFAULT 0,
+                                         task_changeset_id bigint DEFAULT -1,
+                                         reset_interval text DEFAULT '7 days',
+                                         task_mapped_on timestamp DEFAULT NULL,
+                                         task_review_status integer DEFAULT NULL,
+                                         task_review_requested_by integer DEFAULT NULL,
+                                         task_reviewed_by integer DEFAULT NULL,
+                                         task_reviewed_at timestamp DEFAULT NULL
+                                       ) RETURNS integer as $$
+  DECLARE
+    update_id integer;;
+    update_modified timestamp without time zone;;
+    update_status integer;;
+    new_status integer;;
+    geojson_geom geometry;;
+  BEGIN
+    IF (SELECT task_id) = -1 THEN
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+    ELSE
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+    END IF;;
+    new_status := task_status;;
+    -- only reset the status if the task is not currently disabled or set as a false positive and all other criteria is met.
+    IF update_status = task_status AND NOT (update_status = 9 OR update_status = 2) AND (SELECT AGE(NOW(), update_modified)) > reset_interval::INTERVAL THEN
+      new_status := 0;;
+    END IF;;
+    SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+    UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status, priority = task_priority,
+                     changeset_id = task_changeset_id, mapped_on = task_mapped_on, geojson = geo_json,
+                     suggestedfix_geojson = suggestedfix,
+                     location = ST_Centroid(geojson_geom),
+                     geom = geojson_geom
+                     WHERE id = update_id;;
+    UPDATE task_review SET review_status = task_review_status, review_requested_by = task_review_requested_by,
+                           reviewed_by = task_reviewed_by, reviewed_at = task_reviewed_at WHERE task_review.task_id = update_id;;
+    RETURN update_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;
+
+# --- !Downs


### PR DESCRIPTION
This fixes a recently introduced bug (not released) that would cause a match failure in the ChallengeController. 

It also refactors the name resolution code for tasks in geojson and adds a new name field "osm_id". With the refactor it allows an easier way to add new name fields, although there shouldn't be a huge requirement to add this a lot.

Updates the reset mechanism for Tasks so that tasks in the state DISABLED and FALSE_POSITIVE (or "not an issue" as it is displayed in the UI) will not be reset to CREATED if the reset interval criteria is met.