### PR TITLE
Fix quotes being stored in task names

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -297,7 +297,13 @@ class ChallengeProvider @Inject() (
     } else {
       val nameKeys = List.apply("id", "@id", "osmid", "osm_id", "name")
       nameKeys.collectFirst {
-        case x if (value \ x).asOpt[JsValue].isDefined => (value \ x).asOpt[JsValue].get.toString
+        case x if (value \ x).asOpt[JsValue].isDefined =>
+          // Support both string and numeric ids. If it's a string, use it.
+          // Otherwise convert the value to a string
+          (value \ x).asOpt[String] match {
+            case Some(stringValue) => stringValue
+            case None              => (value \ x).asOpt[JsValue].get.toString
+          }
       } match {
         case Some(n) => n
         case None =>


### PR DESCRIPTION
* When determining the task name, explicitly convert numeric feature ids
to strings instead of simply always running the feature id through
JsValue.toString to normalize it, as that was causing quotes to be added
into string values (e.g.  `node/1234` was becoming `"node/1234"`)