### PR TITLE
Change suggested fixes to cooperative challenges

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1019,7 +1019,7 @@ class ChallengeController @Inject() (
   ): Option[Challenge] = {
     var created = super.internalCreate(requestBody, element, user)
     // Fetch challenge fresh from database. There are some fields that are set after creating
-    // children (ie. hasSuggestedFixes) and our cached copy does not reflect those changes
+    // children (ie. cooperativeType) and our cached copy does not reflect those changes
     created match {
       case Some(value) => this.dal._retrieveById(false)(value.id)
       case None        => created
@@ -1054,7 +1054,8 @@ class ChallengeController @Inject() (
       Utils.insertIntoJson(jsonBody, "challengeType", Actions.ITEM_TYPE_CHALLENGE)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "difficulty", Challenge.DIFFICULTY_NORMAL)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "featured", false)(BooleanWrites)
-    jsonBody = Utils.insertIntoJson(jsonBody, "hasSuggestedFixes", false)(BooleanWrites)
+    jsonBody =
+      Utils.insertIntoJson(jsonBody, "cooperativeType", Challenge.COOPERATIVE_NONE)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "checkinComment", "")(StringWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "checkinSource", "")(StringWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "requiresLocal", false)(BooleanWrites)

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -73,7 +73,7 @@ case class ChallengeGeneral(
     blurb: Option[String] = None,
     enabled: Boolean = false,
     featured: Boolean = false,
-    hasSuggestedFixes: Boolean = false,
+    cooperativeType: Int = 0,
     popularity: Option[Int] = None,
     checkinComment: String = "",
     checkinSource: String = "",
@@ -220,6 +220,11 @@ object Challenge extends CommonField {
   val STATUS_PARTIALLY_LOADED = 4
   val STATUS_FINISHED         = 5
   val STATUS_DELETING_TASKS   = 6
+
+  // COOPERATIVE TYPES
+  val COOPERATIVE_NONE       = 0
+  val COOPERATIVE_TAGS       = 1
+  val COOPERATIVE_CHANGEFILE = 2
 
   // CHALLENGE FIELDS
   val FIELD_PARENT_ID = "parent_id"

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -62,7 +62,7 @@ object ChallengeRepository {
       get[Option[String]]("challenges.blurb") ~
       get[Boolean]("challenges.enabled") ~
       get[Boolean]("challenges.featured") ~
-      get[Boolean]("challenges.has_suggested_fixes") ~
+      get[Int]("challenges.cooperative_type") ~
       get[Option[Int]]("challenges.popularity") ~
       get[Option[String]]("challenges.checkin_comment") ~
       get[Option[String]]("challenges.checkin_source") ~
@@ -91,7 +91,7 @@ object ChallengeRepository {
       get[Option[String]]("boundingJSON") ~
       get[Boolean]("deleted") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
-            difficulty ~ blurb ~ enabled ~ featured ~ hasSuggestedFixes ~ popularity ~ checkin_comment ~
+            difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ taskStyles ~ lastTaskRefresh ~
@@ -124,7 +124,7 @@ object ChallengeRepository {
             blurb,
             enabled,
             featured,
-            hasSuggestedFixes,
+            cooperativeType,
             popularity,
             checkin_comment.getOrElse(""),
             checkin_source.getOrElse(""),

--- a/app/org/maproulette/models/ClusteredPoint.scala
+++ b/app/org/maproulette/models/ClusteredPoint.scala
@@ -58,7 +58,7 @@ case class ClusteredPoint(
     difficulty: Int,
     `type`: Int,
     status: Int,
-    suggestedFix: Option[String] = None,
+    cooperativeWork: Option[String] = None,
     mappedOn: Option[DateTime],
     completedTimeSpent: Option[Long] = None,
     completedBy: Option[Long] = None,

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -52,7 +52,7 @@ case class Task(
     instruction: Option[String] = None,
     location: Option[String] = None,
     geometries: String,
-    suggestedFix: Option[String] = None,
+    cooperativeWork: Option[String] = None,
     status: Option[Int] = None,
     mappedOn: Option[DateTime] = None,
     completedTimeSpent: Option[Long] = None,
@@ -123,8 +123,8 @@ object Task {
       }
 
       original = Utils.insertIntoJson(updatedLocation, "geometries", Json.parse(o.geometries), true)
-      var updated = o.suggestedFix match {
-        case Some(sf) => Utils.insertIntoJson(original, "suggestedFix", Json.parse(sf), true)
+      var updated = o.cooperativeWork match {
+        case Some(cw) => Utils.insertIntoJson(original, "cooperativeWork", Json.parse(cw), true)
         case None     => original
       }
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -81,7 +81,7 @@ class ChallengeDAL @Inject() (
       get[Option[String]]("challenges.blurb") ~
       get[Boolean]("challenges.enabled") ~
       get[Boolean]("challenges.featured") ~
-      get[Boolean]("challenges.has_suggested_fixes") ~
+      get[Int]("challenges.cooperative_type") ~
       get[Option[Int]]("challenges.popularity") ~
       get[Option[String]]("challenges.checkin_comment") ~
       get[Option[String]]("challenges.checkin_source") ~
@@ -111,7 +111,7 @@ class ChallengeDAL @Inject() (
       get[Boolean]("challenges.requires_local") ~
       get[Boolean]("deleted") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
-            difficulty ~ blurb ~ enabled ~ featured ~ hasSuggestedFixes ~ popularity ~ checkin_comment ~
+            difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ taskStyles ~ lastTaskRefresh ~
@@ -144,7 +144,7 @@ class ChallengeDAL @Inject() (
             blurb,
             enabled,
             featured,
-            hasSuggestedFixes,
+            cooperativeType,
             popularity,
             checkin_comment.getOrElse(""),
             checkin_source.getOrElse(""),
@@ -194,7 +194,7 @@ class ChallengeDAL @Inject() (
       get[Option[String]]("challenges.blurb") ~
       get[Boolean]("challenges.enabled") ~
       get[Boolean]("challenges.featured") ~
-      get[Boolean]("challenges.has_suggested_fixes") ~
+      get[Int]("challenges.cooperative_type") ~
       get[Option[Int]]("challenges.popularity") ~
       get[Option[String]]("challenges.checkin_comment") ~
       get[Option[String]]("challenges.checkin_source") ~
@@ -225,7 +225,7 @@ class ChallengeDAL @Inject() (
       get[Boolean]("deleted") ~
       get[Option[List[Long]]]("virtual_parent_ids") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
-            difficulty ~ blurb ~ enabled ~ featured ~ hasSuggestedFixes ~ popularity ~
+            difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~
             checkin_comment ~ checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~
             defaultPriority ~ highPriorityRule ~ mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~
             minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~ customBasemap ~ updateTasks ~
@@ -259,7 +259,7 @@ class ChallengeDAL @Inject() (
             blurb,
             enabled,
             featured,
-            hasSuggestedFixes,
+            cooperativeType,
             popularity,
             checkin_comment.getOrElse(""),
             checkin_source.getOrElse(""),
@@ -304,7 +304,7 @@ class ChallengeDAL @Inject() (
       get[Int]("tasks.priority") ~
       get[Option[Long]]("tasks.bundle_id") ~
       get[Option[Boolean]]("tasks.is_bundle_primary") ~
-      get[Option[String]]("suggested_fix") ~
+      get[Option[String]]("cooperative_work") ~
       get[Option[Int]]("task_review.review_status") ~
       get[Option[Long]]("task_review.review_requested_by") ~
       get[Option[Long]]("task_review.reviewed_by") ~
@@ -312,7 +312,7 @@ class ChallengeDAL @Inject() (
       get[Option[DateTime]]("task_review.review_started_at") map {
       case id ~ name ~ parentId ~ parentName ~ instruction ~ location ~ status ~
             mappedOn ~ completedTimeSpent ~ completedBy ~ priority ~ bundleId ~
-            isBundlePrimary ~ suggestedFix ~ reviewStatus ~ reviewRequestedBy ~
+            isBundlePrimary ~ cooperativeWork ~ reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ reviewStartedAt =>
         val locationJSON = Json.parse(location)
         val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
@@ -333,7 +333,7 @@ class ChallengeDAL @Inject() (
           -1,
           Actions.ITEM_TYPE_TASK,
           status,
-          suggestedFix,
+          cooperativeWork,
           mappedOn,
           completedTimeSpent,
           completedBy,
@@ -690,7 +690,7 @@ class ChallengeDAL @Inject() (
           get[Option[String]]("tasks.instruction") ~
           get[Option[String]]("geo_location") ~
           get[Option[String]]("geo_json") ~
-          get[Option[String]]("suggested_fix") ~
+          get[Option[String]]("cooperative_work") ~
           get[Option[Int]]("tasks.status") ~
           get[Option[DateTime]]("tasks.mapped_on") ~
           get[Option[Long]]("tasks.completed_time_spent") ~
@@ -704,10 +704,10 @@ class ChallengeDAL @Inject() (
           get[Option[DateTime]]("task_review.review_claimed_at") ~
           get[Int]("tasks.priority") map {
           case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~
-                geometry ~ suggestedFix ~ status ~ mappedOn ~ completedTimeSpent ~
+                geometry ~ cooperativeWork ~ status ~ mappedOn ~ completedTimeSpent ~
                 completedBy ~ reviewStatus ~ reviewRequestedBy ~ reviewedBy ~ reviewedAt ~
                 reviewStartedAt ~ reviewClaimedBy ~ reviewClaimedAt ~ priority =>
-            val values = taskDAL.updateAndRetrieve(id, geometry, location, suggestedFix)
+            val values = taskDAL.updateAndRetrieve(id, geometry, location, cooperativeWork)
             Task(
               id,
               name,
@@ -1169,7 +1169,7 @@ class ChallengeDAL @Inject() (
                    t.parent_id, t.bundle_id, t.is_bundle_primary,
                    tr.review_status, tr.review_requested_by,
                    tr.reviewed_by, tr.reviewed_at, tr.review_started_at,
-                   t.suggestedfix_geojson::TEXT as suggested_fix, c.name,
+                   t.cooperative_work_json::TEXT as cooperative_work, c.name,
                    ST_AsGeoJSON(t.location) AS location, t.priority
             FROM tasks t
             #${joinClause.toString()}

--- a/app/org/maproulette/models/dal/TaskBundleDAL.scala
+++ b/app/org/maproulette/models/dal/TaskBundleDAL.scala
@@ -56,10 +56,10 @@ class TaskBundleDAL @Inject() (
       val challengeId = lockedTasks.head.parent
       // Verify tasks
       // 1. Must belong to same challenge
-      // 2. suggested Fix tasks not allowed
+      // 2. Cooperative tasks not allowed
       for (task <- lockedTasks) {
-        if (task.suggestedFix.isDefined) {
-          throw new InvalidException("Suggested Fix tasks cannot be bundled.")
+        if (task.cooperativeWork.isDefined) {
+          throw new InvalidException("Cooperative tasks cannot be bundled.")
         }
         if (task.parent != challengeId) {
           throw new InvalidException("All tasks in the bundle must be part of the same challenge.")

--- a/app/org/maproulette/models/dal/TaskClusterDAL.scala
+++ b/app/org/maproulette/models/dal/TaskClusterDAL.scala
@@ -155,7 +155,7 @@ class TaskClusterDAL @Inject() (override val db: Database, challengeDAL: Challen
       }
 
       val query =
-        s"""SELECT *, suggestedfix_geojson::TEXT as suggested_fix,
+        s"""SELECT *, cooperative_work_json::TEXT as cooperative_work,
                      ST_AsGeoJSON(tasks.location) AS location, tasks.priority
                      FROM (
                       SELECT ST_ClusterKMeans(tasks.location,
@@ -265,7 +265,7 @@ class TaskClusterDAL @Inject() (override val db: Database, challengeDAL: Challen
         s"""
           SELECT tasks.id, tasks.name, tasks.parent_id, c.name, tasks.instruction, tasks.status, tasks.mapped_on,
                  tasks.completed_time_spent, tasks.completed_by,
-                 tasks.bundle_id, tasks.is_bundle_primary, tasks.suggestedfix_geojson::TEXT as suggested_fix,
+                 tasks.bundle_id, tasks.is_bundle_primary, tasks.cooperative_work_json::TEXT as cooperative_work,
                  task_review.review_status, task_review.review_requested_by, task_review.reviewed_by, task_review.reviewed_at,
                  task_review.review_started_at,
                  ST_AsGeoJSON(tasks.location) AS location, priority,
@@ -287,7 +287,7 @@ class TaskClusterDAL @Inject() (override val db: Database, challengeDAL: Challen
         str("tasks.instruction") ~
         str("location") ~
         int("tasks.status") ~
-        get[Option[String]]("suggested_fix") ~
+        get[Option[String]]("cooperative_work") ~
         get[Option[DateTime]]("tasks.mapped_on") ~
         get[Option[Long]]("tasks.completed_time_spent") ~
         get[Option[Long]]("tasks.completed_by") ~
@@ -299,7 +299,7 @@ class TaskClusterDAL @Inject() (override val db: Database, challengeDAL: Challen
         int("tasks.priority") ~
         get[Option[Long]]("tasks.bundle_id") ~
         get[Option[Boolean]]("tasks.is_bundle_primary") map {
-        case id ~ name ~ parentId ~ parentName ~ instruction ~ location ~ status ~ suggestedFix ~ mappedOn ~
+        case id ~ name ~ parentId ~ parentName ~ instruction ~ location ~ status ~ cooperativeWork ~ mappedOn ~
               completedTimeSpent ~ completedBy ~ reviewStatus ~ reviewRequestedBy ~ reviewedBy ~ reviewedAt ~
               reviewStartedAt ~ priority ~ bundleId ~ isBundlePrimary =>
           val locationJSON = Json.parse(location)
@@ -321,7 +321,7 @@ class TaskClusterDAL @Inject() (override val db: Database, challengeDAL: Challen
             -1,
             Actions.ITEM_TYPE_TASK,
             status,
-            suggestedFix,
+            cooperativeWork,
             mappedOn,
             completedTimeSpent,
             completedBy,

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -62,7 +62,7 @@ class TaskReviewDAL @Inject() (
       get[Option[String]]("geo_location") ~
       get[Option[Int]]("tasks.status") ~
       get[Option[String]]("geo_json") ~
-      get[Option[String]]("suggested_fix") ~
+      get[Option[String]]("cooperative_work") ~
       get[Option[DateTime]]("tasks.mapped_on") ~
       get[Option[Long]]("tasks.completed_time_spent") ~
       get[Option[Long]]("tasks.completed_by") ~
@@ -82,11 +82,11 @@ class TaskReviewDAL @Inject() (
       get[Option[String]]("reviewed_by_username") ~
       get[Option[String]]("responses") map {
       case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ geojson ~
-            suggestedFix ~ mappedOn ~ completedTimeSpent ~ completedBy ~ reviewStatus ~ reviewRequestedBy ~
+            cooperativeWork ~ mappedOn ~ completedTimeSpent ~ completedBy ~ reviewStatus ~ reviewRequestedBy ~
             reviewedBy ~ reviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~ reviewClaimedAt ~ priority ~
             changesetId ~ bundleId ~ isBundlePrimary ~ challengeName ~ reviewRequestedByUsername ~
             reviewedByUsername ~ responses =>
-        val values = this.updateAndRetrieve(id, geojson, location, suggestedFix)
+        val values = this.updateAndRetrieve(id, geojson, location, cooperativeWork)
         model.TaskWithReview(
           Task(
             id,

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -470,13 +470,13 @@ class VirtualChallengeDAL @Inject() (
         case None    => ""
       }
       val pointParser = long("id") ~ str("name") ~ str("instruction") ~ str("location") ~
-        int("status") ~ get[Option[String]]("suggested_fix") ~ get[Option[DateTime]]("mapped_on") ~
+        int("status") ~ get[Option[String]]("cooperative_work") ~ get[Option[DateTime]]("mapped_on") ~
         get[Option[Long]]("completed_time_spent") ~ get[Option[Long]]("completed_by") ~
         get[Option[Int]]("review_status") ~ get[Option[Long]]("review_requested_by") ~
         get[Option[Long]]("reviewed_by") ~ get[Option[DateTime]]("reviewed_at") ~
         get[Option[DateTime]]("review_started_at") ~ int("priority") ~
         get[Option[Long]]("bundle_id") ~ get[Option[Boolean]]("is_bundle_primary") map {
-        case id ~ name ~ instruction ~ location ~ status ~ suggestedFix ~ mappedOn ~ completedTimeSpent ~
+        case id ~ name ~ instruction ~ location ~ status ~ cooperativeWork ~ mappedOn ~ completedTimeSpent ~
               completedBy ~ reviewStatus ~ reviewRequestedBy ~
               reviewedBy ~ reviewedAt ~ reviewStartedAt ~ priority ~ bundleId ~ isBundlePrimary =>
           val locationJSON = Json.parse(location)
@@ -498,7 +498,7 @@ class VirtualChallengeDAL @Inject() (
             -1,
             Actions.ITEM_TYPE_TASK,
             status,
-            suggestedFix,
+            cooperativeWork,
             mappedOn,
             completedTimeSpent,
             completedBy,
@@ -508,7 +508,7 @@ class VirtualChallengeDAL @Inject() (
             isBundlePrimary
           )
       }
-      SQL"""SELECT tasks.id, name, instruction, status, suggestedfix_geojson::TEXT as suggested_fix,
+      SQL"""SELECT tasks.id, name, instruction, status, cooperative_work_json::TEXT as cooperative_work,
                    mapped_on, completed_time_spent, completed_by, review_status, review_requested_by,
                    reviewed_by, reviewed_at, review_started_at, ST_AsGeoJSON(location) AS location, priority,
                    bundle_id, is_bundle_primary

--- a/conf/evolutions/default/61.sql
+++ b/conf/evolutions/default/61.sql
@@ -1,0 +1,300 @@
+# --- !Ups
+-- Rename suggested_fixes to cooperative_work
+ALTER TABLE tasks RENAME COLUMN suggestedfix_geojson to cooperative_work_json;;
+
+-- Rename has_suggested_fixes and change from boolean to int to track cooperative type
+ALTER TABLE challenges RENAME COLUMN has_suggested_fixes TO cooperative_type;;
+ALTER TABLE challenges ALTER cooperative_type DROP DEFAULT;;
+ALTER TABLE challenges ALTER cooperative_type TYPE INTEGER USING CASE WHEN cooperative_type=TRUE THEN 1 ELSE 0 END;;
+ALTER TABLE challenges ALTER cooperative_type SET DEFAULT 0;;
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change makes sure not to reset the task status if a task is disabled or declared a false positive
+DROP FUNCTION IF EXISTS update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp without time zone,integer,integer,integer,timestamp without time zone);;
+CREATE OR REPLACE FUNCTION update_task(task_name text,
+                                        task_parent_id bigint,
+                                        task_instruction text,
+                                        task_status integer,
+                                        geo_json jsonb,
+                                        cooperative_work jsonb DEFAULT NULL,
+                                        task_id bigint DEFAULT -1,
+                                        task_priority integer DEFAULT 0,
+                                        task_changeset_id bigint DEFAULT -1,
+                                        reset_interval text DEFAULT '7 days',
+                                        task_mapped_on timestamp DEFAULT NULL,
+                                        task_review_status integer DEFAULT NULL,
+                                        task_review_requested_by integer DEFAULT NULL,
+                                        task_reviewed_by integer DEFAULT NULL,
+                                        task_reviewed_at timestamp DEFAULT NULL
+                                      ) RETURNS integer as $$
+  DECLARE
+    update_id integer;;
+    update_modified timestamp without time zone;;
+    update_status integer;;
+    new_status integer;;
+    geojson_geom geometry;;
+  BEGIN
+    IF (SELECT task_id) = -1 THEN
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+    ELSE
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+    END IF;;
+    -- Only if task status is not null set/update it to the new status
+    IF task_status IS NOT NULL THEN
+      new_status := task_status;;
+    ELSE
+      new_status := update_status;;
+    END IF;;
+    -- only reset the status if the task is not currently disabled or set as a false positive and all other criteria is met.
+    IF update_status = task_status AND NOT (update_status = 9 OR update_status = 2) AND (SELECT AGE(NOW(), update_modified)) > reset_interval::INTERVAL THEN
+      new_status := 0;;
+    END IF;;
+    SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+    UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status, priority = task_priority,
+                     changeset_id = task_changeset_id, mapped_on = task_mapped_on, geojson = geo_json,
+                     cooperative_work_json = cooperative_work,
+                     location = ST_Centroid(geojson_geom),
+                     geom = geojson_geom
+                     WHERE id = update_id;;
+
+    -- Note in status actions if status has changed
+    -- Since only when someone with admin privileges to a challenge can call this update
+    -- to change the status we just set osm_user_id to -1 (thereby not impacting any user scores).
+    -- To determine who did the update check the actions table.
+    IF update_status != new_status THEN
+      INSERT INTO status_actions (osm_user_id, project_id, challenge_id, task_id, old_status, status)
+        VALUES (-1, (SELECT parent_id FROM challenges WHERE id = task_parent_id),
+                task_parent_id, update_id, update_status, new_status);;
+    END IF;;
+
+    --
+    -- Only update task_review table if we actually have a task_review_status otherwise we will
+    -- end up with weird empty rows. And if the new status is created we need to delete any requested review
+    --
+    IF task_review_status IS NOT NULL THEN
+      UPDATE task_review SET review_status = task_review_status, review_requested_by = task_review_requested_by,
+                             reviewed_by = task_reviewed_by, reviewed_at = task_reviewed_at WHERE task_review.task_id = update_id;;
+    ELSE IF new_status = 0 THEN
+        DELETE FROM task_review WHERE task_review.task_id = update_id;;
+      END IF;;
+    END IF;;
+    RETURN update_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change adds the mapped_on, review_status, review_requested_by, reviewed_by
+DROP FUNCTION IF EXISTS create_update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp,integer,integer,integer,timestamp);;
+CREATE FUNCTION create_update_task(task_name text,
+                                              task_parent_id bigint,
+                                              task_instruction text,
+                                              task_status integer,
+                                              geo_json jsonb,
+                                              cooperative_work jsonb DEFAULT NULL,
+                                              task_id bigint DEFAULT -1,
+                                              task_priority integer DEFAULT 0,
+                                              task_changeset_id bigint DEFAULT -1,
+                                              reset_interval text DEFAULT '7 days',
+                                              task_mapped_on timestamp DEFAULT NULL,
+                                              task_review_status integer DEFAULT NULL,
+                                              task_review_requested_by integer DEFAULT NULL,
+                                              task_reviewed_by integer DEFAULT NULL,
+                                              task_reviewed_at timestamp DEFAULT NULL) RETURNS integer as $$
+  DECLARE
+    return_id integer;;
+    geojson_geom geometry;;
+  BEGIN
+    return_id := task_id;;
+    IF (SELECT task_id) = -1 THEN
+      BEGIN
+        SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+
+        INSERT INTO tasks (name, parent_id, instruction, priority, geojson, location, geom, cooperative_work_json)
+        VALUES (task_name, task_parent_id, task_instruction, task_priority, geo_json, ST_Centroid(geojson_geom), geojson_geom, cooperative_work) RETURNING id INTO return_id;;
+        EXCEPTION WHEN UNIQUE_VIOLATION THEN
+        SELECT INTO return_id update_task(task_name, task_parent_id, task_instruction, task_status, geo_json, cooperative_work, task_id, task_priority,
+                                            task_changeset_id, reset_interval, task_mapped_on, task_review_status, task_review_requested_by, task_reviewed_by, task_reviewed_at);;
+      END;;
+    ELSE
+      PERFORM update_task(task_name, task_parent_id, task_instruction, task_status, geo_json, cooperative_work, task_id, task_priority,
+                            task_changeset_id, reset_interval, task_mapped_on, task_review_status, task_review_requested_by, task_reviewed_by, task_reviewed_at);;
+    END IF;;
+    RETURN return_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;
+
+DROP FUNCTION IF EXISTS update_geometry(bigint);;
+CREATE OR REPLACE FUNCTION update_geometry(task_identifier bigint)
+	RETURNS TABLE(geo TEXT, loc TEXT, fix_geo TEXT) AS $$
+BEGIN
+    UPDATE tasks t SET geojson = geoms.geometries FROM (SELECT ROW_TO_JSON(fc)::JSONB AS geometries
+                      FROM ( SELECT 'FeatureCollection' AS type, ARRAY_TO_JSON(array_agg(f)) AS features
+                               FROM ( SELECT 'Feature' AS type,
+                                              ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
+                                              HSTORE_TO_JSON(lg.properties) AS properties
+                                      FROM task_geometries AS lg
+                                      WHERE task_id = task_identifier
+                                ) AS f
+                        )  AS fc) AS geoms WHERE id = task_identifier;;
+    -- Update the geometry and location columns
+    UPDATE tasks t SET geom = geoms.geometry, location = ST_CENTROID(geoms.geometry)
+    FROM (SELECT ST_COLLECT(ST_MAKEVALID(geom)) AS geometry FROM (
+            SELECT geom FROM task_geometries WHERE task_id = task_identifier
+         ) AS innerQuery) AS geoms WHERE id = task_identifier;;
+	 RETURN QUERY SELECT geojson::TEXT, ST_AsGeoJSON(location) AS geo_location, cooperative_work_json::TEXT FROM tasks
+	 WHERE id = task_identifier;;
+END
+$$ LANGUAGE plpgsql VOLATILE;;
+
+# --- !Downs
+ALTER TABLE tasks RENAME COLUMN cooperative_work_json to suggestedfix_geojson;;
+ALTER TABLE challenges RENAME COLUMN cooperative_type to has_suggested_fixes;;
+ALTER TABLE challenges ALTER has_suggested_fixes DROP DEFAULT;;
+ALTER TABLE challenges ALTER has_suggested_fixes TYPE BOOLEAN USING CASE WHEN has_suggested_fixes > 0 then TRUE ELSE FALSE END;;
+ALTER TABLE challenges ALTER has_suggested_fixes SET DEFAULT FALSE;;
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change makes sure not to reset the task status if a task is disabled or declared a false positive
+DROP FUNCTION IF EXISTS update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp without time zone,integer,integer,integer,timestamp without time zone);;
+CREATE OR REPLACE FUNCTION update_task(task_name text,
+                                         task_parent_id bigint,
+                                         task_instruction text,
+                                         task_status integer,
+                                         geo_json jsonb,
+                                         suggestedfix jsonb DEFAULT NULL,
+                                         task_id bigint DEFAULT -1,
+                                         task_priority integer DEFAULT 0,
+                                         task_changeset_id bigint DEFAULT -1,
+                                         reset_interval text DEFAULT '7 days',
+                                         task_mapped_on timestamp DEFAULT NULL,
+                                         task_review_status integer DEFAULT NULL,
+                                         task_review_requested_by integer DEFAULT NULL,
+                                         task_reviewed_by integer DEFAULT NULL,
+                                         task_reviewed_at timestamp DEFAULT NULL
+                                       ) RETURNS integer as $$
+  DECLARE
+    update_id integer;;
+    update_modified timestamp without time zone;;
+    update_status integer;;
+    new_status integer;;
+    geojson_geom geometry;;
+  BEGIN
+    IF (SELECT task_id) = -1 THEN
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+    ELSE
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+    END IF;;
+    -- Only if task status is not null set/update it to the new status
+    IF task_status IS NOT NULL THEN
+      new_status := task_status;;
+    ELSE
+      new_status := update_status;;
+    END IF;;
+    -- only reset the status if the task is not currently disabled or set as a false positive and all other criteria is met.
+    IF update_status = task_status AND NOT (update_status = 9 OR update_status = 2) AND (SELECT AGE(NOW(), update_modified)) > reset_interval::INTERVAL THEN
+      new_status := 0;;
+    END IF;;
+    SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+    UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status, priority = task_priority,
+                     changeset_id = task_changeset_id, mapped_on = task_mapped_on, geojson = geo_json,
+                     suggestedfix_geojson = suggestedfix,
+                     location = ST_Centroid(geojson_geom),
+                     geom = geojson_geom
+                     WHERE id = update_id;;
+
+    -- Note in status actions if status has changed
+    -- Since only when someone with admin privileges to a challenge can call this update
+    -- to change the status we just set osm_user_id to -1 (thereby not impacting any user scores).
+    -- To determine who did the update check the actions table.
+    IF update_status != new_status THEN
+      INSERT INTO status_actions (osm_user_id, project_id, challenge_id, task_id, old_status, status)
+        VALUES (-1, (SELECT parent_id FROM challenges WHERE id = task_parent_id),
+                task_parent_id, update_id, update_status, new_status);;
+    END IF;;
+
+    --
+    -- Only update task_review table if we actually have a task_review_status otherwise we will
+    -- end up with weird empty rows. And if the new status is created we need to delete any requested review
+    --
+    IF task_review_status IS NOT NULL THEN
+      UPDATE task_review SET review_status = task_review_status, review_requested_by = task_review_requested_by,
+                             reviewed_by = task_reviewed_by, reviewed_at = task_reviewed_at WHERE task_review.task_id = update_id;;
+    ELSE IF new_status = 0 THEN
+        DELETE FROM task_review WHERE task_review.task_id = update_id;;
+      END IF;;
+    END IF;;
+    RETURN update_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change adds the mapped_on, review_status, review_requested_by, reviewed_by
+DROP FUNCTION IF EXISTS create_update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp without time zone,integer,integer,integer,timestamp without time zone);;
+CREATE FUNCTION create_update_task(task_name text,
+                                              task_parent_id bigint,
+                                              task_instruction text,
+                                              task_status integer,
+                                              geo_json jsonb,
+                                              suggestedfix jsonb DEFAULT NULL,
+                                              task_id bigint DEFAULT -1,
+                                              task_priority integer DEFAULT 0,
+                                              task_changeset_id bigint DEFAULT -1,
+                                              reset_interval text DEFAULT '7 days',
+                                              task_mapped_on timestamp DEFAULT NULL,
+                                              task_review_status integer DEFAULT NULL,
+                                              task_review_requested_by integer DEFAULT NULL,
+                                              task_reviewed_by integer DEFAULT NULL,
+                                              task_reviewed_at timestamp DEFAULT NULL) RETURNS integer as $$
+  DECLARE
+    return_id integer;;
+    geojson_geom geometry;;
+  BEGIN
+    return_id := task_id;;
+    IF (SELECT task_id) = -1 THEN
+      BEGIN
+        SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+
+        INSERT INTO tasks (name, parent_id, instruction, priority, geojson, location, geom, suggestedfix_geojson)
+        VALUES (task_name, task_parent_id, task_instruction, task_priority, geo_json, ST_Centroid(geojson_geom), geojson_geom, suggestedfix) RETURNING id INTO return_id;;
+        EXCEPTION WHEN UNIQUE_VIOLATION THEN
+        SELECT INTO return_id update_task(task_name, task_parent_id, task_instruction, task_status, geo_json, suggestedfix, task_id, task_priority,
+                                            task_changeset_id, reset_interval, task_mapped_on, task_review_status, task_review_requested_by, task_reviewed_by, task_reviewed_at);;
+      END;;
+    ELSE
+      PERFORM update_task(task_name, task_parent_id, task_instruction, task_status, geo_json, suggestedfix, task_id, task_priority,
+                            task_changeset_id, reset_interval, task_mapped_on, task_review_status, task_review_requested_by, task_reviewed_by, task_reviewed_at);;
+    END IF;;
+    RETURN return_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;
+
+DROP FUNCTION IF EXISTS update_geometry(bigint);;
+CREATE OR REPLACE FUNCTION update_geometry(task_identifier bigint)
+	RETURNS TABLE(geo TEXT, loc TEXT, fix_geo TEXT) AS $$
+BEGIN
+    UPDATE tasks t SET geojson = geoms.geometries FROM (SELECT ROW_TO_JSON(fc)::JSONB AS geometries
+                      FROM ( SELECT 'FeatureCollection' AS type, ARRAY_TO_JSON(array_agg(f)) AS features
+                               FROM ( SELECT 'Feature' AS type,
+                                              ST_AsGeoJSON(lg.geom)::JSONB AS geometry,
+                                              HSTORE_TO_JSON(lg.properties) AS properties
+                                      FROM task_geometries AS lg
+                                      WHERE task_id = task_identifier
+                                ) AS f
+                        )  AS fc) AS geoms WHERE id = task_identifier;;
+    -- Update the geometry and location columns
+    UPDATE tasks t SET geom = geoms.geometry, location = ST_CENTROID(geoms.geometry)
+    FROM (SELECT ST_COLLECT(ST_MAKEVALID(geom)) AS geometry FROM (
+            SELECT geom FROM task_geometries WHERE task_id = task_identifier
+         ) AS innerQuery) AS geoms WHERE id = task_identifier;;
+	 RETURN QUERY SELECT geojson::TEXT, ST_AsGeoJSON(location) AS geo_location, suggestedfix_geojson::TEXT FROM tasks
+	 WHERE id = task_identifier;;
+END
+$$ LANGUAGE plpgsql VOLATILE;;

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -205,6 +205,29 @@ GET     /task/:id                                   @org.maproulette.controllers
 #     description: The id of the Task to retrieve
 ###
 GET     /task/:id/start                               @org.maproulette.controllers.api.TaskController.startOnTask(id:Long)
+
+###
+# tags: [ Task ]
+# summary: Retrieve any change XML that is part of this task's cooperative work
+# produces: [ application/json ]
+# description: Retrieve change XML that is part of this task's cooperative work.
+#              The cooperative work on the task should be consulted to determine
+#              if any change exists for the task, and which change format was
+#              used (i.e. JOSM, OSMChange, etc).
+#
+# responses:
+#   '200':
+#     description: The change XML data
+#     schema:
+#       $ref: '#/definitions/org.maproulette.models.Task'
+#   '404':
+#     description: No Task found matching the id, or no change data found on the task
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Task for which change XML is desired
+###
+GET     /task/:id/cooperative/change                  @org.maproulette.controllers.api.TaskController.cooperativeWorkChangeXML(id:Long)
 ###
 # tags: [ Task ]
 # summary: Release a Task (unlocks it)

--- a/docs/tag_changes.md
+++ b/docs/tag_changes.md
@@ -1,6 +1,6 @@
 # OSM Changeset API
 
-This API in MapRoulette allows users to submit tag changes to the server, and then MapRoulette will attempt to conflate those changes with current data in OpenStreetMap. This API is primarily for support for the feature in MapRoulette called Suggested Fixes. Suggested fixes allow challenges to be created that ask the user if a change is valid or not. And if it is then MapRoulette can submit those changes directly to OpenStreetMap without the user having to make edits in JOSM or iD. This document however focuses on the API that is used to make those calls and what is going on behind the scenes and explain the workflow to the user.
+This API in MapRoulette allows users to submit tag changes to the server, and then MapRoulette will attempt to conflate those changes with current data in OpenStreetMap. This API primarily supports a type of "cooperative" task in which tag changes can be proposed in the task, and a MapRoulette mapper can determine if they are valid or not during task completion. If the proposed tag changes are correct then MapRoulette can submit those changes directly to OpenStreetMap without the user having to make edits in JOSM or iD. This document however focuses on the API that is used to make those calls and what is going on behind the scenes and explain the workflow to the user.
 
 ### Tag Changes
 

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -5812,7 +5812,7 @@
 			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "SuggestedFixes",
+			"name": "CooperativeWork",
 			"item": [
 				{
 					"name": "testChange Delta",
@@ -5882,7 +5882,7 @@
 								}
 							]
 						},
-						"description": "testing a sample suggested fix change"
+						"description": "testing a sample cooperative change"
 					},
 					"response": []
 				},
@@ -5968,7 +5968,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"SFChallenge\",\n    \"parent\": {{SimpleProjectID}},\n    \"description\":\"SFChallenge description\",\n    \"instruction\":\"SFChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"SF Task 1\",\n\t        \"suggestedFix\":  {\n        \t\t\"osmId\": 243499890,\n    \t\t\t\"osmType\": \"way\",\n        \t\t\"update\": {\n            \t\t\"tags\": {\n                \t\t\"update\": [{\"name\":\"building\", \"value\":\"yes\"}],            \n                \t\t\"delete\": [{\"name\":\"bldg\", \"ifUnused\":\"true\"}]\n        \t\t\t}\n    \t\t\t}\n    \t\t},\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\", \"building\": \"ok\", \"bldg\":\"y\"\n            }},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        }               \n    ]\n}\n"
+							"raw": "{\n    \"name\":\"SFChallenge\",\n    \"parent\": {{SimpleProjectID}},\n    \"description\":\"SFChallenge description\",\n    \"instruction\":\"SFChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"SF Task 1\",\n\t        \"cooperativeWork\":  {\n        \t\t\"osmId\": 243499890,\n    \t\t\t\"osmType\": \"way\",\n        \t\t\"update\": {\n            \t\t\"tags\": {\n                \t\t\"update\": [{\"name\":\"building\", \"value\":\"yes\"}],            \n                \t\t\"delete\": [{\"name\":\"bldg\", \"ifUnused\":\"true\"}]\n        \t\t\t}\n    \t\t\t}\n    \t\t},\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\", \"building\": \"ok\", \"bldg\":\"y\"\n            }},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        }               \n    ]\n}\n"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge",
@@ -6019,7 +6019,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\":\"SFEChallenge\",\n    \"parent\": {{SimpleProjectID}},\n    \"description\":\"SFEChallenge description\",\n    \"instruction\":\"SFEChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"SFE Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\", \"building\": \"ok\", \"bldg\":\"y\",\n            \t\"maproulette\": {\n            \t\t\"suggestedFix\":  {\n        \t\t\t\t\"update\": {\n            \t\t\t\t\"tags\": {\n                \t\t\t\t\"update\": [{\"name\":\"building\", \"value\":\"yes\"}],            \n                \t\t\t\t\"delete\": [{\"name\":\"bldg\", \"ifUnused\":\"true\"}]\n        \t\t\t\t\t}\n        \t\t\t\t}\n    \t\t\t\t}\n            \t}\n            }},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        }               \n    ]\n}\n"
+							"raw": "{\n    \"name\":\"SFEChallenge\",\n    \"parent\": {{SimpleProjectID}},\n    \"description\":\"SFEChallenge description\",\n    \"instruction\":\"SFEChallenge instruction\",\n    \"children\":[\n        {\n            \"name\":\"SFE Task 1\",\n            \"geometries\":{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.1,0.6]},\"properties\":{\"id\": \"test2\", \"building\": \"ok\", \"bldg\":\"y\",\n            \t\"maproulette\": {\n            \t\t\"cooperativeWork\":  {\n        \t\t\t\t\"update\": {\n            \t\t\t\t\"tags\": {\n                \t\t\t\t\"update\": [{\"name\":\"building\", \"value\":\"yes\"}],            \n                \t\t\t\t\"delete\": [{\"name\":\"bldg\", \"ifUnused\":\"true\"}]\n        \t\t\t\t\t}\n        \t\t\t\t}\n    \t\t\t\t}\n            \t}\n            }},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.2,0.7]},\"properties\":{}}]}\n        }               \n    ]\n}\n"
 						},
 						"url": {
 							"raw": "http://localhost:9000/api/v2/challenge",
@@ -6159,7 +6159,7 @@
 								}
 							]
 						},
-						"description": "testing a sample suggested fix change"
+						"description": "testing a sample cooperative change"
 					},
 					"response": []
 				},


### PR DESCRIPTION
* Rename suggested fixes and associated columns and fields to
"cooperative" variants

* Add support for v2 of cooperative challenge data format

* Continue to support legacy v1 format for existing suggested-fix
challenges

* Support two types of cooperative challenge to start: "tag fix" type
(formerly quick fix, behaves like v1 suggested fixes) and new
change-file type that allows a change file to be associated with the
cooperative task

* Add Challenge.COOPERATIVE_TYPE_* constants to track the types of
cooperative challenge, and store type in cooperative_type column
(formerly has_suggested_fix) on the challenge table, tracking the actual
type instead of just whether or not it is cooperative

* Add `task/:id/cooperative/change` API endpoint for retrieving change
file XML associated with a cooperative task