### PR TITLE
Fix time spent calculation to only use db time not server time

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -368,7 +368,6 @@ class TaskDAL @Inject() (
                     {status}, {geojson}::JSONB, {suggestedFixGeoJson}::JSONB, {id}, {priority}, {changesetId},
                     {reset}, {mappedOn}, {reviewStatus}, CAST({reviewRequestedBy} AS INTEGER),
                     CAST({reviewedBy} AS INTEGER), {reviewedAt})"""
-
       val updatedTaskId = SQL(query)
         .on(
           NamedParameter("name", ToParameterValue.apply[String].apply(element.name)),
@@ -647,8 +646,8 @@ class TaskDAL @Inject() (
         if (!skipStatusUpdate) {
           startedLock match {
             case Some(l) =>
-              completedTimeSpent = Some(new DateTime().getMillis() - l.getMillis())
-              SQL"""UPDATE tasks SET completed_time_spent = ${completedTimeSpent.get}
+              SQL"""UPDATE tasks SET completed_time_spent = (SELECT (extract(epoch from NOW()) * 1000 - ${l
+                .getMillis()}))
                     WHERE id = ${task.id}""".executeUpdate()
             case _ => // do nothing
           }

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -1124,10 +1124,10 @@ class TaskReviewDAL @Inject() (
       }
 
       if (!needsReReview) {
-        var reviewTime: Long = 0
+        var reviewStartTime: Option[Long] = None
         task.review.reviewClaimedAt match {
           case Some(t) =>
-            reviewTime = new DateTime().getMillis() - t.getMillis()
+            reviewStartTime = Some(t.getMillis())
           case None => // do nothing
         }
 
@@ -1146,7 +1146,7 @@ class TaskReviewDAL @Inject() (
           Option(reviewStatus),
           false,
           true,
-          Some(reviewTime),
+          reviewStartTime,
           user.id
         )
       } else if (reviewStatus == Task.REVIEW_STATUS_DISPUTED) {

--- a/app/org/maproulette/session/dal/UserDAL.scala
+++ b/app/org/maproulette/session/dal/UserDAL.scala
@@ -1102,7 +1102,7 @@ class UserDAL @Inject() (
       taskReviewStatus: Option[Int],
       isReviewRevision: Boolean = false,
       asReviewer: Boolean = false,
-      reviewTime: Option[Long] = None,
+      reviewStartTime: Option[Long] = None,
       userId: Long
   )(implicit c: Connection = null) = {
     // We need to invalidate the user in the cache.
@@ -1177,10 +1177,10 @@ class UserDAL @Inject() (
         }
 
         if (asReviewer) {
-          reviewTime match {
+          reviewStartTime match {
             case Some(rTime) =>
               statusBump += ", tasks_with_review_time=(tasks_with_review_time + 1)"
-              statusBump += s", total_review_time=(total_review_time + ${rTime})"
+              statusBump += s", total_review_time=(total_review_time + (SELECT EXTRACT(EPOCH FROM NOW())) * 1000 - ${rTime})"
             case None => // not a review
           }
         } else {


### PR DESCRIPTION
If database and server are running on separate machines and
the machines have different time then the time spent calculation
would be off -- change time spent calculations to only use
db times.