### PR TITLE
Allow OSM id task property to be specified

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -92,7 +92,8 @@ case class ChallengeExtra(defaultZoom: Int = Challenge.DEFAULT_ZOOM,
                           defaultBasemapId: Option[String] = None,
                           customBasemap: Option[String] = None,
                           updateTasks: Boolean = false,
-                          exportableProperties: Option[String] = None) extends DefaultWrites
+                          exportableProperties: Option[String] = None,
+                          osmIdProperty: Option[String] = None) extends DefaultWrites
 
 case class ChallengeListing(id: Long,
                             parent: Long,

--- a/conf/evolutions/default/50.sql
+++ b/conf/evolutions/default/50.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+-- Add configurable feature properties to treat as osm id
+ALTER TABLE IF EXISTS challenges ADD COLUMN osm_id_property VARCHAR;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS challenges DROP COLUMN osm_id_property;;


### PR DESCRIPTION
* Add a new `osmIdProperty` field to challenges that allow challenge
managers to specify which property to inspect when determining the id of
the task

* Use the specified property (if given) when determining the task name