### PR TITLE
Remove updated task from cache after update

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -326,7 +326,7 @@ class TaskDAL @Inject() (
       }
 
       val updatedElement = element.copy(id = updatedTaskId)
-      this.cacheManager.cache.add(updatedTaskId, updatedElement)
+      this.cacheManager.cache.remove(updatedTaskId)
       Some(updatedElement)
     }
   }


### PR DESCRIPTION
Remove created/updated task from cache after database update
since it may have incomplete data.