### PR TITLE
Adding random prefix to named parameters

### DIFF
--- a/app/org/maproulette/framework/psql/Paging.scala
+++ b/app/org/maproulette/framework/psql/Paging.scala
@@ -7,8 +7,7 @@ package org.maproulette.framework.psql
 
 import anorm.NamedParameter
 import org.maproulette.framework.psql.filter.SQLClause
-
-import scala.util.Random
+import org.maproulette.utils.Utils
 
 /**
   * Basic class that handles all the paging for a query
@@ -16,7 +15,7 @@ import scala.util.Random
   * @author mcuthbert
   */
 case class Paging(limit: Int = 0, page: Int = 0) extends SQLClause {
-  val randomPrefix: String = Random.nextInt(1000).toString
+  val randomPrefix: String = Utils.randomStringFromCharList(5)
 
   override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
     if (limit > 0) {

--- a/app/org/maproulette/framework/psql/Paging.scala
+++ b/app/org/maproulette/framework/psql/Paging.scala
@@ -8,27 +8,33 @@ package org.maproulette.framework.psql
 import anorm.NamedParameter
 import org.maproulette.framework.psql.filter.SQLClause
 
+import scala.util.Random
+
 /**
   * Basic class that handles all the paging for a query
   *
   * @author mcuthbert
   */
 case class Paging(limit: Int = 0, page: Int = 0) extends SQLClause {
+  val randomPrefix: String = Random.nextInt(1000).toString
+
   override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
     if (limit > 0) {
-      s"LIMIT {${parameterKey}limit} OFFSET {${parameterKey}offset}"
+      s"LIMIT {${keyPrefix}limit} OFFSET {${keyPrefix}offset}"
     } else {
       ""
     }
   }
+
+  private def keyPrefix(implicit parameterKey: String) = s"$parameterKey$randomPrefix"
 
   override def parameters()(
       implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
   ): List[NamedParameter] = {
     if (limit > 0) {
       List(
-        Symbol(s"${parameterKey}limit")  -> limit,
-        Symbol(s"${parameterKey}offset") -> page * limit
+        Symbol(s"${keyPrefix}limit")  -> limit,
+        Symbol(s"${keyPrefix}offset") -> page * limit
       )
     } else {
       List.empty

--- a/app/org/maproulette/framework/psql/Query.scala
+++ b/app/org/maproulette/framework/psql/Query.scala
@@ -22,7 +22,7 @@ object Query {
   val SECONDARY_QUERY_KEY = "secondary"
 
   //val config:Config
-  def devMode(): Boolean = false //config.isDebugMode || config.isDevMode
+  def devMode(): Boolean = true //config.isDebugMode || config.isDevMode
 
   def simple(
       parameters: List[Parameter[_]],
@@ -32,7 +32,7 @@ object Query {
       order: Order = Order(),
       grouping: Grouping = Grouping()
   ): Query =
-    Query(Filter(key, FilterGroup(key, parameters: _*)), base, paging, order, grouping)
+    Query(Filter(List(FilterGroup(parameters, key)), key), base, paging, order, grouping)
 }
 
 case class Query(

--- a/app/org/maproulette/framework/psql/SQLUtils.scala
+++ b/app/org/maproulette/framework/psql/SQLUtils.scala
@@ -32,7 +32,7 @@ object SQLUtils {
   // The set of characters that are allowed for column names, so that we can sanitize in unknown input
   // for protection against SQL injection
   private val ordinary =
-    (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ Seq('_') ++ Seq('.')).toSet
+    (('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ Seq('_') ++ Seq('.') ++ Seq('-')).toSet
 
   def testColumnName(columnName: String): Unit = {
     if (!columnName.forall(this.ordinary.contains)) {

--- a/app/org/maproulette/framework/psql/filter/Operator.scala
+++ b/app/org/maproulette/framework/psql/filter/Operator.scala
@@ -13,7 +13,7 @@ import org.maproulette.framework.psql.SQLUtils
   */
 object Operator extends Enumeration {
   type Operator = Value
-  val EQ, GT, GTE, LT, LTE, IN, LIKE, ILIKE, CUSTOM, BETWEEN, NULL, SIMILAR_TO, EXISTS = Value
+  val EQ, GT, GTE, LT, LTE, IN, LIKE, ILIKE, CUSTOM, BETWEEN, NULL, SIMILAR_TO, EXISTS, BOOL = Value
 
   def format(
       key: String,
@@ -32,17 +32,18 @@ object Operator extends Enumeration {
       case None    => s"{$parameterKey$key}"
     }
     operator match {
-      case EQ         => s"$negation$key = $rightValue"
-      case GT         => s"$negation$key > $rightValue"
-      case GTE        => s"$negation$key >= $rightValue"
-      case LT         => s"$negation$key < $rightValue"
-      case LTE        => s"$negation$key <= $rightValue"
-      case IN         => s"$negation$key IN ($rightValue)"
-      case LIKE       => s"$negation$key LIKE $rightValue"
-      case ILIKE      => s"$negation$key ILIKE $rightValue"
-      case NULL       => s"$key IS ${negation}NULL"
-      case SIMILAR_TO => s"$negation$key SIMILAR TO $rightValue"
-      case EXISTS     => s"${negation}EXISTS ($rightValue)"
+      case EQ            => s"$negation$key = $rightValue"
+      case GT            => s"$negation$key > $rightValue"
+      case GTE           => s"$negation$key >= $rightValue"
+      case LT            => s"$negation$key < $rightValue"
+      case LTE           => s"$negation$key <= $rightValue"
+      case IN            => s"$negation$key IN ($rightValue)"
+      case LIKE          => s"$negation$key LIKE $rightValue"
+      case ILIKE         => s"$negation$key ILIKE $rightValue"
+      case NULL          => s"$key IS ${negation}NULL"
+      case SIMILAR_TO    => s"$negation$key SIMILAR TO $rightValue"
+      case EXISTS        => s"${negation}EXISTS ($rightValue)"
+      case BOOL | CUSTOM => s"${negation}$key"
       case BETWEEN =>
         throw new InvalidException("Between operator not supported by standard filter")
     }

--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -9,6 +9,7 @@ import anorm.{NamedParameter, ToParameterValue}
 import org.joda.time.DateTime
 import org.maproulette.framework.psql.filter.Operator.Operator
 import org.maproulette.framework.psql.{Query, SQLUtils}
+import org.maproulette.utils.Utils
 
 import scala.util.Random
 
@@ -25,7 +26,7 @@ trait Parameter[T] extends SQLClause {
   val operator: Operator        = Operator.EQ
   val negate: Boolean           = false
   val useValueDirectly: Boolean = false
-  val randomPrefix: String      = Random.nextInt(1000).toString
+  val randomPrefix: String      = Utils.randomStringFromCharList(5)
 
   def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
     if (value.isInstanceOf[Iterable[_]] && value.asInstanceOf[Iterable[_]].isEmpty) {

--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -11,7 +11,7 @@ import org.maproulette.Config
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.framework.model.{StatusActions, TaskReview, User, UserMetrics}
 import org.maproulette.framework.psql.filter._
-import org.maproulette.framework.psql.{AND, OR, Query}
+import org.maproulette.framework.psql.{OR, Query}
 import org.maproulette.framework.repository.{TaskReviewRepository, UserRepository}
 import org.maproulette.models.Task
 import org.maproulette.permissions.Permission
@@ -92,21 +92,25 @@ class UserMetricService @Inject() (
     val reviewCounts = this.taskReviewRepository.getTaskReviewCounts(
       Query(
         Filter(
-          AND(),
-          FilterGroup(AND(), BaseParameter(TaskReview.FIELD_REVIEW_REQUESTED_BY, userId)),
-          FilterGroup(
-            AND(),
-            BaseParameter(
-              TaskReview.FIELD_REVIEW_STATUS,
-              Task.REVIEW_STATUS_UNNECESSARY,
-              Operator.EQ,
-              true
+          List(
+            FilterGroup(List(BaseParameter(TaskReview.FIELD_REVIEW_REQUESTED_BY, userId))),
+            FilterGroup(
+              List(
+                BaseParameter(
+                  TaskReview.FIELD_REVIEW_STATUS,
+                  Task.REVIEW_STATUS_UNNECESSARY,
+                  Operator.EQ,
+                  true
+                )
+              )
+            ),
+            FilterGroup(
+              List(
+                reviewTimeClause,
+                BaseParameter(TaskReview.FIELD_REVIEWED_AT, null, Operator.NULL)
+              ),
+              OR()
             )
-          ),
-          FilterGroup(
-            OR(),
-            reviewTimeClause,
-            BaseParameter(TaskReview.FIELD_REVIEWED_AT, null, Operator.NULL)
           )
         )
       )

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -27,7 +27,7 @@ object Utils extends DefaultWrites {
   def randomStringFromCharList(
       length: Int,
       chars: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z')
-                              ): String =
+  ): String =
     (1 to length).foldLeft("")((previous, _) => {
       val randomNum = Random.nextInt(chars.length)
       previous + chars(randomNum)

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -15,7 +15,7 @@ import play.api.mvc.Results._
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Random, Success, Try}
 
 /**
   * Some random utliity helper functions
@@ -23,6 +23,15 @@ import scala.util.{Failure, Success, Try}
   * @author cuthbertm
   */
 object Utils extends DefaultWrites {
+
+  def randomStringFromCharList(
+      length: Int,
+      chars: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z')
+                              ): String =
+    (1 to length).foldLeft("")((previous, _) => {
+      val randomNum = Random.nextInt(chars.length)
+      previous + chars(randomNum)
+    })
 
   def getProperties(value: JsValue, key: String): JsValue = {
     (value \ key).asOpt[JsObject] match {

--- a/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
@@ -97,6 +97,10 @@ class FilterOperatorSpec extends PlaySpec {
       Operator.format(KEY, Operator.EXISTS, negate = true) mustEqual s"NOT EXISTS ({$parameterKey$KEY})"
     }
 
+    "format BOOL operator correctly" in {
+      Operator.format(KEY, Operator.BOOL) mustEqual s"key"
+    }
+
     "format rightValue correctly if set" in {
       Operator.format(KEY, Operator.EQ, value = Some("test.key")) mustEqual s"$KEY = test.key"
     }

--- a/test/org/maproulette/framework/psql/FilterParameterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterParameterSpec.scala
@@ -9,31 +9,36 @@ import java.sql.SQLException
 
 import anorm.NamedParameter
 import org.joda.time.{DateTime, Months}
+import org.maproulette.framework.model.User
 import org.maproulette.framework.psql.filter._
+import org.maproulette.models.Task
 import org.scalatestplus.play.PlaySpec
 
 /**
   * @author mcuthbert
   */
 class FilterParameterSpec extends PlaySpec {
-  val KEY   = "KEY"
-  val VALUE = "VALUE"
+  val KEY                           = "KEY"
+  val VALUE                         = "VALUE"
+  implicit val parameterKey: String = ""
 
   "BaseParameter" should {
     "set correctly" in {
-      val filter = BaseParameter(KEY, VALUE)
-      filter.sql() mustEqual s"$KEY = {$KEY}"
-      val params = filter.parameters()
+      val parameter = BaseParameter(KEY, VALUE)
+      parameter.sql() mustEqual s"$KEY = {${parameter.getKey}}"
+      val params = parameter.parameters()
       params.size mustEqual 1
-      params.head mustEqual NamedParameter(s"$KEY", VALUE)
+      params.head mustEqual NamedParameter(s"${parameter.getKey}", VALUE)
     }
 
     "set operator correctly" in {
-      BaseParameter(KEY, VALUE, Operator.GT).sql() mustEqual s"$KEY > {$KEY}"
+      val parameter = BaseParameter(KEY, VALUE, Operator.GT)
+      parameter.sql() mustEqual s"$KEY > {${parameter.getKey}}"
     }
 
     "set negation correctly" in {
-      BaseParameter(KEY, VALUE, negate = true).sql() mustEqual s"NOT $KEY = {$KEY}"
+      val parameter = BaseParameter(KEY, VALUE, negate = true)
+      parameter.sql() mustEqual s"NOT $KEY = {${parameter.getKey}}"
     }
 
     "set negation correctly on Custom operator" in {
@@ -52,7 +57,8 @@ class FilterParameterSpec extends PlaySpec {
     }
 
     "set list correctly using IN operator" in {
-      BaseParameter(KEY, List(1, 2, 3), Operator.IN).sql() mustEqual s"$KEY IN ({$KEY})"
+      val parameter = BaseParameter(KEY, List(1, 2, 3), Operator.IN)
+      parameter.sql() mustEqual s"$KEY IN ({${parameter.getKey}})"
     }
 
     "do not set empty list" in {
@@ -65,10 +71,10 @@ class FilterParameterSpec extends PlaySpec {
   "ConditionalFilter" should {
     "set correctly if condition true" in {
       val filter = FilterParameter.conditional(KEY, VALUE, includeOnlyIfTrue = true)
-      filter.sql() mustEqual s"$KEY = {$KEY}"
+      filter.sql() mustEqual s"$KEY = {${filter.filter.getKey}}"
       val params = filter.parameters()
       params.size mustEqual 1
-      params.head mustEqual NamedParameter(s"$KEY", VALUE)
+      params.head mustEqual NamedParameter(filter.filter.getKey, VALUE)
     }
 
     "not set if condition is false" in {
@@ -76,15 +82,14 @@ class FilterParameterSpec extends PlaySpec {
     }
 
     "set operator correctly" in {
-      FilterParameter
-        .conditional(KEY, VALUE, Operator.LT, includeOnlyIfTrue = true)
-        .sql() mustEqual s"$KEY < {$KEY}"
+      val parameter = FilterParameter.conditional(KEY, VALUE, Operator.LT, includeOnlyIfTrue = true)
+      parameter.sql() mustEqual s"$KEY < {${parameter.filter.getKey}}"
     }
 
     "set negation correctly" in {
-      FilterParameter
-        .conditional(KEY, VALUE, negate = true, includeOnlyIfTrue = true)
-        .sql() mustEqual s"NOT $KEY = {$KEY}"
+      val parameter =
+        FilterParameter.conditional(KEY, VALUE, negate = true, includeOnlyIfTrue = true)
+      parameter.sql() mustEqual s"NOT $KEY = {${parameter.filter.getKey}}"
     }
 
     "set value directly correctly" in {
@@ -104,31 +109,34 @@ class FilterParameterSpec extends PlaySpec {
     "set single start date correctly" in {
       val startDate = DateTime.now()
       val filter    = DateParameter(KEY, startDate, null)
-      filter.sql() mustEqual s"$KEY = {$KEY}"
+      filter.sql() mustEqual s"$KEY = {${filter.getKey}}"
       val params = filter.parameters()
       params.size mustEqual 1
-      params.head mustEqual SQLUtils.buildNamedParameter(s"$KEY", startDate)
+      params.head mustEqual SQLUtils.buildNamedParameter(filter.getKey, startDate)
     }
 
     "set two dates correctly" in {
       val endDate   = DateTime.now()
       val startDate = endDate.minus(Months.ONE)
       val filter    = DateParameter(KEY, startDate, endDate, Operator.BETWEEN)
-      filter.sql() mustEqual s"$KEY::DATE BETWEEN {${KEY}_date1} AND {${KEY}_date2}"
+      filter
+        .sql() mustEqual s"$KEY::DATE BETWEEN {${filter.getKey}_date1} AND {${filter.getKey}_date2}"
       val params = filter.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(s"${KEY}_date1", startDate)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(s"${KEY}_date2", endDate)
+      params.head mustEqual SQLUtils.buildNamedParameter(s"${filter.getKey}_date1", startDate)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(s"${filter.getKey}_date2", endDate)
     }
 
     "set negate correctly on two dates" in {
-      DateParameter(
+      val parameter = DateParameter(
         KEY,
         DateTime.now(),
         DateTime.now(),
         Operator.BETWEEN,
         negate = true
-      ).sql() mustEqual s"$KEY::DATE NOT BETWEEN {${KEY}_date1} AND {${KEY}_date2}"
+      )
+      parameter
+        .sql() mustEqual s"$KEY::DATE NOT BETWEEN {${parameter.getKey}_date1} AND {${parameter.getKey}_date2}"
     }
 
     "fail on invalid provided column" in {
@@ -140,70 +148,67 @@ class FilterParameterSpec extends PlaySpec {
 
   "SubQueryFilter" should {
     "Set standard subquery filter" in {
+      val parameter = BaseParameter("Key2", "value2")
       val filter = SubQueryFilter(
         KEY,
-        Query.simple(List(BaseParameter("Key2", "value2")), "SELECT * FROM table")
+        Query.simple(List(parameter), "SELECT * FROM table")
       )
       filter
-        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE Key2 = {${Query.SECONDARY_QUERY_KEY}Key2})"
+        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE Key2 = {${Query.SECONDARY_QUERY_KEY}${parameter.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 1
       params.head mustEqual SQLUtils.buildNamedParameter(
-        s"${Query.SECONDARY_QUERY_KEY}Key2",
+        s"${Query.SECONDARY_QUERY_KEY}${parameter.getKey}",
         "value2"
       )
     }
 
     "Set standard subquery filter with two parameters" in {
-      val filter = SubQueryFilter(
-        KEY,
-        Query.simple(
-          List(
-            BaseParameter("key2", "value2"),
-            BaseParameter("key3", "value3", Operator.LTE)
-          ),
-          "SELECT * FROM table",
-          OR()
-        )
-      )
+      val parameter1 = BaseParameter("key2", "value2")
+      val parameter2 = BaseParameter("key3", "value3", Operator.LTE)
+      val filter =
+        SubQueryFilter(KEY, Query.simple(List(parameter1, parameter2), "SELECT * FROM table", OR()))
       filter
-        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE key2 = {${Query.SECONDARY_QUERY_KEY}key2} OR key3 <= {${Query.SECONDARY_QUERY_KEY}key3})"
+        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE key2 = {${Query.SECONDARY_QUERY_KEY}${parameter1.getKey}} OR key3 <= {${Query.SECONDARY_QUERY_KEY}${parameter2.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 2
       params.head mustEqual SQLUtils.buildNamedParameter(
-        s"${Query.SECONDARY_QUERY_KEY}key2",
+        s"${Query.SECONDARY_QUERY_KEY}${parameter1.getKey}",
         "value2"
       )
       params.tail.head mustEqual SQLUtils.buildNamedParameter(
-        s"${Query.SECONDARY_QUERY_KEY}key3",
+        s"${Query.SECONDARY_QUERY_KEY}${parameter2.getKey}",
         "value3"
       )
     }
 
     "Set exists subquery filter" in {
+      val parameter = BaseParameter("key2", "value2")
       val filter = SubQueryFilter(
         KEY,
-        Query.simple(List(BaseParameter("key2", "value2")), "SELECT * FROM table"),
+        Query.simple(List(parameter), "SELECT * FROM table"),
         operator = Operator.EXISTS
       )
       filter
-        .sql() mustEqual s"EXISTS (SELECT * FROM table WHERE key2 = {${Query.SECONDARY_QUERY_KEY}key2})"
+        .sql() mustEqual s"EXISTS (SELECT * FROM table WHERE key2 = {${Query.SECONDARY_QUERY_KEY}${parameter.getKey}})"
     }
 
     "Set equals subquery filter" in {
+      val parameter = BaseParameter("key2", "value2")
       val filter = SubQueryFilter(
         KEY,
-        Query.simple(List(BaseParameter("key2", "value2")), "SELECT * FROM table"),
+        Query.simple(List(parameter), "SELECT * FROM table"),
         operator = Operator.EQ
       )
       filter
-        .sql() mustEqual s"$KEY = (SELECT * FROM table WHERE key2 = {${Query.SECONDARY_QUERY_KEY}key2})"
+        .sql() mustEqual s"$KEY = (SELECT * FROM table WHERE key2 = {${Query.SECONDARY_QUERY_KEY}${parameter.getKey}})"
     }
 
     "set custom parameterKey correctly" in {
+      val parameter = BaseParameter(KEY, VALUE)
       val filter =
-        SubQueryFilter(KEY, Query.simple(List(BaseParameter(KEY, VALUE)), "SELECT * FROM table"))
-      filter.sql()("custom") mustEqual s"$KEY IN (SELECT * FROM table WHERE KEY = {custom$KEY})"
+        SubQueryFilter(KEY, Query.simple(List(parameter), "SELECT * FROM table"))
+      filter.sql()("custom") mustEqual s"$KEY IN (SELECT * FROM table WHERE KEY = {${parameter.getKey("custom")}})"
     }
 
     "fail on invalid provided column" in {
@@ -227,25 +232,35 @@ class FilterParameterSpec extends PlaySpec {
   "FuzzySearchParameter" should {
     "sets all the correct values for fuzzy searches" in {
       val filter = FuzzySearchParameter(KEY, VALUE)
-      filter.sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY)
+      filter
+        .sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY, keyPrefix = filter.randomPrefix)
       val params = filter.parameters()
       params.size mustEqual 1
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
+      params.head mustEqual SQLUtils.buildNamedParameter(filter.getKey, VALUE)
     }
 
     "sets fuzzy search with default levenshstein score if less than 1" in {
       val filter = FuzzySearchParameter(KEY, VALUE, 0)
-      filter.sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY)
+      filter
+        .sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY, keyPrefix = filter.randomPrefix)
     }
 
     "sets fuzzy search with custom levenshstein score" in {
       val filter = FuzzySearchParameter(KEY, VALUE, 56)
-      filter.sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY, score = 56)
+      filter.sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(
+        KEY,
+        score = 56,
+        keyPrefix = filter.randomPrefix
+      )
     }
 
     "sets fuzzy search with custom metaphone size" in {
       val filter = FuzzySearchParameter(KEY, VALUE, metaphoneSize = 67)
-      filter.sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY, size = 67)
+      filter.sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(
+        KEY,
+        size = 67,
+        keyPrefix = filter.randomPrefix
+      )
     }
 
     "fail on invalid provided column" in {
@@ -261,10 +276,11 @@ object FilterParameterSpec {
       key: String,
       parameterKey: String = Query.PRIMARY_QUERY_KEY,
       score: Int = FilterParameter.DEFAULT_LEVENSHSTEIN_SCORE,
-      size: Int = FilterParameter.DEFAULT_METAPHONE_SIZE
+      size: Int = FilterParameter.DEFAULT_METAPHONE_SIZE,
+      keyPrefix: String = ""
   ) = s"""($key <> '' AND
-      (LEVENSHTEIN(LOWER($key), LOWER({$key})) < $score OR
-      METAPHONE(LOWER($key), 4) = METAPHONE(LOWER({$key}), $size) OR
-      SOUNDEX(LOWER($key)) = SOUNDEX(LOWER({$key})))
+      (LEVENSHTEIN(LOWER($key), LOWER({$keyPrefix$key})) < $score OR
+      METAPHONE(LOWER($key), 4) = METAPHONE(LOWER({$keyPrefix$key}), $size) OR
+      SOUNDEX(LOWER($key)) = SOUNDEX(LOWER({$keyPrefix$key})))
       )"""
 }

--- a/test/org/maproulette/framework/psql/FilterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterSpec.scala
@@ -5,87 +5,87 @@
 
 package org.maproulette.framework.psql
 
-import org.maproulette.framework.psql.filter.{BaseParameter, Filter, FilterGroup, FilterParameter}
+import org.maproulette.framework.psql.filter.{BaseParameter, Filter, FilterGroup, Parameter}
 import org.scalatestplus.play.PlaySpec
 
 /**
   * @author mcuthbert
   */
 class FilterSpec extends PlaySpec {
-  val KEY    = "KEY"
-  val VALUE  = "VALUE"
-  val KEY2   = "KEY2"
-  val VALUE2 = "VALUE2"
+  val KEY                           = "KEY"
+  val VALUE                         = "VALUE"
+  val KEY2                          = "KEY2"
+  val VALUE2                        = "VALUE2"
+  implicit val parameterKey: String = ""
+  val parameter1: Parameter[String] = BaseParameter(KEY, VALUE)
+  val parameter2: Parameter[String] = BaseParameter(KEY2, VALUE2)
+  val parameter3: Parameter[String] = BaseParameter(s"${KEY}_1", VALUE)
+  val parameter4: Parameter[String] = BaseParameter(s"${KEY2}_2", VALUE2)
 
   "FilterGroup" should {
     "Create a group of AND filters parameters" in {
-      val group =
-        FilterGroup(AND(), BaseParameter(KEY, VALUE), BaseParameter(KEY2, VALUE2))
-      group.sql() mustEqual "KEY = {KEY} AND KEY2 = {KEY2}"
+      val group = FilterGroup(List(parameter1, parameter2))
+      group.sql() mustEqual s"KEY = {${parameter1.getKey}} AND KEY2 = {${parameter2.getKey}}"
       val params = group.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(KEY2, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
     }
 
     "Create a group of OR filter parameters" in {
       val group =
-        FilterGroup(OR(), BaseParameter(KEY, VALUE), BaseParameter(KEY2, VALUE2))
-      group.sql() mustEqual "KEY = {KEY} OR KEY2 = {KEY2}"
+        FilterGroup(List(parameter1, parameter2), OR())
+      group.sql() mustEqual s"KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}}"
       val params = group.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(KEY2, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
     }
   }
 
   "Filter" should {
     "generate standard sql for AND parameters" in {
-      val filter = Filter.simple(
-        List(BaseParameter(KEY, VALUE), BaseParameter(KEY2, VALUE2)),
-        AND()
-      )
-      filter.sql() mustEqual "KEY = {KEY} AND KEY2 = {KEY2}"
+      val filter = Filter.simple(List(parameter1, parameter2), AND())
+      filter.sql() mustEqual s"KEY = {${parameter1.getKey}} AND KEY2 = {${parameter2.getKey}}"
       val params = filter.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(KEY2, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
     }
 
     "generate standard sql for OR parameters" in {
-      val filter = Filter.simple(
-        List(BaseParameter(KEY, VALUE), BaseParameter(KEY2, VALUE2)),
-        OR()
-      )
-      filter.sql() mustEqual "KEY = {KEY} OR KEY2 = {KEY2}"
+      val filter = Filter.simple(List(parameter1, parameter2), OR())
+      filter.sql() mustEqual s"KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}}"
       val params = filter.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(KEY2, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
     }
 
     "generate filter groups for AND parameters" in {
       val filter = this.genericFilter(AND(), AND(), AND())
-      filter.sql() mustEqual "(KEY = {KEY} AND KEY_1 = {KEY_1}) AND (KEY2 = {KEY2} AND KEY2_2 = {KEY2_2})"
+      filter
+        .sql() mustEqual s"(KEY = {${parameter1.getKey}} AND KEY_1 = {${parameter3.getKey}}) AND (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 4
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-      params(1) mustEqual SQLUtils.buildNamedParameter(s"${KEY}_1", VALUE)
-      params(2) mustEqual SQLUtils.buildNamedParameter(KEY2, VALUE2)
-      params(3) mustEqual SQLUtils.buildNamedParameter(s"${KEY2}_2", VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
+      params(1) mustEqual SQLUtils.buildNamedParameter(parameter3.getKey, VALUE)
+      params(2) mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
+      params(3) mustEqual SQLUtils.buildNamedParameter(parameter4.getKey, VALUE2)
     }
 
     "generate filter groups for OR parameters" in {
       val filter = this.genericFilter(OR(), OR(), OR())
       filter
-        .sql() mustEqual "(KEY = {KEY} OR KEY_1 = {KEY_1}) OR (KEY2 = {KEY2} OR KEY2_2 = {KEY2_2})"
+        .sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}}) OR (KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }
 
     "generate filter groups for AND/OR/AND parameters" in {
       val filter = this.genericFilter(OR(), AND(), AND())
-      filter.sql() mustEqual "(KEY = {KEY} AND KEY_1 = {KEY_1}) OR (KEY2 = {KEY2} AND KEY2_2 = {KEY2_2})"
+      filter
+        .sql() mustEqual s"(KEY = {${parameter1.getKey}} AND KEY_1 = {${parameter3.getKey}}) OR (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -93,7 +93,7 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR/AND/OR parameters" in {
       val filter = this.genericFilter(AND(), OR(), OR())
       filter
-        .sql() mustEqual "(KEY = {KEY} OR KEY_1 = {KEY_1}) AND (KEY2 = {KEY2} OR KEY2_2 = {KEY2_2})"
+        .sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}}) AND (KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -101,7 +101,7 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR/OR/AND parameters" in {
       val filter = this.genericFilter(OR(), OR(), AND())
       filter
-        .sql() mustEqual "(KEY = {KEY} OR KEY_1 = {KEY_1}) OR (KEY2 = {KEY2} AND KEY2_2 = {KEY2_2})"
+        .sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}}) OR (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -109,17 +109,11 @@ class FilterSpec extends PlaySpec {
 
   private def genericFilter(key: SQLKey, group1Key: SQLKey, group2Key: SQLKey): Filter = {
     Filter(
-      key,
-      FilterGroup(
-        group1Key,
-        BaseParameter(KEY, VALUE),
-        BaseParameter(s"${KEY}_1", VALUE)
+      List(
+        FilterGroup(List(parameter1, parameter3), group1Key),
+        FilterGroup(List(parameter2, parameter4), group2Key)
       ),
-      FilterGroup(
-        group2Key,
-        BaseParameter(KEY2, VALUE2),
-        BaseParameter(s"${KEY2}_2", VALUE2)
-      )
+      key
     )
   }
 }

--- a/test/org/maproulette/framework/psql/PagingSpec.scala
+++ b/test/org/maproulette/framework/psql/PagingSpec.scala
@@ -21,20 +21,22 @@ class PagingSpec extends PlaySpec {
 
     "set to limit greater than zero" in {
       val paging = Paging(10000)
-      paging.sql() mustEqual "LIMIT {limit} OFFSET {offset}"
+      paging
+        .sql() mustEqual s"LIMIT {${paging.randomPrefix}limit} OFFSET {${paging.randomPrefix}offset}"
       val params = paging.parameters()
       params.size mustEqual 2
-      params.head mustEqual NamedParameter("limit", 10000)
-      params.tail.head mustEqual NamedParameter("offset", 0)
+      params.head mustEqual NamedParameter(s"${paging.randomPrefix}limit", 10000)
+      params.tail.head mustEqual NamedParameter(s"${paging.randomPrefix}offset", 0)
     }
 
     "set to limit and offset multiplied by limit" in {
       val paging = Paging(100, 5)
-      paging.sql() mustEqual "LIMIT {limit} OFFSET {offset}"
+      paging
+        .sql() mustEqual s"LIMIT {${paging.randomPrefix}limit} OFFSET {${paging.randomPrefix}offset}"
       val params = paging.parameters()
       params.size mustEqual 2
-      params.head mustEqual NamedParameter("limit", 100)
-      params.tail.head mustEqual NamedParameter("offset", 500)
+      params.head mustEqual NamedParameter(s"${paging.randomPrefix}limit", 100)
+      params.tail.head mustEqual NamedParameter(s"${paging.randomPrefix}offset", 500)
     }
   }
 }

--- a/test/org/maproulette/framework/psql/QuerySpec.scala
+++ b/test/org/maproulette/framework/psql/QuerySpec.scala
@@ -13,131 +13,148 @@ import org.scalatestplus.play.PlaySpec
   * @author mcuthbert
   */
 class QuerySpec extends PlaySpec {
-  val KEY   = "KEY"
-  val VALUE = "VALUE"
+  val KEY                          = "KEY"
+  val VALUE                        = "VALUE"
+  val parameter: Parameter[String] = BaseParameter(KEY, VALUE)
+  val setKey: String               = s"${parameter.randomPrefix}$KEY"
 
   "Query" should {
     "build standard query" in {
-      val query = Query.simple(List(BaseParameter(KEY, VALUE)), "SELECT * FROM table")
-      query.sql() mustEqual "SELECT * FROM table WHERE KEY = {KEY}"
+      val query = Query.simple(List(parameter), "SELECT * FROM table")
+      query.sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey}"
       val params = query.parameters()
       params.size mustEqual 1
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
+      params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
     }
 
     "build standard query with paging" in {
-      val query = Query.simple(
-        List(BaseParameter(KEY, VALUE)),
-        "SELECT * FROM table",
-        paging = Paging(10, 2)
-      )
-      query.sql() mustEqual "SELECT * FROM table WHERE KEY = {KEY} LIMIT {limit} OFFSET {offset}"
+      val paging       = Paging(10, 2)
+      val pagingPrefix = paging.randomPrefix
+      val query        = Query.simple(List(parameter), "SELECT * FROM table", paging = paging)
+      query
+        .sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey} LIMIT {${pagingPrefix}limit} OFFSET {${pagingPrefix}offset}"
       val params = query.parameters()
       params.size mustEqual 3
-      params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-      params(1) mustEqual SQLUtils.buildNamedParameter("limit", 10)
-      params(2) mustEqual SQLUtils.buildNamedParameter("offset", 20)
+      params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
+      params(1) mustEqual SQLUtils.buildNamedParameter(s"${pagingPrefix}limit", 10)
+      params(2) mustEqual SQLUtils.buildNamedParameter(s"${pagingPrefix}offset", 20)
     }
 
     "build standard query with ordering" in {
       val query = Query.simple(
-        List(BaseParameter(KEY, VALUE)),
+        List(parameter),
         "SELECT * FROM table",
         order = Order.simple("test", Order.ASC)
       )
-      query.sql() mustEqual "SELECT * FROM table WHERE KEY = {KEY} ORDER BY test ASC"
+      query.sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey} ORDER BY test ASC"
       query.parameters().size mustEqual 1
     }
   }
 
   "build standard query with grouping" in {
     val query = Query.simple(
-      List(BaseParameter(KEY, VALUE)),
+      List(parameter),
       "SELECT * FROM table",
       grouping = Grouping("test1", "test2")
     )
-    query.sql() mustEqual "SELECT * FROM table WHERE KEY = {KEY} GROUP BY test1,test2"
+    query.sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey} GROUP BY test1,test2"
     query.parameters().size mustEqual 1
   }
 
   "build standard query with all extras" in {
+    val paging       = Paging(10, 5)
+    val pagingPrefix = paging.randomPrefix
     val query = Query.simple(
-      List(BaseParameter(KEY, VALUE)),
+      List(parameter),
       "SELECT * FROM table",
       AND(),
-      Paging(10, 5),
+      paging,
       Order.simple("order"),
       Grouping("test1")
     )
-    query.sql() mustEqual "SELECT * FROM table WHERE KEY = {KEY} GROUP BY test1 ORDER BY order DESC LIMIT {limit} OFFSET {offset}"
+    query
+      .sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey} GROUP BY test1 ORDER BY order DESC LIMIT {${pagingPrefix}limit} OFFSET {${pagingPrefix}offset}"
     val params = query.parameters()
     params.size mustEqual 3
-    params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-    params(1) mustEqual SQLUtils.buildNamedParameter("limit", 10)
-    params(2) mustEqual SQLUtils.buildNamedParameter("offset", 50)
+    params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
+    params(1) mustEqual SQLUtils.buildNamedParameter(s"${pagingPrefix}limit", 10)
+    params(2) mustEqual SQLUtils.buildNamedParameter(s"${pagingPrefix}offset", 50)
   }
 
   "build complex query" in {
-    val firstDate  = DateTime.now()
-    val secondDate = DateTime.now()
+    implicit val parameterKey = ""
+    val firstDate             = DateTime.now()
+    val secondDate            = DateTime.now()
+    val parameter2            = BaseParameter("key2", "value2")
+    val parameter3            = CustomParameter("a.g = g.a")
+    val parameter4            = DateParameter("dateField", firstDate, secondDate, Operator.BETWEEN)
+    val parameter5            = FuzzySearchParameter("fuzzy", "fuzzyValue")
+    val parameter6            = BaseParameter("subsubKey", "subsubValue")
+    val paging1               = Paging(10)
+    val paging2               = Paging(35, 15)
     val query = Query(
       Filter(
-        AND(),
-        FilterGroup(OR(), BaseParameter(KEY, VALUE), BaseParameter("key2", "value2")),
-        FilterGroup(
-          OR(),
-          CustomParameter("a.g = g.a"),
-          DateParameter("dateField", firstDate, secondDate, Operator.BETWEEN)
-        ),
-        FilterGroup(
-          AND(),
-          FuzzySearchParameter("fuzzy", "fuzzyValue"),
-          SubQueryFilter(
-            "subQueryKey",
-            Query.simple(
-              List(BaseParameter("subsubKey", "subsubValue")),
-              "SELECT * FROM subTable",
-              paging = Paging(10)
+        List(
+          FilterGroup(List(parameter, parameter2), OR()),
+          FilterGroup(List(parameter3, parameter4), OR()),
+          FilterGroup(
+            List(
+              parameter5,
+              SubQueryFilter(
+                "subQueryKey",
+                Query.simple(
+                  List(parameter6),
+                  "SELECT * FROM subTable",
+                  paging = paging1
+                )
+              )
             )
           )
         )
       ),
       "SELECT * FROM table",
-      paging = Paging(35, 15),
+      paging = paging2,
       order = Order.simple("oField")
     )
 
     query
-      .sql() mustEqual s"SELECT * FROM table WHERE (KEY = {KEY} OR key2 = {key2}) AND (a.g = g.a OR dateField::DATE BETWEEN {dateField_date1} AND {dateField_date2}) AND (${FilterParameterSpec.DEFAULT_FUZZY_SQL("fuzzy")} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {secondarysubsubKey} LIMIT {secondarylimit} OFFSET {secondaryoffset})) ORDER BY oField DESC LIMIT {limit} OFFSET {offset}"
+      .sql() mustEqual s"SELECT * FROM table WHERE (KEY = {$setKey} OR key2 = {${parameter2.getKey}}) AND (a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2}) AND (${FilterParameterSpec
+      .DEFAULT_FUZZY_SQL("fuzzy", keyPrefix = parameter5.randomPrefix)} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {secondary${parameter6.getKey}} LIMIT {secondary${paging1.randomPrefix}limit} OFFSET {secondary${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"
     val params = query.parameters()
     params.size mustEqual 10
-    params.head mustEqual SQLUtils.buildNamedParameter(KEY, VALUE)
-    params(1) mustEqual SQLUtils.buildNamedParameter("key2", "value2")
-    params(2) mustEqual SQLUtils.buildNamedParameter("dateField_date1", firstDate)
-    params(3) mustEqual SQLUtils.buildNamedParameter("dateField_date2", secondDate)
-    params(4) mustEqual SQLUtils.buildNamedParameter("fuzzy", "fuzzyValue")
-    params(5) mustEqual SQLUtils.buildNamedParameter("secondarysubsubKey", "subsubValue")
-    params(6) mustEqual SQLUtils.buildNamedParameter("secondarylimit", 10)
-    params(7) mustEqual SQLUtils.buildNamedParameter("secondaryoffset", 0)
-    params(8) mustEqual SQLUtils.buildNamedParameter("limit", 35)
-    params(9) mustEqual SQLUtils.buildNamedParameter("offset", 525)
+    params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
+    params(1) mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, "value2")
+    params(2) mustEqual SQLUtils.buildNamedParameter(s"${parameter4.getKey}_date1", firstDate)
+    params(3) mustEqual SQLUtils.buildNamedParameter(s"${parameter4.getKey}_date2", secondDate)
+    params(4) mustEqual SQLUtils.buildNamedParameter(
+      s"${parameter5.randomPrefix}fuzzy",
+      "fuzzyValue"
+    )
+    params(5) mustEqual SQLUtils.buildNamedParameter(
+      s"secondary${parameter6.getKey}",
+      "subsubValue"
+    )
+    params(6) mustEqual SQLUtils.buildNamedParameter(s"secondary${paging1.randomPrefix}limit", 10)
+    params(7) mustEqual SQLUtils.buildNamedParameter(s"secondary${paging1.randomPrefix}offset", 0)
+    params(8) mustEqual SQLUtils.buildNamedParameter(s"${paging2.randomPrefix}limit", 35)
+    params(9) mustEqual SQLUtils.buildNamedParameter(s"${paging2.randomPrefix}offset", 525)
   }
 
   "handle input base query correctly when no base set" in {
     Query
-      .simple(List(BaseParameter(KEY, VALUE)))
-      .sqlWithBaseQuery("SELECT * FROM projects") mustEqual s"SELECT * FROM projects WHERE $KEY = {$KEY}"
+      .simple(List(parameter))
+      .sqlWithBaseQuery("SELECT * FROM projects") mustEqual s"SELECT * FROM projects WHERE $KEY = {$setKey}"
   }
 
   "handle input base query correctly when base is set" in {
     Query
-      .simple(List(BaseParameter(KEY, VALUE)), "SELECT * FROM challenges")
-      .sqlWithBaseQuery("SELECT * FROM projects") mustEqual s"SELECT * FROM challenges WHERE $KEY = {$KEY}"
+      .simple(List(parameter), "SELECT * FROM challenges")
+      .sqlWithBaseQuery("SELECT * FROM projects") mustEqual s"SELECT * FROM challenges WHERE $KEY = {$setKey}"
   }
 
   "handle input base query correctly when base is set and forced to base" in {
     Query
-      .simple(List(BaseParameter(KEY, VALUE)), "SELECT * FROM projects")
-      .sqlWithBaseQuery("SELECT * FROM challenges") mustEqual s"SELECT * FROM projects WHERE $KEY = {$KEY}"
+      .simple(List(parameter), "SELECT * FROM projects")
+      .sqlWithBaseQuery("SELECT * FROM challenges") mustEqual s"SELECT * FROM projects WHERE $KEY = {$setKey}"
   }
 }


### PR DESCRIPTION
- Needed to add a random prefix to named parameters so that if you are using the same column for multiple queries that there is no clash. 
- Also cleaned up the Query building case classes a bit to try make them a little less confusing.
- Added conditional for filter group in case you want to exclude/include an entire filter group based on some condition.