### PR TITLE
Add 'requires_local' column to challenges

### DIFF
--- a/app/org/maproulette/models/Challenge.scala
+++ b/app/org/maproulette/models/Challenge.scala
@@ -77,7 +77,8 @@ case class ChallengeGeneral(
     popularity: Option[Int] = None,
     checkinComment: String = "",
     checkinSource: String = "",
-    virtualParents: Option[Array[Long]] = None
+    virtualParents: Option[Array[Long]] = None,
+    requiresLocal: Boolean = false
 ) extends DefaultWrites
 
 case class ChallengeCreation(

--- a/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
+++ b/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
@@ -38,6 +38,7 @@ trait SearchParametersMixin extends DALHelper {
     this.paramsPriority(params, whereClause)
     this.paramsChallengeDifficulty(params, whereClause)
     this.paramsChallengeStatus(params, whereClause, joinClause)
+    this.paramsChallengeRequiresLocal(params, whereClause, joinClause)
     this.paramsBoundingGeometries(params, whereClause)
 
     // For efficiency can only query on task properties with a parent challenge id
@@ -164,6 +165,27 @@ trait SearchParametersMixin extends DALHelper {
         this.appendInWhereClause(whereClause, statusClause.toString())
       case Some(sl) if sl.isEmpty => //ignore this scenario
       case _                      =>
+    }
+  }
+
+  def paramsChallengeRequiresLocal(
+      params: SearchParameters,
+      whereClause: StringBuilder,
+      joinClause: StringBuilder
+  ): Unit = {
+    params.challengeParams.challengeIds match {
+      case Some(ids) if ids.nonEmpty =>
+      // do nothing, we don't want to restrict to requiresLocal if we have
+      // specific challenge ids
+      case _ =>
+        params.challengeParams.requiresLocal match {
+          case SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE =>
+            this.appendInWhereClause(whereClause, s"c.requires_local = false")
+          case SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY =>
+            this.appendInWhereClause(whereClause, s"c.requires_local = true")
+          case _ =>
+          // allow everything
+        }
     }
   }
 

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -29,7 +29,8 @@ case class SearchChallengeParameters(
     challengeSearch: Option[String] = None,
     challengeEnabled: Option[Boolean] = None,
     challengeDifficulty: Option[Int] = None,
-    challengeStatus: Option[List[Int]] = None
+    challengeStatus: Option[List[Int]] = None,
+    requiresLocal: Int = SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE
 )
 
 case class SearchParameters(
@@ -101,6 +102,10 @@ object SearchParameters {
   val TASK_PROP_OPERATION_TYPE_AND = "and"
   val TASK_PROP_OPERATION_TYPE_OR  = "or"
 
+  val CHALLENGE_REQUIRES_LOCAL_EXCLUDE = 0
+  val CHALLENGE_REQUIRES_LOCAL_INCLUDE = 1
+  val CHALLENGE_REQUIRES_LOCAL_ONLY    = 2
+
   implicit val locationWrites = Json.writes[SearchLocation]
   implicit val locationReads  = Json.reads[SearchLocation]
   implicit val taskPropertySearchWrites: Writes[TaskPropertySearch] =
@@ -147,6 +152,8 @@ object SearchParameters {
         case Some(r) => Utils.insertIntoJson(updated, "challengeStatus", r, true)
         case None    => updated
       }
+      updated =
+        Utils.insertIntoJson(updated, "requiresLocal", o.challengeParams.requiresLocal, true)
 
       updated = updated.as[JsObject] - "challengeParams"
       updated
@@ -189,6 +196,11 @@ object SearchParameters {
 
       (json \ "challengeStatus").toOption match {
         case Some(v) => challengeParams = challengeParams + ("challengeStatus" -> v)
+        case None    => // do nothing
+      }
+
+      (json \ "requiresLocal").toOption match {
+        case Some(v) => challengeParams = challengeParams + ("requiresLocal" -> v)
         case None    => // do nothing
       }
 
@@ -292,7 +304,11 @@ object SearchParameters {
         request.getQueryString("cStatus") match {
           case Some(v) => Utils.toIntList(v)
           case None => params.challengeParams.challengeStatus
-        }),
+        },
+        //requiresLocal
+        this.getIntParameter(request.getQueryString("cLocal"),
+          Some(params.challengeParams.requiresLocal)).getOrElse(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE)
+      ),
       //taskTags
       request.getQueryString("tt") match {
         case Some(v) => Some(v.split(",").toList)

--- a/conf/evolutions/default/58.sql
+++ b/conf/evolutions/default/58.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+-- Add requires_local.
+SELECT add_drop_column('challenges', 'requires_local', 'BOOLEAN DEFAULT FALSE');;
+
+# --- !Downs
+SELECT add_drop_column('challenges', 'requires_local', '', false);;


### PR DESCRIPTION
* Add 'requires_local' column to challenges

* Default is to not return requiresLocal challenges when
  searching.

* Local challenges not included in featured/popular/new

* SearchParameter cLocal will search on 'requires_local':
   0 - Exclude local
   1 - Include local
   2 - Return only local