### PR TITLE
Add task property filters search types 'exists' and 'missing'

### DIFF
--- a/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
+++ b/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
@@ -256,6 +256,10 @@ trait SearchParametersMixin extends DALHelper {
                     query ++= s" AND features->'properties'->>'${k}' != '${v}' "
                   } else if (searchType == SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS) {
                     query ++= s" AND features->'properties'->>'${k}' LIKE '%${v}%' "
+                  } else if (searchType == SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS) {
+                    query ++= s" AND features->'properties'->>'${k}' IS NOT NULL "
+                  } else if (searchType == SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING) {
+                    query ++= s" AND features->'properties'->>'${k}' IS NULL "
                   }
                 }
                 query ++= "))"

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -89,6 +89,8 @@ object SearchParameters {
   val TASK_PROP_SEARCH_TYPE_EQUALS       = "equals"
   val TASK_PROP_SEARCH_TYPE_NOT_EQUAL    = "not_equal"
   val TASK_PROP_SEARCH_TYPE_CONTAINS     = "contains"
+  val TASK_PROP_SEARCH_TYPE_EXISTS       = "exists"
+  val TASK_PROP_SEARCH_TYPE_MISSING      = "missing"
   val TASK_PROP_SEARCH_TYPE_LESS_THAN    = "less_than"
   val TASK_PROP_SEARCH_TYPE_GREATER_THAN = "greater_than"
 

--- a/app/org/maproulette/session/TaskPropertySearch.scala
+++ b/app/org/maproulette/session/TaskPropertySearch.scala
@@ -50,6 +50,8 @@ case class TaskPropertySearch(
         searchType.get match {
           case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS =>
             where ++= "'%" + value.getOrElse("").replaceAll("\'", "\'\'") + "%' "
+          case SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS  => // do nothing
+          case SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING => // do nothing
           case _ =>
             where ++= " '" + value.getOrElse("").replaceAll("\'", "\'\'") + "'"
         }
@@ -65,6 +67,8 @@ case class TaskPropertySearch(
       case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS       => "="
       case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL    => "!="
       case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS     => " LIKE "
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS       => " IS NOT NULL "
+      case SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING      => " IS NULL "
       case SearchParameters.TASK_PROP_SEARCH_TYPE_LESS_THAN    => "<"
       case SearchParameters.TASK_PROP_SEARCH_TYPE_GREATER_THAN => ">"
       case e                                                   => throw new InvalidException("Search Type: '" + e + "' not supported.")
@@ -142,6 +146,8 @@ case class TaskPropertySearch(
                 case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS    => true
                 case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL => true
                 case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS  => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS    => true
+                case SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING   => true
                 case e =>
                   throw new InvalidException(
                     "Search Type: '" + e + "' not supported when comparing strings."


### PR DESCRIPTION
Add support for "missing" and "exists" task property search types. (ie: "building" exists or "building" missing)