### PR TITLE
Add support for additional filters when exporting

### DIFF
--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -5,7 +5,7 @@ package org.maproulette.session
 import java.net.URLDecoder
 
 import org.maproulette.utils.Utils
-import play.api.mvc.{AnyContent, Request}
+import play.api.mvc.{AnyContent, Request, AnyContentAsFormUrlEncoded}
 import play.api.data.format.Formats
 import play.api.libs.json._
 import play.api.libs.json.JodaWrites._
@@ -212,21 +212,44 @@ object SearchParameters {
       case None => params.challengeParams.challengeIds
     }
 
-    val taskPropertySearch = (request.body.asJson) match {
-      case Some(v) =>
-        (v \ "taskPropertySearch").toOption match {
-          case Some(result) => {
-            Json.fromJson[TaskPropertySearch](result) match {
-              case JsSuccess(tps, _) => {
-                Some(tps)
+    var taskPropertySearch:Option[TaskPropertySearch] = None
+
+    // If we are submitting the taskPropertySearch JSON as POST form data
+    if (request.method == "POST") {
+      request.body match {
+        case AnyContentAsFormUrlEncoded(formData) =>
+          val tpsData = formData("taskPropertySearch")
+          if (tpsData.length > 0 && tpsData.head != "{}") {
+            taskPropertySearch =
+              Json.fromJson[TaskPropertySearch](Json.parse(tpsData.head)) match {
+                case JsSuccess(tps, _) => {
+                  Some(tps)
+                }
+                case e: JsError =>
+                  throw new InvalidException(s"Unable to create TaskPropertySearch from JSON: ${JsError toJson e}")
               }
-              case e: JsError =>
-                throw new InvalidException(s"Unable to create TaskPropertySearch from JSON: ${JsError toJson e}")
-            }
           }
-          case None => None
-        }
-      case None => None
+        case _ => None
+      }
+    }
+    // Otherwise if submitted as PUT data.
+    else {
+      taskPropertySearch = (request.body.asJson) match {
+        case Some(v) =>
+          (v \ "taskPropertySearch").toOption match {
+            case Some(result) => {
+              Json.fromJson[TaskPropertySearch](result) match {
+                case JsSuccess(tps, _) => {
+                  Some(tps)
+                }
+                case e: JsError =>
+                  throw new InvalidException(s"Unable to create TaskPropertySearch from JSON: ${JsError toJson e}")
+              }
+            }
+            case None => None
+          }
+        case None => None
+      }
     }
 
     block(SearchParameters(

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -1835,8 +1835,12 @@ GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers
 #   - name: reviewStatus
 #     in: query
 #     description: Can filter the Tasks returned by the reviewStatus of the Task. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted, 4 - Disputed
+#   - name: taskPropertySearch
+#     in: POST form data
+#     description: Can filter by specific task properties.
 ###
 GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
+POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves clustered Task points
@@ -1981,8 +1985,12 @@ GET     /challenge/:id/comments/extract             @org.maproulette.controllers
 #   - name: reviewStatus
 #     in: query
 #     description: Can filter the Tasks returned by the reviewStatus of the Task. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted, 4 - Disputed
+#   - name: taskPropertySearch
+#     in: POST form data
+#     description: Can filter by specific task properties.
 ###
 GET     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
+POST     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
 ###
 # tags: [ Project ]
 # summary: Retrieve summaries of all tasks in a Project


### PR DESCRIPTION
* When exporting CSV (tasks/extract) support additional
  filters: taskPropertySearch, taskId, reviewer, owner

* When exporting challenge geojson support additional
  filters: taskPropertySearch, taskId, reviwewer, owner

Since taskPropertySearch is a json object, added
api for POST of this data so it can be downloaded with
an HTML Form ```<form>```.