### PR TITLE
Add api to fetch list of challenges for review

### DIFF
--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -8,8 +8,9 @@ import javax.inject.Inject
 import org.maproulette.Config
 import org.maproulette.data.ActionManager
 import org.maproulette.exception.NotFoundException
-import org.maproulette.framework.model.{Challenge, User}
+import org.maproulette.framework.model.{Challenge, ChallengeListing, User, Project}
 import org.maproulette.framework.service.ServiceManager
+import org.maproulette.framework.psql.Paging
 import org.maproulette.models.Task
 import org.maproulette.models.dal._
 import org.maproulette.provider.websockets.WebSocketProvider
@@ -54,6 +55,8 @@ class TaskReviewController @Inject() (
       changeService,
       bodyParsers
     ) {
+
+  implicit val challengeListingWrites: Writes[ChallengeListing] = Json.writes[ChallengeListing]
 
   /**
     * Gets and claims a task that needs to be reviewed.
@@ -425,4 +428,77 @@ class TaskReviewController @Inject() (
     }
   }
 
+  /**
+    * Returns a list of challenges that have reviews/review requests.
+    *
+    * @param reviewTasksType  The type of reviews (1: To Be Reviewed,  2: User's reviewed Tasks, 3: All reviewed by users)
+    * @param tStatus The task statuses to include
+    * @param excludeOtherReviewers Whether tasks completed by other reviewers should be included
+    * @return JSON challenge list
+    */
+  def listChallenges(
+      reviewTasksType: Int,
+      tStatus: String,
+      excludeOtherReviewers: Boolean = false,
+      limit: Int,
+      page: Int
+  ): Action[AnyContent] =
+    Action.async { implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        val taskStatus = tStatus match {
+          case v if v.nonEmpty => Utils.toIntList(v)
+          case _               => None
+        }
+
+        val challenges = this.serviceManager.challengeListing.withReviewList(
+          reviewTasksType,
+          user,
+          taskStatus,
+          excludeOtherReviewers,
+          Paging(limit, page)
+        )
+
+        // Populate some parent/virtual parent project data
+        val projects = Some(
+          this.serviceManager.project
+            .list(challenges.map(c => c.parent))
+            .map(p => p.id -> p)
+            .toMap
+        )
+
+        var vpIds = scala.collection.mutable.Set[Long]()
+        challenges.map(c => {
+          c.virtualParents match {
+            case Some(vps) =>
+              vps.map(vp => vpIds += vp)
+            case _ => // do nothing
+          }
+        })
+        val vpObjects =
+          this.serviceManager.project.list(vpIds.toList).map(p => p.id -> p).toMap
+
+        val jsonList = challenges.map { c =>
+          val projectJson = Json
+            .toJson(projects.get(c.parent))
+            .as[JsObject] - Project.KEY_GROUPS
+
+          var updated =
+            Utils.insertIntoJson(Json.toJson(c), Challenge.KEY_PARENT, projectJson, true)
+          c.virtualParents match {
+            case Some(vps) =>
+              val vpJson =
+                Some(
+                  vps.map(vp => Json.toJson(vpObjects.get(vp)).as[JsObject] - Project.KEY_GROUPS)
+                )
+              updated = Utils.insertIntoJson(updated, Challenge.KEY_VIRTUAL_PARENTS, vpJson, true)
+            case _ => // do nothing
+          }
+          updated
+        }
+
+        Ok(
+          Json.toJson(jsonList)
+        )
+      }
+    }
 }

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.controller
+
+import javax.inject.Inject
+import org.maproulette.data.ActionManager
+import org.maproulette.framework.service.{ChallengeListingService, ProjectService}
+import org.maproulette.framework.psql.Paging
+import org.maproulette.framework.model.{Challenge, ChallengeListing, Project}
+import org.maproulette.session.SessionManager
+import org.maproulette.utils.Utils
+import play.api.mvc._
+import play.api.libs.json._
+
+/**
+  * TaskReviewController is responsible for handling functionality related to
+  * task reviews.
+  *
+  * @author krotstan
+  */
+class TaskReviewController @Inject() (
+    override val sessionManager: SessionManager,
+    override val actionManager: ActionManager,
+    override val bodyParsers: PlayBodyParsers,
+    challengeListingService: ChallengeListingService,
+    projectService: ProjectService,
+    components: ControllerComponents
+) extends AbstractController(components)
+    with MapRouletteController {
+
+  implicit val challengeListingWrites: Writes[ChallengeListing] = Json.writes[ChallengeListing]
+
+  /**
+    * Returns a list of challenges that have reviews/review requests.
+    *
+    * @param reviewTasksType  The type of reviews (1: To Be Reviewed,  2: User's reviewed Tasks, 3: All reviewed by users)
+    * @param tStatus The task statuses to include
+    * @param excludeOtherReviewers Whether tasks completed by other reviewers should be included
+    * @return JSON challenge list
+    */
+  def listChallenges(
+      reviewTasksType: Int,
+      tStatus: String,
+      excludeOtherReviewers: Boolean = false,
+      limit: Int,
+      page: Int
+  ): Action[AnyContent] =
+    Action.async { implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        val taskStatus = tStatus match {
+          case v if v.nonEmpty => Utils.toIntList(v)
+          case _               => None
+        }
+
+        val challenges = this.challengeListingService.withReviewList(
+          reviewTasksType,
+          user,
+          taskStatus,
+          excludeOtherReviewers,
+          Paging(limit, page)
+        )
+
+        // Populate some parent/virtual parent project data
+        val projects = Some(
+          this.projectService
+            .list(challenges.map(c => c.parent))
+            .map(p => p.id -> p)
+            .toMap
+        )
+
+        var vpIds = scala.collection.mutable.Set[Long]()
+        challenges.map(c => {
+          c.virtualParents match {
+            case Some(vps) =>
+              vps.map(vp => vpIds += vp)
+            case _ => // do nothing
+          }
+        })
+        val vpObjects =
+          this.projectService.list(vpIds.toList).map(p => p.id -> p).toMap
+
+        val jsonList = challenges.map { c =>
+          val projectJson = Json
+            .toJson(projects.get(c.parent))
+            .as[JsObject] - Project.KEY_GROUPS
+
+          var updated =
+            Utils.insertIntoJson(Json.toJson(c), Challenge.KEY_PARENT, projectJson, true)
+          c.virtualParents match {
+            case Some(vps) =>
+              val vpJson =
+                Some(
+                  vps.map(vp => Json.toJson(vpObjects.get(vp)).as[JsObject] - Project.KEY_GROUPS)
+                )
+              updated = Utils.insertIntoJson(updated, Challenge.KEY_VIRTUAL_PARENTS, vpJson, true)
+            case _ => // do nothing
+          }
+          updated
+        }
+
+        Ok(
+          Json.toJson(jsonList)
+        )
+      }
+    }
+}

--- a/app/org/maproulette/framework/model/SavedTasks.scala
+++ b/app/org/maproulette/framework/model/SavedTasks.scala
@@ -16,4 +16,5 @@ object SavedTasks extends CommonField {
   val FIELD_USER_ID      = "user_id"
   val FIELD_TASK_ID      = "task_id"
   val FIELD_CHALLENGE_ID = "challenge_id"
+  val FIELD_STATUS       = "status"
 }

--- a/app/org/maproulette/framework/repository/ChallengeListingRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeListingRepository.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.repository
+
+import java.sql.Connection
+
+import anorm.SqlParser.get
+import anorm.{RowParser, ~}
+import javax.inject.{Inject, Singleton}
+import org.apache.commons.lang3.StringUtils
+import org.joda.time.DateTime
+import org.maproulette.framework.model._
+import org.maproulette.framework.psql.{Paging, Query}
+import play.api.db.Database
+
+/**
+  * The challenge repository handles all the querying with the databases related to
+  * challenge list objects
+  *
+  * @author krotstan
+  */
+@Singleton
+class ChallengeListingRepository @Inject() (override val db: Database) extends RepositoryMixin {
+
+  /**
+    * Query function that allows a user to build their own query against the Challenge table
+    *
+    * @param query The query to execute
+    * @param c An implicit connection
+    * @return A list of returned Challenges
+    */
+  def query(query: Query)(implicit c: Option[Connection] = None): List[ChallengeListing] = {
+    withMRConnection { implicit c =>
+      query
+        .build(s"""SELECT ${ChallengeListingRepository.standardColumns} FROM challenges c
+          INNER JOIN projects p ON p.id = c.parent_id
+          INNER JOIN tasks t ON t.parent_id = c.id
+          LEFT OUTER JOIN task_review ON task_review.task_id = t.id
+          LEFT OUTER JOIN virtual_project_challenges vp ON c.id = vp.challenge_id
+          """)
+        .as(ChallengeListingRepository.parser.*)
+    }
+  }
+}
+
+object ChallengeListingRepository {
+  val standardColumns: String =
+    "c.id, c.parent_id, c.name, c.enabled, array_remove(array_agg(vp.project_id), NULL) AS virtual_parent_ids"
+
+  /**
+    * The row parser for Anorm to enable the object to be read from the retrieved row directly
+    * to the ChallengeListing object.
+    */
+  val parser: RowParser[ChallengeListing] = {
+    get[Long]("challenges.id") ~
+      get[Long]("challenges.parent_id") ~
+      get[String]("challenges.name") ~
+      get[Boolean]("challenges.enabled") ~
+      get[Option[Array[Long]]]("virtual_parent_ids") map {
+      case id ~ parent ~ name ~ enabled ~ virtualParents =>
+        ChallengeListing(id, parent, name, enabled, virtualParents)
+    }
+  }
+}

--- a/app/org/maproulette/framework/service/ChallengeListingService.scala
+++ b/app/org/maproulette/framework/service/ChallengeListingService.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import javax.inject.{Inject, Singleton}
+import org.maproulette.models.Task
+import org.maproulette.framework.model._
+import org.maproulette.framework.psql.Query
+import org.maproulette.framework.psql.filter.BaseParameter
+import org.maproulette.framework.repository.ChallengeListingRepository
+import org.maproulette.framework.psql.filter._
+import org.maproulette.framework.psql._
+import org.maproulette.framework.service.ServiceHelper
+
+/**
+  * Service layer for ChallengeListings to handle all the challenge listing business logic
+  *
+  * @author krotstan
+  */
+@Singleton
+class ChallengeListingService @Inject() (repository: ChallengeListingRepository)
+    extends ServiceHelper
+    with ServiceMixin[ChallengeListing] {
+  def retrieve(parentId: Long): Option[ChallengeListing] =
+    this.query(Query.simple(List(BaseParameter(Challenge.FIELD_PARENT_ID, parentId)))).headOption
+
+  def query(query: Query): List[ChallengeListing] = this.repository.query(query)
+
+  /**
+    * Returns a list of challenges that have reviews/review requests.
+    *
+    * @param reviewTasksType  The type of reviews (1: To Be Reviewed,  2: User's reviewed Tasks, 3: All reviewed by users)
+    * @param user The user making request (for challenge permission visibility)
+    * @param taskStatus The task statuses to include
+    * @param excludeOtherReviewers Whether tasks completed by other reviewers should be included
+    * @return A list of children listing objects
+    */
+  def withReviewList(
+      reviewTasksType: Int,
+      user: User,
+      taskStatus: Option[List[Int]] = None,
+      excludeOtherReviewers: Boolean = false,
+      paging: Paging = Paging()
+  ): List[ChallengeListing] = {
+    val filter =
+      Filter(
+        List(
+          FilterGroup(
+            List(
+              // Has a task review
+              BaseParameter("task_review.id", "", Operator.NULL, negate = true),
+              // Task Status in list if given a list of task statuses
+              FilterParameter.conditional(
+                "t.status",
+                taskStatus.getOrElse(List.empty),
+                Operator.IN,
+                includeOnlyIfTrue = taskStatus.nonEmpty
+              ),
+              // review_requested_by != user.id unless a super user
+              // to be reviewed tasks (review type = 1)
+              FilterParameter.conditional(
+                "task_review.review_requested_by",
+                user.id,
+                negate = true,
+                includeOnlyIfTrue = (reviewTasksType == 1) && !user.isSuperUser
+              ),
+              // reviewed_by == user.id for 'tasks reviewed by me' (review type = 3)
+              FilterParameter.conditional(
+                "task_review.reviewed_by",
+                user.id,
+                includeOnlyIfTrue = (reviewTasksType == 2)
+              ),
+              // reviewed_by == user.id for 'my reviewed tasks' (review type = 2)
+              FilterParameter.conditional(
+                "task_review.review_requested_by",
+                user.id,
+                includeOnlyIfTrue = (reviewTasksType == 3)
+              ),
+              // review status = requested or disputed if reviewTasksType = 1
+              FilterParameter.conditional(
+                "task_review.review_status",
+                List(Task.REVIEW_STATUS_REQUESTED, Task.REVIEW_STATUS_DISPUTED),
+                Operator.IN,
+                includeOnlyIfTrue = (reviewTasksType == 1)
+              )
+            )
+          ),
+          // Check project/challenge visiblity
+          this.challengeVisibilityFilter(user),
+          // reviewed_by is empty or user.id if excludeOtherReviewers
+          FilterGroup(
+            List(
+              BaseParameter("task_review.reviewed_by", "", Operator.NULL),
+              BaseParameter("task_review.reviewed_by", user.id)
+            ),
+            OR(),
+            (excludeOtherReviewers && reviewTasksType == 1)
+          )
+        )
+      )
+
+    val query = Query(
+      filter,
+      paging = paging,
+      grouping = Grouping("c.id")
+    )
+    this.query(query)
+  }
+}

--- a/app/org/maproulette/framework/service/ServiceHelper.scala
+++ b/app/org/maproulette/framework/service/ServiceHelper.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.service
+
+import org.maproulette.framework.model._
+import org.maproulette.framework.psql.filter._
+import org.maproulette.framework.psql.{Query, OR}
+
+/**
+  * Helper functions for services
+  *
+  */
+trait ServiceHelper {
+
+  /**
+    * Returns a FilterGroup that creates a subquery to filter challengs
+    * to include only ones visible to the user. Which includes:
+    *  - Both Project and Challenge are enabled
+    *  - Project is owned by the user
+    *  - User belongs to a user_group associated with the project
+    *  - Or user is a superUser
+    *
+    * @param - User to check visibility for.
+    */
+  def challengeVisibilityFilter(user: User): FilterGroup = {
+    // If !superUser
+    // s""" AND ((p.enabled AND c.enabled) OR
+    //       p.owner_id = ${user.osmProfile.id} OR
+    //       ${user.osmProfile.id} IN (SELECT ug.osm_user_id FROM user_groups ug, groups g
+    //                                  WHERE ug.group_id = g.id AND g.project_id = p.id))
+    FilterGroup(
+      List(
+        SubQueryFilter(
+          "",
+          Query.simple(
+            List(
+              BaseParameter("p.enabled", "", Operator.BOOL),
+              BaseParameter("c.enabled", "", Operator.BOOL)
+            ),
+            includeWhere = false
+          ),
+          operator = Operator.CUSTOM
+        ),
+        BaseParameter("p.owner_id", user.osmProfile.id),
+        SubQueryFilter(
+          user.osmProfile.id.toString,
+          Query.simple(
+            List(
+              BaseParameter("ug.group_id", "g.id", useValueDirectly = true),
+              BaseParameter("g.project_id", "p.id", useValueDirectly = true)
+            ),
+            base = "SELECT ug.osm_user_id FROM user_groups ug, groups g "
+          )
+        )
+      ),
+      OR(),
+      !user.isSuperUser
+    )
+  }
+}

--- a/app/org/maproulette/framework/service/ServiceManager.scala
+++ b/app/org/maproulette/framework/service/ServiceManager.scala
@@ -21,6 +21,7 @@ class ServiceManager @Inject() (
     userService: Provider[UserService],
     commentService: Provider[CommentService],
     challengeService: Provider[ChallengeService],
+    challengeListingService: Provider[ChallengeListingService],
     userMetricService: Provider[UserMetricService],
     virtualProjectService: Provider[VirtualProjectService]
 ) {
@@ -45,4 +46,6 @@ class ServiceManager @Inject() (
   def user: UserService = userService.get()
 
   def challenge: ChallengeService = challengeService.get()
+
+  def challengeListing: ChallengeListingService = challengeListingService.get()
 }

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -408,7 +408,7 @@ class TaskReviewDAL @Inject() (
     }
 
     val parameters = new ListBuffer[NamedParameter]()
-    parameters ++= addSearchToQuery(searchParameters, whereClause)
+    parameters ++= addSearchToQuery(searchParameters, whereClause)(false)
 
     setupReviewSearchClause(whereClause, joinClause, searchParameters, startDate, endDate)
 

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -208,7 +208,7 @@ trait DALHelper {
     if (!projectSearch) {
       params.getProjectIds match {
         case Some(p) if p.nonEmpty =>
-          whereClause ++= s"$challengePrefix.parent_id IN (${p.mkString(",")})"
+          appendInWhereClause(whereClause, s"$challengePrefix.parent_id IN (${p.mkString(",")})")
         case _ =>
           params.projectSearch match {
             case Some(ps) if ps.nonEmpty =>

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -454,6 +454,37 @@ GET     /challenges/preferred                             @org.maproulette.contr
 GET     /challenges                                 @org.maproulette.controllers.api.ChallengeController.list(limit:Int ?= 10, page:Int ?= 0, onlyEnabled:Boolean ?= false)
 ###
 # tags: [ Challenge ]
+# summary: List all the Challenges with review tasks.
+# produces: [ application/json ]
+# description: Lists all the Challenges in the system with review tasks.
+# responses:
+#   '200':
+#     description: A list of all the Challenges with review tasks
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.framework.model.Challenge'
+# parameters:
+#   - name: reviewTasksType
+#     in: query
+#     description: Limit challenges to reviews of type... 1/To Be Reviewed 2/User's reviewed Tasks 3/All reviewed by users
+#   - name: tStatus
+#     in: query
+#     description: Task statuses to include in search (default all statuses)
+#   - name: excludeOtherReviewers
+#     in: query
+#     description: Exclude reviews by completed by other reviewers (default true)
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /review/challenges                                 @org.maproulette.controllers.api.TaskReviewController.listChallenges(reviewTasksType:Int, tStatus:String ?= "", excludeOtherReviewers:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0)
+###
+# tags: [ Challenge ]
 # summary: List all the Challenges Tasks.
 # consumes: [ application/json ]
 # produces: [ application/json ]

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -482,7 +482,7 @@ GET     /challenges                                 @org.maproulette.controllers
 #     in: query
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
-GET     /review/challenges                                 @org.maproulette.controllers.api.TaskReviewController.listChallenges(reviewTasksType:Int, tStatus:String ?= "", excludeOtherReviewers:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0)
+GET     /review/challenges                                 @org.maproulette.framework.controller.TaskReviewController.listChallenges(reviewTasksType:Int, tStatus:String ?= "", excludeOtherReviewers:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0)
 ###
 # tags: [ Challenge ]
 # summary: List all the Challenges Tasks.

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -645,7 +645,7 @@ PUT     /taskBundle/:bundleId/:status                           @org.maproulette
 #     description: The ID of the task
 #   - name: status
 #     in: path
-#     description: The status to update the Task to. Following status Integers can be used. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted
+#     description: Will update a Tasks review status to one of the following. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted, 4 - Disputed, 5 - Unnecessary
 #   - name: comment
 #     in: query
 #     description: Any comment that is provided by the user when setting the review status

--- a/test/org/maproulette/framework/ChallengeListingSpec.scala
+++ b/test/org/maproulette/framework/ChallengeListingSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework
+import java.util.UUID
+
+import org.maproulette.models.Task
+import org.maproulette.framework.model._
+import org.maproulette.framework.psql.{Query, Grouping}
+import org.maproulette.framework.psql.filter.BaseParameter
+import org.maproulette.framework.repository.ChallengeListingRepository
+import org.maproulette.framework.service.ChallengeListingService
+import org.maproulette.framework.util.{ChallengeListingTag, FrameworkHelper}
+import play.api.Application
+
+/**
+  * @author krotstan
+  */
+class ChallengeListingSpec(implicit val application: Application) extends FrameworkHelper {
+  val repository: ChallengeListingRepository =
+    this.application.injector.instanceOf(classOf[ChallengeListingRepository])
+  val service: ChallengeListingService = this.serviceManager.challengeListing
+  var randomUser: User                 = null
+
+  "ChallengeListingRepository" should {
+    "make a basic query" taggedAs (ChallengeListingTag) in {
+      val challenges = this.repository.query(Query.simple(List(), grouping = Grouping("c.id")))
+      challenges.size mustEqual 11
+    }
+  }
+
+  "ChallengeListingService" should {
+    "make a basic query" taggedAs (ChallengeListingTag) in {
+      val challenges = this.service.query(
+        Query.simple(List(), grouping = Grouping("c.id"))
+      )
+      challenges.size mustEqual 11
+    }
+
+    "fetch challenges with reviews" taggedAs (ChallengeListingTag) in {
+      val challenges = this.service.withReviewList(1, User.superUser)
+      challenges.size mustEqual 1
+    }
+  }
+
+  override implicit val projectTestName: String = "ChallengeListingSpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    val createdReviewChallenge = this.challengeDAL
+      .insert(
+        Challenge(
+          -1,
+          "reviewChallenge",
+          null,
+          null,
+          general = ChallengeGeneral(
+            User.superUser.osmProfile.id,
+            this.defaultProject.id,
+            "TestChallengeInstruction"
+          ),
+          creation = ChallengeCreation(),
+          priority = ChallengePriority(),
+          extra = ChallengeExtra()
+        ),
+        User.superUser
+      )
+    val task = this.taskDAL
+      .insert(
+        this.getTestTask(UUID.randomUUID().toString, createdReviewChallenge.id),
+        User.superUser
+      )
+
+    randomUser = this.serviceManager.user.create(
+      this.getTestUser(12345, "RandomOUser"),
+      User.superUser
+    )
+    this.taskDAL.setTaskStatus(List(task), Task.STATUS_FIXED, randomUser, Some(true))
+  }
+}

--- a/test/org/maproulette/framework/FrameworkMasterSuite.scala
+++ b/test/org/maproulette/framework/FrameworkMasterSuite.scala
@@ -14,6 +14,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite, Suites}
 class FrameworkMasterSuite extends Suites with BeforeAndAfterAll with TestDatabase {
   private val suites = IndexedSeq(
     new ChallengeSpec,
+    new ChallengeListingSpec,
     new CommentSpec,
     new GroupSpec,
     new ProjectSpec,

--- a/test/org/maproulette/framework/util/FrameworkHelper.scala
+++ b/test/org/maproulette/framework/util/FrameworkHelper.scala
@@ -143,6 +143,7 @@ trait FrameworkHelper extends PlaySpec with BeforeAndAfterAll with MockitoSugar 
 
 // Test tags so that you only have to run specific tests
 object ChallengeTag        extends Tag("challenge")
+object ChallengeListingTag extends Tag("challengelisting")
 object ProjectTag          extends Tag("project")
 object CommentTag          extends Tag("comment")
 object GroupTag            extends Tag("group")

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -107,6 +107,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
   val groupService          = mock[GroupService]
   val commentService        = mock[CommentService]
   val challengeService      = mock[ChallengeService]
+  val challengeListingService      = mock[ChallengeListingService]
   val userMetricService     = mock[UserMetricService]
   val virtualProjectService = mock[VirtualProjectService]
   val serviceManager = new ServiceManager(
@@ -115,6 +116,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     Providers.of[UserService](userService),
     Providers.of[CommentService](commentService),
     Providers.of[ChallengeService](challengeService),
+    Providers.of[ChallengeListingService](challengeListingService),
     Providers.of[UserMetricService](userMetricService),
     Providers.of[VirtualProjectService](virtualProjectService)
   )

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -104,12 +104,12 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     taskClusterDAL,
     statusActionManager
   )
-  val groupService          = mock[GroupService]
-  val commentService        = mock[CommentService]
-  val challengeService      = mock[ChallengeService]
-  val challengeListingService      = mock[ChallengeListingService]
-  val userMetricService     = mock[UserMetricService]
-  val virtualProjectService = mock[VirtualProjectService]
+  val groupService            = mock[GroupService]
+  val commentService          = mock[CommentService]
+  val challengeService        = mock[ChallengeService]
+  val challengeListingService = mock[ChallengeListingService]
+  val userMetricService       = mock[UserMetricService]
+  val virtualProjectService   = mock[VirtualProjectService]
   val serviceManager = new ServiceManager(
     Providers.of[ProjectService](projectService),
     Providers.of[GroupService](groupService),


### PR DESCRIPTION
Add api '/review/challenges' which will fetch challenges that have tasks that have reviews/review requests. From this list, the front end will be able to narrow down the reviews to be returned to the user by challenge (or even by project) when fetching the full list of reviews.