### PR TITLE
Fix caching on setTaskReviewStatus

### DIFF
--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -182,7 +182,7 @@ class TaskReviewDAL @Inject() (
     val updatedTask =
       primaryTask.copy(review = primaryTask.review.copy(reviewClaimedBy = Option(user.id.toInt)))
 
-    this.cacheManager.withOptionCaching { () =>
+    this.manager.task.cacheManager.withOptionCaching { () =>
       Some(updatedTask)
     }
     Option(updatedTask)
@@ -1111,7 +1111,7 @@ class TaskReviewDAL @Inject() (
         }
       }
 
-      this.cacheManager.withOptionCaching { () =>
+      this.manager.task.cacheManager.withOptionCaching { () =>
         Some(
           task.copy(review = task.review.copy(
             reviewStatus = Some(reviewStatus),


### PR DESCRIPTION
* If a task is rejected in review and immediately viewed by the
  mapper they would still see it as awaiting review until cache
  is refreshed. Wrong cacheManager was being updated.