### PR TITLE
Include by priority when fetching review stats.

### DIFF
--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -212,17 +212,48 @@ class TaskReviewController @Inject()(override val sessionManager: SessionManager
     * @return
     */
   def getReviewMetrics(reviewTasksType: Int, mappers: String="", reviewers: String="", priorities: String="",
-                       startDate: String=null, endDate: String=null,
-                       onlySaved: Boolean=false, excludeOtherReviewers: Boolean=false) : Action[AnyContent] = Action.async { implicit request =>
+                       startDate: String=null, endDate: String=null, onlySaved: Boolean=false,
+                       excludeOtherReviewers: Boolean=false, includeByPriority: Boolean=false) : Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
         val result = this.taskReviewDAL.getReviewMetrics(User.userOrMocked(user),
                        reviewTasksType, params, Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
                        Utils.toIntList(priorities), startDate, endDate, onlySaved, excludeOtherReviewers)
-        Ok(Json.toJson(result))
+
+        if (includeByPriority) {
+          val priorityMap = this._fetchPriorityReviewMetrics(
+                              User.userOrMocked(user), reviewTasksType, params,
+                              Some(Utils.split(mappers)), Some(Utils.split(reviewers)),
+                              startDate, endDate, onlySaved, excludeOtherReviewers)
+
+          Ok(Json.obj("reviewActions" -> Json.toJson(result),
+                      "priorityReviewActions" -> Json.toJson(priorityMap)))
+        }
+        else {
+          Ok(Json.toJson(List(result)))
+        }
       }
     }
   }
+
+  private def _fetchPriorityReviewMetrics(user: User, reviewTasksType: Int, params: SearchParameters,
+                       mappers: Option[List[String]], reviewers: Option[List[String]],
+                       startDate: String, endDate: String, onlySaved: Boolean,
+                       excludeOtherReviewers: Boolean): scala.collection.mutable.Map[String, JsValue] = {
+    val prioritiesToFetch = List(Challenge.PRIORITY_HIGH, Challenge.PRIORITY_MEDIUM, Challenge.PRIORITY_LOW)
+
+    val priorityMap = scala.collection.mutable.Map[String, JsValue]()
+
+    prioritiesToFetch.foreach(p => {
+      val pResult = this.taskReviewDAL.getReviewMetrics(user, reviewTasksType, params,
+                      mappers, reviewers, Some(List(p)), startDate, endDate, onlySaved, excludeOtherReviewers)
+
+      priorityMap.put(p.toString, Json.toJson(pResult))
+    })
+
+    priorityMap
+  }
+
 
   /**
     * Gets clusters of review tasks. Uses kmeans method in postgis.

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -777,8 +777,11 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #   - name: excludeOtherReviewers
 #     in: query
 #     description: exclude tasks that have been reviewed by someone else
+#   - name: includeByPriority
+#     in: query
+#     description: Also include a breakdown of review status by priority
 ###
-GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers: Boolean ?= false)
+GET     /tasks/review/metrics                          @org.maproulette.controllers.api.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers: Boolean ?= false, includeByPriority:Boolean ?= false)
 ###
 # tags: [ Project ]
 # summary: Retrieves clustered challenge points


### PR DESCRIPTION
* Add optional flag "includeByPriority" to fetch review metrics
  to also include results broken down by priority. When false,
  results will be as before. When true, it will look as follows:

 ```
{reviewActions:{total:X,reviewRequested:X,....}
   priorityReviewActions:{
    0: {total:X,reviewRequested:X....},
    1: {total:X,reviewRequested:X....},
    2: {total:X,reviewRequested:X....}}
  }
```