### PR TITLE
Remove `/task/:taskId/suggestedFix/apply` API

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -729,67 +729,6 @@ class TaskController @Inject() (
       }
     }
 
-  def applySuggestedFix(
-      taskId: Long,
-      comment: String = "",
-      tags: String = ""
-  ): Action[JsValue] = Action.async(bodyParsers.json) { implicit request =>
-    this.sessionManager.authenticatedFutureRequest { implicit user =>
-      val result = request.body.validate[OSMChangeSubmission]
-      result.fold(
-        errors => {
-          Future {
-            BadRequest(Json.toJson(StatusMessage("KO", JsError.toJson(errors))))
-          }
-        },
-        element => {
-          val p = Promise[Result]
-
-          val requestReview = request.getQueryString("requestReview") match {
-            case Some(v) => Some(v.toBoolean)
-            case None    => None
-          }
-
-          config.skipOSMChangesetSubmission match {
-            // If we are skipping the OSM submission then we don't actually do the tag change on OSM
-            case true =>
-              this.customTaskStatus(
-                taskId,
-                TaskStatusSet(Task.STATUS_FIXED),
-                user,
-                comment,
-                tags,
-                requestReview
-              )
-              p success Ok(Json.toJson(true))
-            case _ =>
-              None
-              changeService.submitOsmChange(
-                element.changes,
-                element.comment,
-                user.osmProfile.requestToken,
-                Some(taskId)
-              ) onComplete {
-                case Success(res) => {
-                  this.customTaskStatus(
-                    taskId,
-                    TaskStatusSet(Task.STATUS_FIXED),
-                    user,
-                    comment,
-                    tags,
-                    requestReview
-                  )
-                  p success Ok(res)
-                }
-                case Failure(f) => p failure f
-              }
-          }
-          p.future
-        }
-      )
-    }
-  }
-
   /**
     * Fetches and inserts usernames for 'reviewRequestedBy' and 'reviewBy' into
     * the ClusteredPoint.pointReview

--- a/conf/route/v2.api
+++ b/conf/route/v2.api
@@ -557,37 +557,6 @@ POST    /change/test                        @org.maproulette.controllers.OSMChan
 ###
 POST    /task/:taskId/fix/apply                     @org.maproulette.controllers.api.TaskController.applyTagFix(taskId:Long, comment:String ?= "", tags:String ?= "")
 ###
-# tags: [ Changes ]
-# summary: Apply suggested fix for task
-# description: Submit a group of changes to OSM. Will return a standard OSMChange XML that has been applied to the OSM servers
-# responses:
-#   '200':
-#     description: Ok with a standard message
-#   '401':
-#     description: The user is not authorized to make this request
-# parameters:
-#   - name: taskId
-#     in: query
-#     description: The task id that should be marked as fixed after this tag change has been applied.
-#   - name: comment
-#     in: query
-#     description: A task comment to be stored in map roulette with this change.
-#   - name: requestReview
-#     in: query
-#     description: Boolean indicating if a review is requested on this task. (Will override user settings if provided)
-#   - name: tags
-#     in: query
-#     description: A list of mrTags to be stored with the task
-#   - name: body
-#     in: body
-#     description: The OSMChangeSubmission
-#     required: true
-#     schema:
-#       type: object
-#       $ref: '#/definitions/org.maproulette.services.osm.ChangeObjects.OSMChangeSubmission'
-###
-POST    /task/:taskId/suggestedFix/apply                     @org.maproulette.controllers.api.TaskController.applySuggestedFix(taskId:Long, comment:String ?= "", tags:String ?= "")
-###
 # tags: [ Bundle ]
 # summary: Create a task bundle
 # consumes: [ application/json ]


### PR DESCRIPTION
* Remove API endpoint previously used to apply suggested fixes
containing simple geometry fixes, as going forward these will be handled
through the upcoming "cooperative challenges" functionality

* Application of suggested fixes containing tag fixes uses a different
API endpoint and is unchanged