### PR TITLE
Don't require permission to fetch user by OSM id

### DIFF
--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -250,7 +250,7 @@ class SessionManager @Inject() (
         if (impersonateUserId < 0) {
           p success Some(User.superUser)
         } else {
-          this.dalManager.user.retrieveByOSMID(impersonateUserId, User.superUser) match {
+          this.dalManager.user.retrieveByOSMID(impersonateUserId) match {
             case Some(user) => p success Some(user)
             case None       => p success Some(User.superUser)
           }

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -160,22 +160,16 @@ class UserDAL @Inject() (
     * instead of hitting the database
     *
     * @param id   The user's osm ID
-    * @param user The user making the request
     * @return The matched user, None if User not found
     */
-  def retrieveByOSMID(implicit id: Long, user: User): Option[User] =
+  def retrieveByOSMID(implicit id: Long): Option[User] =
     this.cacheManager.withOptionCaching { () =>
       this.db.withConnection { implicit c =>
         val query =
           s"""SELECT ${this.retrieveColumns}, score FROM users
                       LEFT JOIN user_metrics ON users.id = user_metrics.user_id
                       WHERE osm_id = {id}"""
-        SQL(query).on(Symbol("id") -> id).as(this.parser.*).headOption match {
-          case Some(u) =>
-            this.permission.hasObjectReadAccess(u, user)
-            Some(u)
-          case None => None
-        }
+        SQL(query).on(Symbol("id") -> id).as(this.parser.*).headOption
       }
     }
 


### PR DESCRIPTION
* Remove requirement that requesting user has read access to target user
being fetched by OSM id, bringing it in line with requirements for
fetching a user by internal id

* Fixes security errors when trying to add managers via OSM id to a
project