### PR TITLE
Notify reviewer of re-review on task status change

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -663,6 +663,20 @@ class TaskDAL @Inject() (
                       SET review_status = ${Task.REVIEW_STATUS_REQUESTED}, review_requested_by = ${user.id}
                       WHERE tr.task_id = ${task.id}
                  """.executeUpdate()
+
+              // Let's note in the task_review_history table that this task needs review again
+              SQL"""INSERT INTO task_review_history
+                                 (task_id, requested_by, reviewed_by, review_status, reviewed_at, review_started_at)
+                     VALUES (${task.id}, ${user.id}, ${task.review.reviewedBy},
+                             ${Task.REVIEW_STATUS_REQUESTED}, ${Instant.now()},
+                             ${task.review.reviewStartedAt})""".executeUpdate()
+              this.manager.notification.createReviewNotification(
+                user,
+                task.review.reviewedBy.getOrElse(-1),
+                Task.REVIEW_STATUS_REQUESTED,
+                task,
+                None
+              )
             case None =>
               SQL"""INSERT INTO task_review (task_id, review_status, review_requested_by)
                       VALUES (${task.id}, ${Task.REVIEW_STATUS_REQUESTED}, ${user.id})"""


### PR DESCRIPTION
If the task status has changed following a review rejection,
notify the reviewer that a re-review is needed.