### PR TITLE
Don't change virtual status of project on update

### DIFF
--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -291,6 +291,7 @@ class ProjectService @Inject() (
           case Some(f) => f
           case None    => cachedItem.featured
         }
+        val isVirtual = cachedItem.isVirtual // Don't allow updates to virtual status
 
         this.repository.update(
           Project(
@@ -300,6 +301,7 @@ class ProjectService @Inject() (
             displayName = Some(displayName),
             description = Some(description),
             enabled = enabled,
+            isVirtual = isVirtual,
             featured = featured
           )
         )

--- a/test/org/maproulette/framework/ProjectSpec.scala
+++ b/test/org/maproulette/framework/ProjectSpec.scala
@@ -214,6 +214,29 @@ class ProjectSpec(implicit val application: Application) extends FrameworkHelper
       update4.get.enabled mustEqual true
     }
 
+    "update cannot change virtual status" taggedAs (ProjectTag) in {
+      val randomUser =
+        this.serviceManager.user.create(this.getTestUser(9876, "RANDOM_USER"), User.superUser)
+      val updateProject = this.service
+        .create(
+          Project(
+            -1,
+            randomUser.osmProfile.id,
+            "ChangeVirtualStatusProject",
+            isVirtual = Some(true)
+          ),
+          User.superUser
+        )
+      // Update that omits isVirtual
+      val update1 =
+        this.service.update(updateProject.id, Json.obj("featured" -> true), randomUser)
+      update1.get.isVirtual.get mustEqual true
+      // Update that explicitly tries to change isVirtual
+      val update2 = this.service
+        .update(updateProject.id, Json.obj("featured" -> false, "isVirtual" -> false), randomUser)
+      update2.get.isVirtual.get mustEqual true
+    }
+
     "delete a project" taggedAs (ProjectTag) in {
       val createdProject = this.service
         .create(Project(-1, User.superUser.osmProfile.id, "DeleteTestProject"), User.superUser)


### PR DESCRIPTION
* Change ProjectService to use a project's existing virtual status when
updating a project rather than simply ommiting it, as that would cause
the virtual status to be updated to the default value of false

* Add unit test verifying that ProjectService doesn't update virtual
status

* Fixes osmlab/maproulette3#1207