### PR TITLE
Add support for preferred task tags on challenge

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -93,7 +93,8 @@ case class ChallengeExtra(defaultZoom: Int = Challenge.DEFAULT_ZOOM,
                           customBasemap: Option[String] = None,
                           updateTasks: Boolean = false,
                           exportableProperties: Option[String] = None,
-                          osmIdProperty: Option[String] = None) extends DefaultWrites
+                          osmIdProperty: Option[String] = None,
+                          preferredTags: Option[String] = None) extends DefaultWrites
 
 case class ChallengeListing(id: Long,
                             parent: Long,

--- a/conf/evolutions/default/52.sql
+++ b/conf/evolutions/default/52.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+-- Add preferred_tags to challenges.
+ALTER TABLE IF EXISTS challenges ADD COLUMN preferred_tags VARCHAR;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS challenges DROP COLUMN preferred_tags;;


### PR DESCRIPTION
Add field to Challenge to support a comma separated string
of 'preferredTags' on the challenge that the challenge owner
would like the user to use on task completion.

Requires evolution.