### PR TITLE
Support geometry changes in suggested fixes

### DIFF
--- a/app/org/maproulette/provider/osm/ChangeObjects.scala
+++ b/app/org/maproulette/provider/osm/ChangeObjects.scala
@@ -4,7 +4,9 @@ package org.maproulette.services.osm
 
 import org.maproulette.services.osm.OSMType.OSMType
 import org.maproulette.utils.Utils
+import org.maproulette.exception.InvalidException
 import play.api.libs.json.{Json, Reads, Writes}
+import scala.xml.{Attribute, Elem, Null, Text, MetaData}
 
 object OSMType extends Enumeration {
   type OSMType = Value
@@ -20,6 +22,14 @@ object OSMType extends Enumeration {
   * @param changes The changes to be applied to the data
   */
 case class TagChangeSubmission(comment: String, changes: List[TagChange])
+
+/**
+  * A class that wraps around the OSMChange class for submission to the API
+  *
+  * @param comment Comment for the changes checkin
+  * @param changes The changes to be applied to the data
+  */
+case class OSMChangeSubmission(comment: String, changes: OSMChange)
 
 /**
   * Case class that will contain all requested additions, updates and deletes. The different
@@ -57,10 +67,106 @@ case class TagChangeResult(
     deletes: Map[String, String]
 )
 
+/**
+  * Represents a set of changes (creates, updates, and deletes) of OSM elements,
+  * encompassing both tag and geometry changes
+  *
+  * TODO: support deletes
+  */
+case class OSMChange(creates: Option[List[ElementCreate]], updates: Option[List[ElementUpdate]])
+
+/**
+  * Represents changes to tags on an element, with new and modified tags in the
+  * `updates` and tag (keys) to be removed in the `deletes`
+  */
+case class ElementTagChange(updates: Map[String, String], deletes: List[String])
+
+/**
+  * Case class that will contain data for creation of a new OSM elements. Currently
+  * only creation of new nodes is supported
+  *
+  * @param osmId     Negative placeholder id of the element being created
+  * @param osmType   The type of object (node, way or relation)
+  * @param fields    The element's fields, e.g. lat and lon for a node
+  * @param tags      The element's tags
+  *
+  * TODO: support members
+  */
+case class ElementCreate(
+    osmId: Long,
+    osmType: OSMType,
+    fields: Map[String, String],
+    tags: Map[String, String]
+) {
+  def toCreateElement(changesetId: Int): Elem = {
+    val tagNodes =
+      for (tagKV <- tags)
+        yield <tag/> % Attribute("v", Text(tagKV._2), Attribute("k", Text(tagKV._1), Null))
+
+    val attributes = this.fieldAttributes(
+      fields,
+      Attribute(
+        "changeset",
+        Text(changesetId.toString),
+        Attribute("version", Text("1"), Attribute("id", Text(osmId.toString), Null))
+      )
+    )
+
+    osmType match {
+      case OSMType.NODE => <node>{tagNodes}</node> % attributes
+      case _ =>
+        throw new InvalidException(s"Creation of $osmType elements is not currently supported")
+    }
+  }
+
+  /**
+    * Generate chained Attribute instances for the given fields, finishing the
+    * chain with the given terminator
+    */
+  def fieldAttributes(fields: Map[String, String], terminator: MetaData = Null): MetaData = {
+    fields.isEmpty match {
+      case true => terminator
+      case false =>
+        Attribute(
+          fields.head._1,
+          Text(fields.head._2),
+          this.fieldAttributes(fields - fields.head._1, terminator)
+        )
+    }
+  }
+}
+
+/**
+  * Case class that will contain data for updates of existing OSM elements.
+  * Currently only changes to tags are supported
+  *
+  * @param osmId   The id of the object you are requesting the changes for
+  * @param osmType The type of object (node, way or relation)
+  * @param tags    The tag changes to apply
+  *
+  * TODO: support members
+  */
+case class ElementUpdate(
+    osmId: Long,
+    osmType: OSMType,
+    version: Option[Int] = None,
+    tags: ElementTagChange
+)
+
 object ChangeObjects {
   implicit val enumReads                                      = Utils.enumReads(OSMType)
   implicit val tagChangeReads: Reads[TagChange]               = Json.reads[TagChange]
   implicit val tagChangeResultWrites: Writes[TagChangeResult] = Json.writes[TagChangeResult]
   implicit val tagChangeSubmissionReads: Reads[TagChangeSubmission] =
     Json.reads[TagChangeSubmission]
+  implicit val elementTagChangeReads: Reads[ElementTagChange] =
+    Json.reads[ElementTagChange]
+  implicit val elementCreateReads: Reads[ElementCreate] =
+    Json.reads[ElementCreate]
+  implicit val elementUpdateReads: Reads[ElementUpdate] =
+    Json.reads[ElementUpdate]
+  implicit val changeReads: Reads[OSMChange] =
+    Json.reads[OSMChange]
+  implicit val changeSubmissionReads: Reads[OSMChangeSubmission] =
+    Json.reads[OSMChangeSubmission]
 }

--- a/conf/apiv2.routes
+++ b/conf/apiv2.routes
@@ -4437,6 +4437,27 @@ DELETE  /user/project/:projectId/:groupType         @org.maproulette.controllers
 POST    /change/tag/test                            @org.maproulette.controllers.OSMChangesetController.testTagChange(changeType:String ?= "delta")
 ###
 # tags: [ Changes ]
+# summary: Test OSM changes (currently only node creation or tag changes)
+# description: Takes in a set of changes and, instead of submitting them to OSM, will return a standard OSMChange XML that would have been submitted to the OSM servers
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: body
+#     in: body
+#     description: The nodes to be created
+#     required: true
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.services.osm.ChangeObjects.Change'
+###
+POST    /change/test                        @org.maproulette.controllers.OSMChangesetController.testChange()
+###
+# tags: [ Changes ]
 # summary: Apply Tag Changes for task
 # description: Submit a group of changes to OSM. Will return a standard OSMChange XML that has been applied to the OSM servers
 # responses:
@@ -4466,6 +4487,38 @@ POST    /change/tag/test                            @org.maproulette.controllers
 #       $ref: '#/definitions/org.maproulette.services.osm.ChangeObjects.TagChangeSubmission'
 ###
 POST    /task/:taskId/fix/apply                     @org.maproulette.controllers.api.TaskController.applyTagFix(taskId:Long, comment:String ?= "", tags:String ?= "")
+
+###
+# tags: [ Changes ]
+# summary: Apply suggested fix for task
+# description: Submit a group of changes to OSM. Will return a standard OSMChange XML that has been applied to the OSM servers
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: taskId
+#     in: query
+#     description: The task id that should be marked as fixed after this tag change has been applied.
+#   - name: comment
+#     in: query
+#     description: A task comment to be stored in map roulette with this change.
+#   - name: requestReview
+#     in: query
+#     description: Boolean indicating if a review is requested on this task. (Will override user settings if provided)
+#   - name: tags
+#     in: query
+#     description: A list of mrTags to be stored with the task
+#   - name: body
+#     in: body
+#     description: The OSMChangeSubmission
+#     required: true
+#     schema:
+#       type: object
+#       $ref: '#/definitions/org.maproulette.services.osm.ChangeObjects.OSMChangeSubmission'
+###
+POST    /task/:taskId/suggestedFix/apply                     @org.maproulette.controllers.api.TaskController.applySuggestedFix(taskId:Long, comment:String ?= "", tags:String ?= "")
 
 ###
 # tags: [ Bundle ]


### PR DESCRIPTION
* Add support for general suggested fix that include geometry
and tag changes

* For now, creation of nodes is the only supported geometry fix

* Preserve old tag-specific suggested fixes and API endpoints for
backward compatibility

* Add two new API endpoints for general suggested fixes: POST
`/change/test` to test a change and POST
`/task/:taskId/suggestedFix/apply` to apply a change to a task and
submit to OSM