### PR TITLE
Updating SubQueryFilter

### DIFF
--- a/app/org/maproulette/framework/psql/Query.scala
+++ b/app/org/maproulette/framework/psql/Query.scala
@@ -30,9 +30,17 @@ object Query {
       key: SQLKey = AND(),
       paging: Paging = Paging(),
       order: Order = Order(),
-      grouping: Grouping = Grouping()
+      grouping: Grouping = Grouping(),
+      includeWhere: Boolean = true
   ): Query =
-    Query(Filter(List(FilterGroup(parameters, key)), key), base, paging, order, grouping)
+    Query(
+      Filter(List(FilterGroup(parameters, key)), key),
+      base,
+      paging,
+      order,
+      grouping,
+      includeWhere
+    )
 }
 
 case class Query(
@@ -40,7 +48,8 @@ case class Query(
     base: String = "",
     paging: Paging = Paging(),
     order: Order = Order(),
-    grouping: Grouping = Grouping()
+    grouping: Grouping = Grouping(),
+    includeWhere: Boolean = true
 ) extends SQLClause {
   def build(
       baseQuery: String = ""
@@ -65,8 +74,8 @@ case class Query(
       baseQuery: String = ""
   )(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
     val filterQuery = filter.sql() match {
-      case x if x.nonEmpty => s"WHERE $x"
-      case x               => x
+      case x if x.nonEmpty & includeWhere => s"WHERE $x"
+      case x                              => x
     }
     val pagingQuery = paging.sql()
     val start = base match {

--- a/app/org/maproulette/framework/psql/filter/Operator.scala
+++ b/app/org/maproulette/framework/psql/filter/Operator.scala
@@ -32,20 +32,20 @@ object Operator extends Enumeration {
       case None    => s"{$parameterKey$key}"
     }
     operator match {
-      case EQ            => s"$negation$key = $rightValue"
-      case GT            => s"$negation$key > $rightValue"
-      case GTE           => s"$negation$key >= $rightValue"
-      case LT            => s"$negation$key < $rightValue"
-      case LTE           => s"$negation$key <= $rightValue"
-      case IN            => s"$negation$key IN ($rightValue)"
-      case LIKE          => s"$negation$key LIKE $rightValue"
-      case ILIKE         => s"$negation$key ILIKE $rightValue"
-      case NULL          => s"$key IS ${negation}NULL"
-      case SIMILAR_TO    => s"$negation$key SIMILAR TO $rightValue"
-      case EXISTS        => s"${negation}EXISTS ($rightValue)"
-      case BOOL | CUSTOM => s"${negation}$key"
-      case BETWEEN =>
-        throw new InvalidException("Between operator not supported by standard filter")
+      case EQ         => s"$negation$key = $rightValue"
+      case GT         => s"$negation$key > $rightValue"
+      case GTE        => s"$negation$key >= $rightValue"
+      case LT         => s"$negation$key < $rightValue"
+      case LTE        => s"$negation$key <= $rightValue"
+      case IN         => s"$negation$key IN ($rightValue)"
+      case LIKE       => s"$negation$key LIKE $rightValue"
+      case ILIKE      => s"$negation$key ILIKE $rightValue"
+      case NULL       => s"$key IS ${negation}NULL"
+      case SIMILAR_TO => s"$negation$key SIMILAR TO $rightValue"
+      case EXISTS     => s"${negation}EXISTS ($rightValue)"
+      case BOOL       => s"${negation}$key"
+      case _ =>
+        throw new InvalidException("Operator not supported by standard filter")
     }
   }
 }

--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -161,12 +161,16 @@ case class SubQueryFilter(
     override val operator: Operator = Operator.IN
 ) extends Parameter[Query] {
   override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
-    val filterValue = if (operator == Operator.IN || operator == Operator.EXISTS) {
-      Some(value.sql()(this.getParameterKey))
+    if (operator == Operator.CUSTOM) {
+      s"(${value.sql()(this.getParameterKey)})"
     } else {
-      Some(s"(${value.sql()(this.getParameterKey)})")
+      val filterValue = if (operator == Operator.IN || operator == Operator.EXISTS) {
+        Some(value.sql()(this.getParameterKey))
+      } else {
+        Some(s"(${value.sql()(this.getParameterKey)})")
+      }
+      Operator.format(key, operator, negate, filterValue)(getKeyPrefix)
     }
-    Operator.format(key, operator, negate, filterValue)(getKeyPrefix)
   }
 
   // This may work for a single subquery, but there may be issues if you have more than one subquery


### PR DESCRIPTION
The subqueryfilter added
- Ability to ignore the "WHERE" clause
- Fixes the filter such that if the key is empty it will still include the filter sql value correctly.