### PR TITLE
Let client specify filename for XML change files

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -226,7 +226,7 @@ class TaskController @Inject() (
     * @param taskId     Id of task that you wish to start
     * @return
     */
-  def cooperativeWorkChangeXML(taskId: Long): Action[AnyContent] = Action.async {
+  def cooperativeWorkChangeXML(taskId: Long, filename: String): Action[AnyContent] = Action.async {
     implicit request =>
       val task = this.dal.retrieveById(taskId) match {
         case Some(t) => t
@@ -249,7 +249,7 @@ class TaskController @Inject() (
         Result(
           header = ResponseHeader(
             OK,
-            Map(CONTENT_DISPOSITION -> s"attachment; filename=task_${taskId}_proposed_change.xml")
+            Map(CONTENT_DISPOSITION -> s"attachment; filename=${filename}")
           ),
           body = HttpEntity.Strict(
             ByteString.fromString(xml),

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -226,8 +226,13 @@ GET     /task/:id/start                               @org.maproulette.controlle
 #   - name: id
 #     in: path
 #     description: The id of the Task for which change XML is desired
+#   - name: filename
+#     in: path
+#     description: A filename to use. Some editors will use this as a hint as
+#                  to the change format of the XML. Must be alphanumeric with optional
+#                  underscores, dashes, and dots.
 ###
-GET     /task/:id/cooperative/change                  @org.maproulette.controllers.api.TaskController.cooperativeWorkChangeXML(id:Long)
+GET     /task/:id/cooperative/change/$filename<\w[\w\d-_\.]*>            @org.maproulette.controllers.api.TaskController.cooperativeWorkChangeXML(id:Long, filename:String)
 ###
 # tags: [ Task ]
 # summary: Release a Task (unlocks it)


### PR DESCRIPTION
* Update the `task/:id/cooperative/change` API to accept a filename that
is now used when serving the cooperative XML change content

* This provides maximum flexibility for integrating with editors that
look for a filename portion in the URL and use it for hints as to the
format of the downloaded change XML