### PR TITLE
Support custom dates for user metrics.

### DIFF
--- a/app/org/maproulette/controllers/api/UserController.scala
+++ b/app/org/maproulette/controllers/api/UserController.scala
@@ -373,9 +373,12 @@ class UserController @Inject()(userDAL: UserDAL,
     }
   }
 
-  def getMetricsForUser(userId: Long, monthDuration:Int = -1, reviewDuration:Int = -1, reviewerDuration:Int = -1): Action[AnyContent] = Action.async { implicit request =>
+  def getMetricsForUser(userId: Long, monthDuration:Int = -1, reviewDuration:Int = -1, reviewerDuration:Int = -1,
+                        start: String, end: String, reviewStart: String, reviewEnd: String,
+                        reviewerStart: String, reviewerEnd: String): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
-      Ok(Json.toJson(this.userDAL.getMetricsForUser(userId, User.userOrMocked(user), monthDuration, reviewDuration, reviewerDuration)))
+      Ok(Json.toJson(this.userDAL.getMetricsForUser(userId, User.userOrMocked(user), monthDuration, reviewDuration, reviewerDuration,
+        start, end, reviewStart, reviewEnd, reviewerStart, reviewerEnd)))
     }
   }
 }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -3708,7 +3708,7 @@ GET     /data/user/:userId/leaderboard              @org.maproulette.controllers
 ### NoDocs ###
 GET     /data/user/:userId/topChallenges            @org.maproulette.controllers.api.DataController.getUserTopChallenges(userId:Long, projectIds:String ?= "", challengeIds:String ?= "", countryCodes:String ?= "", monthDuration:String ?= "", start:String ?= "", end:String ?= "", onlyEnabled:Boolean ?= true, limit:Int ?= 20, offset:Int ?= 0)
 ### NoDocs ###
-GET     /data/user/:userId/metrics                  @org.maproulette.controllers.api.UserController.getMetricsForUser(userId:Long, monthDuration:Int ?= -1, reviewDuration:Int ?= -1, reviewerDuration:Int ?= -1)
+GET     /data/user/:userId/metrics                  @org.maproulette.controllers.api.UserController.getMetricsForUser(userId:Long, monthDuration:Int ?= -1, reviewDuration:Int ?= -1, reviewerDuration:Int ?= -1, start: String ?= null, end: String ?= null, reviewStart: String ?= null, reviewEnd: String ?= null, reviewerStart: String ?= null, reviewerEnd: String ?= null)
 ### NoDocs ###
 GET     /data/project/activity                      @org.maproulette.controllers.api.DataController.getProjectActivity(projectList:String ?= "", start:String ?= "", end:String ?= "")
 ### NoDocs ###


### PR DESCRIPTION
Add custom date ranges for user metrics:
  - For tasks: start, end
  - For Reviewed tasks: reviewStart, reviewEnd
  - For As Reviewer: reviewerStart, reviewerEnd

Note: Month duration is still supported. We could
deprecate month duration values and the client could
return the same data by doing the start/end calculations
themeselves.