### PR TITLE
Update challenge status after adding new task

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -170,8 +170,12 @@ class TaskController @Inject() (
     */
   override def extractAndCreate(body: JsValue, createdObject: Task, user: User)(
       implicit c: Option[Connection] = None
-  ): Unit =
+  ): Unit = {
+    // If we have added a new task to a 'finished' challenge, we need to make
+    // sure to set challenge back to 'ready'
+    this.dalManager.challenge.updateReadyStatus()(createdObject.parent)
     this.extractTags(body, createdObject, User.superUser, true)
+  }
 
   /**
     * Gets a json list of tags of the task

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -431,9 +431,13 @@ class TaskDAL @Inject() (
         case None => // ignore
       }
 
+      val newItem = Some(element.copy(id = updatedTaskId))
+
       this.cacheManager.withUpdatingCache(Long => retrieveById) { implicit cachedItem =>
-        Some(element.copy(id = updatedTaskId))
+        newItem
       }(updatedTaskId, true, true)
+
+      newItem
     }
   }
 


### PR DESCRIPTION
If a challenge is 'finished' but a new task is added, the status
needs to be set back to 'ready'