### PR TITLE
Additional support for searching by task id, review requested by and reviewer 

### DIFF
--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -417,30 +417,27 @@ class DataManager @Inject()(config: Config, db: Database, boundingBoxFinder: Bou
 
           search.owner match {
            case Some(o) if o.nonEmpty =>
-             val filter = new StringBuilder(s""" AND (t.id IN (SELECT task_id
-                                                              FROM task_review tr
-                                                              INNER JOIN users u ON u.id = tr.review_requested_by
-                                                         WHERE tr.task_id = t.id AND
-                                                         LOWER(u.name) LIKE LOWER('%${o}%') )) """)
-             searchFilters.append(filter)
+             searchFilters.append(s""" AND (t.id IN (SELECT task_id
+                                                     FROM task_review tr
+                                                     INNER JOIN users u ON u.id = tr.review_requested_by
+                                                     WHERE tr.task_id = t.id AND
+                                                     LOWER(u.name) LIKE LOWER('%${o}%') )) """)
            case _ => // ignore
           }
 
           search.reviewer match {
            case Some(r) if r.nonEmpty =>
-             val filter = new StringBuilder(s""" AND (t.id IN (SELECT task_id
-                                                              FROM task_review tr
-                                                              INNER JOIN users u ON u.id = tr.reviewed_by
-                                                         WHERE tr.task_id = t.id AND
-                                                         LOWER(u.name) LIKE LOWER('%${r}%') )) """)
-             searchFilters.append(filter)
+             searchFilters.append(s""" AND (t.id IN (SELECT task_id
+                                                     FROM task_review tr
+                                                     INNER JOIN users u ON u.id = tr.reviewed_by
+                                                     WHERE tr.task_id = t.id AND
+                                                    LOWER(u.name) LIKE LOWER('%${r}%') )) """)
            case _ => // ignore
           }
 
           search.taskId match {
            case Some(tid) =>
-             val filter = new StringBuilder(s" AND CAST(t.id AS TEXT) LIKE '${tid}%' ")
-             searchFilters.append(filter)
+             searchFilters.append(s" AND CAST(t.id AS TEXT) LIKE '${tid}%' ")
            case _ => // ignore
           }
         case _ =>

--- a/app/org/maproulette/models/dal/TaskReviewDal.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDal.scala
@@ -473,7 +473,7 @@ class TaskReviewDAL @Inject()(override val db: Database,
           ${whereClause}
         """
     }
-
+   
    var count = 0
    val tasks = this.taskDAL.cacheManager.withIDListCaching { implicit cachedItems =>
       this.withMRTransaction { implicit c =>
@@ -674,6 +674,11 @@ class TaskReviewDAL @Inject()(override val db: Database,
       }
       this.appendInWhereClause(whereClause, "(t.bundle_id is NULL OR t.is_bundle_primary = true)")
 
+      params.taskId match {
+        case Some(tid) => this.appendInWhereClause(whereClause, s"CAST(t.id AS TEXT) LIKE '${tid}%'")
+        case _ => // do nothing
+      }
+
       val parameters = new ListBuffer[NamedParameter]()
       parameters ++= addSearchToQuery(params, whereClause)
 
@@ -749,6 +754,11 @@ class TaskReviewDAL @Inject()(override val db: Database,
         this.appendInWhereClause(whereClause, s"""LOWER(p.display_name) LIKE LOWER('%${projectName}%')""")
       }
       case None => // do nothing
+    }
+
+    searchParameters.taskId match {
+      case Some(tid) => this.appendInWhereClause(whereClause, s"CAST(${tasksTableName}.id AS TEXT) LIKE '${tid}%'")
+      case _ => // do nothing
     }
 
     if (startDate != null && startDate.matches("[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]")) {

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -39,6 +39,7 @@ case class SearchParameters(projectIds: Option[List[Long]] = None,
                             taskTagConjunction: Option[Boolean] = None,
                             taskSearch: Option[String] = None,
                             taskStatus: Option[List[Int]] = None,
+                            taskId: Option[Long] = None,
                             taskReviewStatus: Option[List[Int]] = None,
                             taskProperties: Option[Map[String, String]] = None,
                             taskPropertySearchType: Option[String] = None,
@@ -270,6 +271,8 @@ object SearchParameters {
         case Some(v) => Utils.toIntList(v)
         case None => params.taskStatus
       },
+      //taskIds
+      this.getLongParameter(request.getQueryString("tid"), params.taskId),
       //taskReviewStatus
       request.getQueryString("trStatus") match {
         case Some(v) => Utils.toIntList(v)


### PR DESCRIPTION
* When fetching task clusters and tasks in bounding box support
  searching by a task id, reviewed by, and review requested by

* When fetching metrics support searching by reviewed by and
  review requested by and task id

* When doing a review search support searching by task id