### PR TITLE
Speed up query in managed project listing

### DIFF
--- a/app/org/maproulette/models/dal/ProjectDAL.scala
+++ b/app/org/maproulette/models/dal/ProjectDAL.scala
@@ -238,17 +238,18 @@ class ProjectDAL @Inject()(override val db: Database,
         } else {
           var permissionMatch = "p.owner_id = {osmId}"
           if (!onlyOwned) {
-            permissionMatch = permissionMatch + " OR (g.project_id = p.id AND g.id IN ({ids}))"
+            permissionMatch = permissionMatch + " OR g.id IN ({ids})"
           }
 
           val query =
             s"""SELECT distinct p.*, LOWER(p.name), LOWER(p.display_name)
-                FROM projects p, groups g
+                FROM projects p
+                INNER JOIN groups g on g.project_id = p.id
                 WHERE ${permissionMatch}
                 ${this.searchField("p.name")} ${this.enabled(onlyEnabled)}
                 ${
               this.order(orderColumn = Some(sort), orderDirection = "ASC",
-                nameFix = true, ignoreCase = (sort == "name" || sort == "display_name"))
+                nameFix = true, ignoreCase = (sort == "p.name" || sort == "p.display_name"))
             }
                 LIMIT ${this.sqlLimit(limit)} OFFSET {offset}"""
 


### PR DESCRIPTION
* Switch to using inner join to speed up query that fetches projects
that a user can manage

On my local machine this speeds up the query from 4221.132 ms to 7.266 ms.

Before:
```
QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=335409.54..335411.29 rows=50 width=156) (actual time=4196.722..4214.281 rows=4 loops=1)
   ->  Unique  (cost=335409.54..335554.30 rows=4136 width=156) (actual time=4196.722..4214.280 rows=4 loops=1)
         ->  Sort  (cost=335409.54..335419.88 rows=4136 width=156) (actual time=4196.721..4202.973 rows=16636 loops=1)
               Sort Key: (lower((p.display_name)::text)), p.name, p.id, p.created, p.modified, p.description, p.enabled, p.display_name, p.owner_id, p.deleted, p.is_virtual, p.featured, (lower((p.name)::text))
               Sort Method: external sort  Disk: 2360kB
               ->  Nested Loop  (cost=0.00..335161.09 rows=4136 width=156) (actual time=2.772..3915.706 rows=16636 loops=1)
                     Join Filter: ((p.owner_id = 8828) OR ((g.project_id = p.id) AND (g.id = ANY ('{6879,6902,6905,6908}'::integer[])) AND (lower((p.name)::text) ~~ '%'::text)))
                     Rows Removed by Join Filter: 12244096
                     ->  Seq Scan on groups g  (cost=0.00..71.32 rows=4132 width=8) (actual time=0.011..1.441 rows=4159 loops=1)
                     ->  Materialize  (cost=0.00..95.22 rows=2948 width=92) (actual time=0.000..0.182 rows=2948 loops=4159)
                           ->  Seq Scan on projects p  (cost=0.00..80.48 rows=2948 width=92) (actual time=0.006..1.027 rows=2948 loops=1)
 Planning time: 0.215 ms
 Execution time: 4221.132 ms
```

After:
```
QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=297.20..297.37 rows=5 width=156) (actual time=6.791..6.806 rows=4 loops=1)
   ->  Unique  (cost=297.20..297.37 rows=5 width=156) (actual time=6.790..6.804 rows=4 loops=1)
         ->  Sort  (cost=297.20..297.21 rows=5 width=156) (actual time=6.789..6.791 rows=12 loops=1)
               Sort Key: (lower((p.display_name)::text)), p.name, p.id, p.created, p.modified, p.description, p.enabled, p.display_name, p.owner_id, p.deleted, p.is_virtual, p.featured, (lower((p.name)::text))
               Sort Method: quicksort  Memory: 28kB
               ->  Hash Join  (cost=117.33..297.14 rows=5 width=156) (actual time=6.676..6.709 rows=12 loops=1)
                     Hash Cond: (g.project_id = p.id)
                     Join Filter: ((p.owner_id = 8828) OR ((g.id = ANY ('{6879,6902,6905,6908}'::integer[])) AND (lower((p.name)::text) ~~ '%'::text)))
                     Rows Removed by Join Filter: 4147
                     ->  Seq Scan on groups g  (cost=0.00..71.32 rows=4132 width=8) (actual time=0.014..0.571 rows=4159 loops=1)
                     ->  Hash  (cost=80.48..80.48 rows=2948 width=92) (actual time=3.239..3.239 rows=2948 loops=1)
                           Buckets: 4096  Batches: 1  Memory Usage: 409kB
                           ->  Seq Scan on projects p  (cost=0.00..80.48 rows=2948 width=92) (actual time=0.007..1.497 rows=2948 loops=1)
 Planning time: 0.674 ms
 Execution time: 7.266 ms
```