### PR TITLE
Add isOSMUserId param to project manager APIs

### DIFF
--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -4230,15 +4230,21 @@ GET     /user/project/:projectId                     @org.maproulette.controller
 # parameters:
 #   - name: userId
 #     in: path
-#     description: The id of the user to add
+#     description: The id of the user to add. If using an OSM user id, then
+#                  the isOSMUserId query parameter must be set to true
 #   - name: projectId
 #     in: path
 #     description: The id of the project to add the user too
 #   - name: groupType
 #     in: path
 #     description: Either 1 - Admin, 2 - Write, 3 - Read
+#   - name: isOSMUserId
+#     in: query
+#     type: boolean
+#     default: false
+#     description: Specify if the user id is to be treated as an OSM user id
 ###
-POST     /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.addUserToProject(userId:Long, projectId:Long, groupType:Int)
+POST     /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.addUserToProject(userId:Long, projectId:Long, groupType:Int, isOSMUserId:Boolean ?= false)
 ###
 # tags: [ User ]
 # summary: Set project group for user, removing any prior groups
@@ -4258,8 +4264,13 @@ POST     /user/:userId/project/:projectId/:groupType  @org.maproulette.controlle
 #   - name: groupType
 #     in: path
 #     description: Either 1 - Admin, 2 - Write, 3 - Read
+#   - name: isOSMUserId
+#     in: query
+#     type: boolean
+#     default: false
+#     description: Specify if the user id is to be treated as an OSM user id
 ###
-PUT     /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.setUserProjectGroup(userId:Long, projectId:Long, groupType:Int)
+PUT     /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.setUserProjectGroup(userId:Long, projectId:Long, groupType:Int, isOSMUserId:Boolean ?= false)
 ###
 # tags: [ User ]
 # summary: Adds a list of user to project group
@@ -4278,14 +4289,20 @@ PUT     /user/:userId/project/:projectId/:groupType  @org.maproulette.controller
 #     description: Either 1 - Admin, 2 - Write, 3 - Read
 #   - name: body
 #     in: body
-#     description: A JSON array of user ids. This can be either the MapRoulette or OSM Id.
+#     description: A JSON array of user ids. If using OSM user Ids then the
+#                  isOSMUserId query parameter must be set to true
 #     required: true
 #     schema:
 #       type: array
 #       items:
 #         type: integer
+#   - name: isOSMUserId
+#     in: query
+#     type: boolean
+#     default: false
+#     description: Specify if the user ids are to be treated as OSM user ids
 ###
-PUT     /user/project/:projectId/:groupType         @org.maproulette.controllers.api.UserController.addUsersToProject(projectId:Long, groupType:Int)
+PUT     /user/project/:projectId/:groupType         @org.maproulette.controllers.api.UserController.addUsersToProject(projectId:Long, groupType:Int, isOSMUserId:Boolean ?= false)
 ###
 # tags: [ User ]
 # summary: Removes a user from a project group
@@ -4298,15 +4315,21 @@ PUT     /user/project/:projectId/:groupType         @org.maproulette.controllers
 # parameters:
 #   - name: userId
 #     in: path
-#     description: The id of the user to add
+#     description: The id of the user to remove. If using an OSM user id, then
+#                  the isOSMUserId query parameter must be set to true
 #   - name: projectId
 #     in: path
-#     description: The id of the project to add the user too
+#     description: The id of the project to remove the user from
 #   - name: groupType
 #     in: path
 #     description: Either -1 all, 1 - Admin, 2 - Write, 3 - Read
+#   - name: isOSMUserId
+#     in: query
+#     type: boolean
+#     default: false
+#     description: Specify if the user ids are to be treated as OSM user ids
 ###
-DELETE  /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.removeUserFromProject(userId:Long, projectId:Long, groupType:Int)
+DELETE  /user/:userId/project/:projectId/:groupType  @org.maproulette.controllers.api.UserController.removeUserFromProject(userId:Long, projectId:Long, groupType:Int, isOSMUserId:Boolean ?= false)
 ###
 # tags: [ User ]
 # summary: Removes a list of users from a project group
@@ -4319,20 +4342,27 @@ DELETE  /user/:userId/project/:projectId/:groupType  @org.maproulette.controller
 # parameters:
 #   - name: projectId
 #     in: path
-#     description: The id of the project to add the user too
+#     description: The id of the project to remove the users from
 #   - name: groupType
 #     in: path
 #     description: Either 1 - Admin, 2 - Write, 3 - Read
 #   - name: body
 #     in: body
 #     description: A JSON array of user ids. This can be either the MapRoulette or OSM Id.
+#                  If using OSM user ids, then the isOSMUserId query parameter must be
+#                  set to true
 #     required: true
 #     schema:
 #       type: array
 #       items:
 #         type: integer
+#   - name: isOSMUserId
+#     in: query
+#     type: boolean
+#     default: false
+#     description: Specify if the user ids are to be treated as OSM user ids
 ###
-DELETE  /user/project/:projectId/:groupType         @org.maproulette.controllers.api.UserController.removeUsersFromProject(projectId:Long, groupType:Int)
+DELETE  /user/project/:projectId/:groupType         @org.maproulette.controllers.api.UserController.removeUsersFromProject(projectId:Long, groupType:Int, isOSMUserId:Boolean ?= false)
 ###
 # tags: [ Changes ]
 # summary: Test Changes


### PR DESCRIPTION
> Note: this represents a breaking change to the API that will require
clients who currently pass OSM user ids to the project manager APIs to
update their code to include a new `isOSMUserId=true` query parameter.
Clients that are exclusively passing MapRoulette user ids are unaffected.

* Add new `isOSMUserId` boolean parameter to project manager API
endpoints that must now be explicitly provided for the given user id(s) to
be treated as an OSM user id(s)

* If `isOSMUserId` is not expicitly set to true in request, treat given
user id(s) as internal MapRoulette ids only

* This new requirement eliminates the potential of erroneously acting on
the wrong target user in the case where a given id matches both internal
and OSM user ids