### PR TITLE
Implicit Table for Queries

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -859,7 +859,7 @@ class ChallengeController @Inject() (
       val jsonList = challenges.map { c =>
         var updated = Utils.insertIntoJson(
           Json.toJson(c),
-          Tag.KEY,
+          Tag.TABLE,
           Json.toJson(tags.getOrElse(c.id, List.empty).map(_.name))
         )
         val projectJson = Json
@@ -1013,7 +1013,7 @@ class ChallengeController @Inject() (
     */
   override def inject(obj: Challenge)(implicit request: Request[Any]): JsValue = {
     val tags = this.tagService.listByChallenge(obj.id)
-    Utils.insertIntoJson(Json.toJson(obj), Tag.KEY, Json.toJson(tags.map(_.name)))
+    Utils.insertIntoJson(Json.toJson(obj), Tag.TABLE, Json.toJson(tags.map(_.name)))
   }
 
   /**

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -405,7 +405,7 @@ class TaskController @Inject() (
     }
 
     val tags = this.tagService.listByTask(taskToReturn.id)
-    Utils.insertIntoJson(Json.toJson(taskToReturn), Tag.KEY, Json.toJson(tags.map(_.name)))
+    Utils.insertIntoJson(Json.toJson(taskToReturn), Tag.TABLE, Json.toJson(tags.map(_.name)))
   }
 
   /**

--- a/app/org/maproulette/framework/graphql/schemas/CommentSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/CommentSchema.scala
@@ -75,8 +75,8 @@ class CommentSchema @Inject() (override val service: CommentService)
       arguments = MRSchema.idArg :: CommentSchema.taskIdArg :: Nil,
       resolve = context =>
         this.service.delete(
-          context.arg(MRSchema.idArg),
           context.arg(CommentSchema.taskIdArg),
+          context.arg(MRSchema.idArg),
           context.ctx.user
         )
     ),

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -227,6 +227,7 @@ object Challenge extends CommonField {
   val COOPERATIVE_CHANGEFILE = 2
 
   // CHALLENGE FIELDS
+  val TABLE           = "challenges"
   val FIELD_PARENT_ID = "parent_id"
   val FIELD_ENABLED   = "enabled"
 

--- a/app/org/maproulette/framework/model/Comment.scala
+++ b/app/org/maproulette/framework/model/Comment.scala
@@ -33,6 +33,7 @@ object Comment extends CommonField {
   implicit val writes: Writes[Comment] = Json.writes[Comment]
   implicit val reads: Reads[Comment]   = Json.reads[Comment]
 
+  val TABLE              = "task_comments"
   val FIELD_OSM_ID       = "osm_id"
   val FIELD_OSM_USERNAME = "name"
   val FIELD_TASK_ID      = "task_id"

--- a/app/org/maproulette/framework/model/Group.scala
+++ b/app/org/maproulette/framework/model/Group.scala
@@ -22,6 +22,8 @@ object Group extends CommonField {
   implicit val writes: Writes[Group] = Json.writes[Group]
   implicit val reads: Reads[Group]   = Json.reads[Group]
 
+  val TABLE                = "groups"
+  val TABLE_USER_GROUP     = "user_groups"
   val FIELD_GROUP_TYPE     = "group_type"
   val FIELD_PROJECT_ID     = "project_id"
   val FIELD_UG_OSM_USER_ID = "osm_user_id"

--- a/app/org/maproulette/framework/model/Project.scala
+++ b/app/org/maproulette/framework/model/Project.scala
@@ -39,6 +39,7 @@ object Project extends CommonField {
   implicit val writes: Writes[Project]    = Json.writes[Project]
   implicit val reads: Reads[Project]      = Json.reads[Project]
 
+  val TABLE              = "projects"
   val KEY_GROUPS         = "groups"
   val FIELD_OWNER        = "owner_id"
   val FIELD_ENABLED      = "enabled"

--- a/app/org/maproulette/framework/model/SavedChallenge.scala
+++ b/app/org/maproulette/framework/model/SavedChallenge.scala
@@ -11,6 +11,8 @@ import org.maproulette.framework.psql.CommonField
   * @author mcuthbert
   */
 object SavedChallenge extends CommonField {
+  val TABLE = "saved_challenges"
+
   val FIELD_USER_ID      = "user_id"
   val FIELD_CHALLENGE_ID = "challenge_id"
 }

--- a/app/org/maproulette/framework/model/SavedTasks.scala
+++ b/app/org/maproulette/framework/model/SavedTasks.scala
@@ -13,6 +13,8 @@ import org.maproulette.framework.psql.CommonField
   * @author mcuthbert
   */
 object SavedTasks extends CommonField {
+  val TABLE = "saved_tasks"
+
   val FIELD_USER_ID      = "user_id"
   val FIELD_TASK_ID      = "task_id"
   val FIELD_CHALLENGE_ID = "challenge_id"

--- a/app/org/maproulette/framework/model/StatusActions.scala
+++ b/app/org/maproulette/framework/model/StatusActions.scala
@@ -11,6 +11,8 @@ import org.maproulette.framework.psql.CommonField
   * @author mcuthbert
   */
 object StatusActions extends CommonField {
+  val TABLE = "status_actions"
+
   val FIELD_OSM_USER_ID  = "osm_user_id"
   val FIELD_PROJECT_ID   = "project_id"
   val FIELD_CHALLENGE_ID = "challenge_id"

--- a/app/org/maproulette/framework/model/Tag.scala
+++ b/app/org/maproulette/framework/model/Tag.scala
@@ -31,10 +31,12 @@ object Tag extends CommonField {
   implicit val tagWrites: Writes[Tag] = Json.writes[Tag]
   implicit val tagReads: Reads[Tag]   = Json.reads[Tag]
 
-  val KEY                = "tags"
-  val FIELD_TAG_TYPE     = "tag_type"
-  val FIELD_PARENT_ID    = "parent_id"
-  val FIELD_ENABLED      = "enabled"
-  val FIELD_TASK_ID      = "task_id"
-  val FIELD_CHALLENGE_ID = "challenge_id"
+  val TABLE                    = "tags"
+  val TABLE_TAGS_ON_TASKS      = "tags_on_tasks"
+  val TABLE_TAGS_ON_CHALLENGES = "tags_on_challenges"
+  val FIELD_TAG_TYPE           = "tag_type"
+  val FIELD_PARENT_ID          = "parent_id"
+  val FIELD_ENABLED            = "enabled"
+  val FIELD_TASK_ID            = "task_id"
+  val FIELD_CHALLENGE_ID       = "challenge_id"
 }

--- a/app/org/maproulette/framework/model/TaskReview.scala
+++ b/app/org/maproulette/framework/model/TaskReview.scala
@@ -5,6 +5,7 @@
 package org.maproulette.framework.model
 
 import org.joda.time.DateTime
+import org.maproulette.framework.psql.CommonField
 import org.maproulette.models.Task
 import play.api.libs.json.{Json, Reads, Writes}
 import play.api.libs.json.JodaWrites._
@@ -25,10 +26,11 @@ case class TaskReview(
     reviewClaimedByUsername: Option[String],
     reviewClaimedAt: Option[DateTime]
 )
-object TaskReview {
+object TaskReview extends CommonField {
   implicit val writes: Writes[TaskReview] = Json.writes[TaskReview]
   implicit val reads: Reads[TaskReview]   = Json.reads[TaskReview]
 
+  val TABLE                     = "task_review"
   val FIELD_TASK_ID             = "task_id"
   val FIELD_REVIEW_STATUS       = "review_status"
   val FIELD_REVIEW_REQUESTED_BY = "review_requested_by"

--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -209,6 +209,7 @@ object User extends CommonField {
   implicit val searchResultWrites: Writes[UserSearchResult] = Json.writes[UserSearchResult]
   implicit val projectManagerWrites: Writes[ProjectManager] = Json.writes[ProjectManager]
 
+  val TABLE                     = "users"
   val FIELD_OSM_ID              = "osm_id"
   val FIELD_OSM_CREATED         = "osm_created"
   val FIELD_API_KEY             = "api_key"

--- a/app/org/maproulette/framework/model/UserMetrics.scala
+++ b/app/org/maproulette/framework/model/UserMetrics.scala
@@ -9,6 +9,8 @@ package org.maproulette.framework.model
   * @author mcuthbert
   */
 object UserMetrics {
+  val TABLE = "user_metrics"
+
   val FIELD_USER_ID                    = "user_id"
   val FIELD_SCORE                      = "score"
   val FIELD_TOTAL_FIXED                = "total_fixed"

--- a/app/org/maproulette/framework/model/VirtualProject.scala
+++ b/app/org/maproulette/framework/model/VirtualProject.scala
@@ -11,6 +11,8 @@ import org.maproulette.framework.psql.CommonField
   * @author mcuthbert
   */
 object VirtualProject extends CommonField {
+  val TABLE = "virtual_project_challenges"
+
   val FIELD_PROJECT_ID   = "project_id"
   val FIELD_CHALLENGE_ID = "challenge_id"
 }

--- a/app/org/maproulette/framework/psql/Grouping.scala
+++ b/app/org/maproulette/framework/psql/Grouping.scala
@@ -22,7 +22,7 @@ case class Grouping(groups: GroupField*) extends SQLClause {
         .map(group => {
           SQLUtils.testColumnName(group.name)
           group.table.getOrElse(table) match {
-            case "" => group.name
+            case ""    => group.name
             case value => s"$value.${group.name}"
           }
         })

--- a/app/org/maproulette/framework/psql/Grouping.scala
+++ b/app/org/maproulette/framework/psql/Grouping.scala
@@ -11,17 +11,29 @@ import org.maproulette.framework.psql.filter.SQLClause
 /**
   * @author mcuthbert
   */
-case class Grouping(groups: String*) extends SQLClause {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+case class GroupField(name: String, table: Option[String] = None)
+
+case class Grouping(groups: GroupField*) extends SQLClause {
+  override def sql()(implicit table: String = ""): String = {
     if (groups.isEmpty) {
       ""
     } else {
-      groups.foreach(SQLUtils.testColumnName)
-      s"GROUP BY ${groups.mkString(",")}"
+      val groupString = groups
+        .map(group => {
+          SQLUtils.testColumnName(group.name)
+          group.table.getOrElse(table) match {
+            case "" => group.name
+            case value => s"$value.${group.name}"
+          }
+        })
+        .mkString(",")
+      s"GROUP BY $groupString"
     }
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = List.empty
+  override def parameters(): List[NamedParameter] = List.empty
+}
+
+object Grouping {
+  def >(groups: String*): Grouping = Grouping(groups.map(GroupField(_)): _*)
 }

--- a/app/org/maproulette/framework/psql/Order.scala
+++ b/app/org/maproulette/framework/psql/Order.scala
@@ -8,7 +8,7 @@ package org.maproulette.framework.psql
 import anorm.NamedParameter
 import org.maproulette.framework.psql.filter.SQLClause
 
-case class OrderField(name: String, direction: Int = Order.DESC, table:Option[String] = None)
+case class OrderField(name: String, direction: Int = Order.DESC, table: Option[String] = None)
 
 /**
   * Basic class to handle any ordering that needs to be added to the query
@@ -16,14 +16,14 @@ case class OrderField(name: String, direction: Int = Order.DESC, table:Option[St
   * @author mcuthbert
   */
 case class Order(fields: List[OrderField] = List.empty) extends SQLClause {
-  override def sql()(implicit table:String = ""): String = {
+  override def sql()(implicit table: String = ""): String = {
     val directions = fields.map(field => field.direction).distinct
     val orderFields = fields
       .map(field => {
         SQLUtils.testColumnName(field.name)
         val fieldDirection = if (directions.size > 1) Order.direction(field.direction) else ""
         val columnKey = field.table.getOrElse(table) match {
-          case "" => field.name
+          case ""    => field.name
           case value => s"$value.${field.name}"
         }
         s"$columnKey $fieldDirection".trim

--- a/app/org/maproulette/framework/psql/Order.scala
+++ b/app/org/maproulette/framework/psql/Order.scala
@@ -8,7 +8,7 @@ package org.maproulette.framework.psql
 import anorm.NamedParameter
 import org.maproulette.framework.psql.filter.SQLClause
 
-case class OrderField(name: String, direction: Int = Order.DESC)
+case class OrderField(name: String, direction: Int = Order.DESC, table:Option[String] = None)
 
 /**
   * Basic class to handle any ordering that needs to be added to the query
@@ -16,13 +16,17 @@ case class OrderField(name: String, direction: Int = Order.DESC)
   * @author mcuthbert
   */
 case class Order(fields: List[OrderField] = List.empty) extends SQLClause {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  override def sql()(implicit table:String = ""): String = {
     val directions = fields.map(field => field.direction).distinct
     val orderFields = fields
       .map(field => {
         SQLUtils.testColumnName(field.name)
         val fieldDirection = if (directions.size > 1) Order.direction(field.direction) else ""
-        s"${field.name} $fieldDirection".trim
+        val columnKey = field.table.getOrElse(table) match {
+          case "" => field.name
+          case value => s"$value.${field.name}"
+        }
+        s"$columnKey $fieldDirection".trim
       })
       .mkString(",")
       .trim
@@ -35,9 +39,7 @@ case class Order(fields: List[OrderField] = List.empty) extends SQLClause {
     }
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = List.empty
+  override def parameters(): List[NamedParameter] = List.empty
 }
 
 object Order {

--- a/app/org/maproulette/framework/psql/Paging.scala
+++ b/app/org/maproulette/framework/psql/Paging.scala
@@ -17,23 +17,19 @@ import org.maproulette.utils.Utils
 case class Paging(limit: Int = 0, page: Int = 0) extends SQLClause {
   val randomPrefix: String = Utils.randomStringFromCharList(5)
 
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  override def sql()(implicit table: String = ""): String = {
     if (limit > 0) {
-      s"LIMIT {${keyPrefix}limit} OFFSET {${keyPrefix}offset}"
+      s"LIMIT {${randomPrefix}limit} OFFSET {${randomPrefix}offset}"
     } else {
       ""
     }
   }
 
-  private def keyPrefix(implicit parameterKey: String) = s"$parameterKey$randomPrefix"
-
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = {
+  override def parameters(): List[NamedParameter] = {
     if (limit > 0) {
       List(
-        Symbol(s"${keyPrefix}limit")  -> limit,
-        Symbol(s"${keyPrefix}offset") -> page * limit
+        Symbol(s"${randomPrefix}limit")  -> limit,
+        Symbol(s"${randomPrefix}offset") -> page * limit
       )
     } else {
       List.empty

--- a/app/org/maproulette/framework/psql/Query.scala
+++ b/app/org/maproulette/framework/psql/Query.scala
@@ -17,9 +17,7 @@ import org.slf4j.{Logger, LoggerFactory}
   * @author mcuthbert
   */
 object Query {
-  val logger: Logger      = LoggerFactory.getLogger(Query.getClass)
-  val PRIMARY_QUERY_KEY   = ""
-  val SECONDARY_QUERY_KEY = "secondary"
+  val logger: Logger = LoggerFactory.getLogger(Query.getClass)
 
   //val config:Config
   def devMode(): Boolean = true //config.isDebugMode || config.isDevMode
@@ -51,9 +49,7 @@ case class Query(
     grouping: Grouping = Grouping(),
     includeWhere: Boolean = true
 ) extends SQLClause {
-  def build(
-      baseQuery: String = ""
-  )(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): SimpleSql[Row] = {
+  def build(baseQuery: String = "")(implicit baseTable: String = ""): SimpleSql[Row] = {
     val parameters = this.parameters()
     val sql        = this.sqlWithBaseQuery(baseQuery)
     if (parameters.nonEmpty) {
@@ -63,16 +59,11 @@ case class Query(
     }
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = filter.parameters() ++ paging.parameters()
+  override def parameters(): List[NamedParameter] = filter.parameters() ++ paging.parameters()
 
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String =
-    this.sqlWithBaseQuery()
+  override def sql()(implicit table: String = ""): String = this.sqlWithBaseQuery()
 
-  def sqlWithBaseQuery(
-      baseQuery: String = ""
-  )(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  def sqlWithBaseQuery(baseQuery: String = "")(implicit baseTable: String = ""): String = {
     val filterQuery = filter.sql() match {
       case x if x.nonEmpty & includeWhere => s"WHERE $x"
       case x                              => x

--- a/app/org/maproulette/framework/psql/filter/Filter.scala
+++ b/app/org/maproulette/framework/psql/filter/Filter.scala
@@ -17,7 +17,7 @@ import org.maproulette.framework.psql.{AND, Query, SQLKey}
   * @author mcuthbert
   */
 trait SQLClause {
-  def sql()(implicit tableKey:String = ""): String
+  def sql()(implicit tableKey: String = ""): String
   def parameters(): List[NamedParameter] = List.empty
 
   // Simple function that makes sure I don't have a bunch of empty spaces at the end of the query.
@@ -32,7 +32,7 @@ trait SQLClause {
 
 case class FilterGroup(params: List[Parameter[_]], key: SQLKey = AND(), condition: Boolean = true)
     extends SQLClause {
-  override def sql()(implicit tableKey:String = ""): String =
+  override def sql()(implicit tableKey: String = ""): String =
     if (condition) {
       params
         .flatMap(param =>
@@ -50,7 +50,7 @@ case class FilterGroup(params: List[Parameter[_]], key: SQLKey = AND(), conditio
 }
 
 case class Filter(groups: List[FilterGroup], key: SQLKey = AND()) extends SQLClause {
-  def sql()(implicit tableKey:String = ""): String = {
+  def sql()(implicit tableKey: String = ""): String = {
     val groupSeparator = if (groups.size == 1) {
       ("", "")
     } else {

--- a/app/org/maproulette/framework/psql/filter/Filter.scala
+++ b/app/org/maproulette/framework/psql/filter/Filter.scala
@@ -17,10 +17,8 @@ import org.maproulette.framework.psql.{AND, Query, SQLKey}
   * @author mcuthbert
   */
 trait SQLClause {
-  def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String
-  def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = List.empty
+  def sql()(implicit tableKey:String = ""): String
+  def parameters(): List[NamedParameter] = List.empty
 
   // Simple function that makes sure I don't have a bunch of empty spaces at the end of the query.
   // It doesn't really matter, but makes it easier to look at.
@@ -34,7 +32,7 @@ trait SQLClause {
 
 case class FilterGroup(params: List[Parameter[_]], key: SQLKey = AND(), condition: Boolean = true)
     extends SQLClause {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String =
+  override def sql()(implicit tableKey:String = ""): String =
     if (condition) {
       params
         .flatMap(param =>
@@ -48,14 +46,11 @@ case class FilterGroup(params: List[Parameter[_]], key: SQLKey = AND(), conditio
       ""
     }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] =
-    params.flatMap(param => param.parameters()).toList
+  override def parameters(): List[NamedParameter] = params.flatMap(param => param.parameters())
 }
 
 case class Filter(groups: List[FilterGroup], key: SQLKey = AND()) extends SQLClause {
-  def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  def sql()(implicit tableKey:String = ""): String = {
     val groupSeparator = if (groups.size == 1) {
       ("", "")
     } else {
@@ -71,10 +66,7 @@ case class Filter(groups: List[FilterGroup], key: SQLKey = AND()) extends SQLCla
       .mkString(s" ${key.getSQLKey()} ")
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] =
-    groups.flatMap(param => param.parameters()).toList
+  override def parameters(): List[NamedParameter] = groups.flatMap(param => param.parameters())
 }
 
 object Filter {

--- a/app/org/maproulette/framework/psql/filter/Operator.scala
+++ b/app/org/maproulette/framework/psql/filter/Operator.scala
@@ -17,10 +17,11 @@ object Operator extends Enumeration {
 
   def format(
       key: String,
+      parameterKey: String,
       operator: Operator,
       negate: Boolean = false,
       value: Option[String] = None
-  )(implicit parameterKey: String): String = {
+  ): String = {
     SQLUtils.testColumnName(key)
     val negation = if (negate) {
       "NOT "
@@ -29,7 +30,7 @@ object Operator extends Enumeration {
     }
     val rightValue = value match {
       case Some(v) => v
-      case None    => s"{$parameterKey$key}"
+      case None    => s"{$parameterKey}"
     }
     operator match {
       case EQ         => s"$negation$key = $rightValue"

--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -11,8 +11,6 @@ import org.maproulette.framework.psql.filter.Operator.Operator
 import org.maproulette.framework.psql.{Query, SQLUtils}
 import org.maproulette.utils.Utils
 
-import scala.util.Random
-
 /**
   * Filter Parameters are generally be used for filter select queries using some basic filtering. It
   * also can be used for updating objects, as the SET clause using a very similar structure to the
@@ -26,9 +24,10 @@ trait Parameter[T] extends SQLClause {
   val operator: Operator        = Operator.EQ
   val negate: Boolean           = false
   val useValueDirectly: Boolean = false
+  val table: Option[String]     = None
   val randomPrefix: String      = Utils.randomStringFromCharList(5)
 
-  def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  def sql()(implicit tableKey: String = ""): String = {
     if (value.isInstanceOf[Iterable[_]] && value.asInstanceOf[Iterable[_]].isEmpty) {
       ""
     } else if (operator == Operator.CUSTOM) {
@@ -46,25 +45,28 @@ trait Parameter[T] extends SQLClause {
       } else {
         None
       }
-      Operator.format(key, operator, negate, directValue)(getKeyPrefix)
+      Operator.format(this.getColumnKey(tableKey), this.getKey(), operator, negate, directValue)
     }
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = {
+  protected def getColumnKey(tableKey: String): String = {
+    this.table.getOrElse(tableKey) match {
+      case "" => key
+      case v => s"$v.$key"
+    }
+  }
+
+  override def parameters(): List[NamedParameter] = {
     if ((value.isInstanceOf[Iterable[_]] && value
           .asInstanceOf[Iterable[_]]
           .isEmpty) || operator == Operator.CUSTOM || operator == Operator.NULL || operator == Operator.BOOL || useValueDirectly) {
       List.empty
     } else {
-      List(SQLUtils.buildNamedParameter(s"$getKey", value))
+      List(SQLUtils.buildNamedParameter(this.getKey(), value))
     }
   }
 
-  def getKey(implicit parameterKey: String): String = s"$getKeyPrefix$key"
-
-  protected def getKeyPrefix(implicit parameterKey: String): String = s"$parameterKey$randomPrefix"
+  def getKey(): String = s"$randomPrefix$key"
 }
 
 /**
@@ -82,26 +84,27 @@ case class BaseParameter[T](
     override val value: T,
     override val operator: Operator = Operator.EQ,
     override val negate: Boolean = false,
-    override val useValueDirectly: Boolean = false
+    override val useValueDirectly: Boolean = false,
+    override val table: Option[String] = None
 ) extends Parameter[T]
 
 case class ConditionalFilterParameter[T](
     filter: Parameter[T],
-    includeOnlyIfTrue: Boolean = false
+    includeOnlyIfTrue: Boolean = false,
+    override val table: Option[String] = None
 ) extends Parameter[T] {
   override val key: String = filter.key
   override val value: T    = filter.value
 
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String =
+  override def sql()(implicit tableKey: String = ""): String = {
     if (includeOnlyIfTrue) {
-      filter.sql()
+      filter.sql()(table.getOrElse(tableKey))
     } else {
       ""
     }
+  }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] =
+  override def parameters(): List[NamedParameter] =
     if (includeOnlyIfTrue) {
       filter.parameters()
     } else {
@@ -114,9 +117,10 @@ case class DateParameter(
     override val value: DateTime,
     value2: DateTime,
     override val operator: Operator = Operator.EQ,
-    override val negate: Boolean = false
+    override val negate: Boolean = false,
+    override val table: Option[String] = None
 ) extends Parameter[DateTime] {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  override def sql()(implicit tableKey: String = ""): String = {
     if (operator == Operator.BETWEEN) {
       SQLUtils.testColumnName(key)
       val negation = if (negate) {
@@ -124,21 +128,19 @@ case class DateParameter(
       } else {
         ""
       }
-      s"$key::DATE ${negation}BETWEEN {${getKey}_date1} AND {${getKey}_date2}"
+      s"${this.getColumnKey(tableKey)}::DATE ${negation}BETWEEN {${this.getKey()}_date1} AND {${this.getKey()}_date2}"
     } else {
       super.sql()
     }
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = {
+  override def parameters(): List[NamedParameter] = {
     if (operator == Operator.BETWEEN) {
       List(
-        Symbol(s"${getKey}_date1") -> ToParameterValue
+        Symbol(s"${this.getKey()}_date1") -> ToParameterValue
           .apply[DateTime](p = SQLUtils.toStatement)
           .apply(value),
-        Symbol(s"${getKey}_date2") -> ToParameterValue
+        Symbol(s"${this.getKey()}_date2") -> ToParameterValue
           .apply[DateTime](p = SQLUtils.toStatement)
           .apply(value2)
       )
@@ -158,36 +160,31 @@ case class SubQueryFilter(
     override val key: String,
     override val value: Query,
     override val negate: Boolean = false,
-    override val operator: Operator = Operator.IN
+    override val operator: Operator = Operator.IN,
+    override val table: Option[String] = None,
+    subQueryTable: Option[String] = Some("")
 ) extends Parameter[Query] {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  override def sql()(implicit tableKey: String = ""): String = {
+    val innerKey = subQueryTable.getOrElse(tableKey)
     if (operator == Operator.CUSTOM) {
-      s"(${value.sql()(this.getParameterKey)})"
+      s"(${value.sql()(innerKey)})"
     } else {
       val filterValue = if (operator == Operator.IN || operator == Operator.EXISTS) {
-        Some(value.sql()(this.getParameterKey))
+        Some(value.sql()(innerKey))
       } else {
-        Some(s"(${value.sql()(this.getParameterKey)})")
+        Some(s"(${value.sql()(innerKey)})")
       }
-      Operator.format(key, operator, negate, filterValue)(getKeyPrefix)
+      Operator.format(
+        this.getColumnKey(tableKey),
+        this.getKey(),
+        operator,
+        negate,
+        filterValue
+      )
     }
   }
 
-  // This may work for a single subquery, but there may be issues if you have more than one subquery
-  // as it will always choose "SECONDARY" as it parameterKey which might not make the keys unique
-  // for the parameter, also we add a
-  def getParameterKey(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
-    if (parameterKey.equals(Query.PRIMARY_QUERY_KEY)) {
-      Query.SECONDARY_QUERY_KEY
-    } else {
-      parameterKey
-    }
-
-  }
-
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = value.parameters()(this.getParameterKey)
+  override def parameters(): List[NamedParameter] = value.parameters()
 }
 
 /**
@@ -195,13 +192,12 @@ case class SubQueryFilter(
   *
   * @param key
   */
-case class CustomParameter(override val key: String, override val value: String = "")
-    extends Parameter[String] {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = key
+case class CustomParameter(override val key: String) extends Parameter[String] {
+  override val value: String = ""
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] = List.empty
+  override def sql()(implicit tableKey: String = ""): String = key
+
+  override def parameters(): List[NamedParameter] = List.empty
 }
 
 case class FuzzySearchParameter(
@@ -210,24 +206,22 @@ case class FuzzySearchParameter(
     levenshsteinScore: Int = FilterParameter.DEFAULT_LEVENSHSTEIN_SCORE,
     metaphoneSize: Int = FilterParameter.DEFAULT_METAPHONE_SIZE
 ) extends Parameter[String] {
-  override def sql()(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): String = {
+  override def sql()(implicit tableKey: String = ""): String = {
     SQLUtils.testColumnName(key)
     val score = if (levenshsteinScore > 0) {
       levenshsteinScore
     } else {
       FilterParameter.DEFAULT_LEVENSHSTEIN_SCORE
     }
-    s"""($key <> '' AND
-      (LEVENSHTEIN(LOWER($key), LOWER({$getKey})) < $score OR
-      METAPHONE(LOWER($key), 4) = METAPHONE(LOWER({$getKey}), $metaphoneSize) OR
-      SOUNDEX(LOWER($key)) = SOUNDEX(LOWER({$getKey})))
+    val columnKey = this.getColumnKey(tableKey)
+    s"""($columnKey <> '' AND
+      (LEVENSHTEIN(LOWER($columnKey), LOWER({${this.getKey()}})) < $score OR
+      METAPHONE(LOWER($columnKey), 4) = METAPHONE(LOWER({${this.getKey()}}), $metaphoneSize) OR
+      SOUNDEX(LOWER($columnKey)) = SOUNDEX(LOWER({${this.getKey()}})))
       )"""
   }
 
-  override def parameters()(
-      implicit parameterKey: String = Query.PRIMARY_QUERY_KEY
-  ): List[NamedParameter] =
-    List(Symbol(getKey) -> value)
+  override def parameters(): List[NamedParameter] = List(Symbol(getKey) -> value)
 }
 
 object FilterParameter {
@@ -241,10 +235,11 @@ object FilterParameter {
       operator: Operator = Operator.EQ,
       negate: Boolean = false,
       useValueDirectly: Boolean = false,
-      includeOnlyIfTrue: Boolean = false
-  )(implicit parameterKey: String = Query.PRIMARY_QUERY_KEY): ConditionalFilterParameter[T] =
+      includeOnlyIfTrue: Boolean = false,
+      table: Option[String] = None
+  ): ConditionalFilterParameter[T] =
     ConditionalFilterParameter(
-      BaseParameter(key, value, operator, negate, useValueDirectly),
+      BaseParameter(key, value, operator, negate, useValueDirectly, table),
       includeOnlyIfTrue
     )
 }

--- a/app/org/maproulette/framework/repository/ChallengeListingRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeListingRepository.scala
@@ -22,7 +22,7 @@ import play.api.db.Database
   */
 @Singleton
 class ChallengeListingRepository @Inject() (override val db: Database) extends RepositoryMixin {
-  implicit val baseTable:String = Challenge.TABLE
+  implicit val baseTable: String = Challenge.TABLE
 
   /**
     * Query function that allows a user to build their own query against the Challenge table

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -23,6 +23,7 @@ import play.api.db.Database
   */
 @Singleton
 class ChallengeRepository @Inject() (override val db: Database) extends RepositoryMixin {
+  implicit val baseTable:String = Challenge.TABLE
 
   /**
     * Query function that allows a user to build their own query against the Challenge table

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -23,7 +23,7 @@ import play.api.db.Database
   */
 @Singleton
 class ChallengeRepository @Inject() (override val db: Database) extends RepositoryMixin {
-  implicit val baseTable:String = Challenge.TABLE
+  implicit val baseTable: String = Challenge.TABLE
 
   /**
     * Query function that allows a user to build their own query against the Challenge table

--- a/app/org/maproulette/framework/repository/CommentRepository.scala
+++ b/app/org/maproulette/framework/repository/CommentRepository.scala
@@ -22,6 +22,7 @@ import play.api.db.Database
   * @author mcuthbert
   */
 class CommentRepository @Inject() (override val db: Database) extends RepositoryMixin {
+  implicit val baseTable: String = Comment.TABLE
 
   /**
     * Query function that allows a user to build their own query against the Comment table
@@ -92,9 +93,9 @@ class CommentRepository @Inject() (override val db: Database) extends Repository
   def retrieve(id: Long)(implicit c: Option[Connection] = None): Option[Comment] = {
     this.withMRConnection { implicit c =>
       Query
-        .simple(List(BaseParameter("tc.id", id)))
-        .build("""SELECT * FROM task_comments tc
-              INNER JOIN users u ON u.osm_id = tc.osm_id""")
+        .simple(List(BaseParameter("id", id)))
+        .build("""SELECT * FROM task_comments
+              INNER JOIN users ON users.osm_id = task_comments.osm_id""")
         .as(CommentRepository.parser.*)
         .headOption
     }

--- a/app/org/maproulette/framework/repository/GroupRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupRepository.scala
@@ -12,7 +12,7 @@ import anorm._
 import javax.inject.{Inject, Singleton}
 import org.maproulette.framework.model.Group
 import org.maproulette.framework.psql.Query
-import org.maproulette.framework.psql.filter.{BaseParameter, FilterParameter, SubQueryFilter}
+import org.maproulette.framework.psql.filter.BaseParameter
 import play.api.db.Database
 
 /**
@@ -20,6 +20,7 @@ import play.api.db.Database
   */
 @Singleton
 class GroupRepository @Inject() (val db: Database) extends RepositoryMixin {
+  implicit val baseTable: String = Group.TABLE
 
   /**
     * Retrieves a single Group matching the given id

--- a/app/org/maproulette/framework/repository/RepositoryMixin.scala
+++ b/app/org/maproulette/framework/repository/RepositoryMixin.scala
@@ -14,5 +14,5 @@ import org.maproulette.utils.{Readers, Writers}
   * @author mcuthbert
   */
 trait RepositoryMixin extends TransactionManager with Readers with Writers {
-  implicit val baseTable:String
+  implicit val baseTable: String
 }

--- a/app/org/maproulette/framework/repository/RepositoryMixin.scala
+++ b/app/org/maproulette/framework/repository/RepositoryMixin.scala
@@ -13,4 +13,6 @@ import org.maproulette.utils.{Readers, Writers}
   *
   * @author mcuthbert
   */
-trait RepositoryMixin extends TransactionManager with Readers with Writers {}
+trait RepositoryMixin extends TransactionManager with Readers with Writers {
+  implicit val baseTable:String
+}

--- a/app/org/maproulette/framework/repository/TagRepository.scala
+++ b/app/org/maproulette/framework/repository/TagRepository.scala
@@ -20,6 +20,7 @@ import play.api.db.Database
   * @author mcuthbert
   */
 class TagRepository @Inject() (override val db: Database) extends RepositoryMixin {
+  implicit val baseTable: String = Tag.TABLE
 
   /**
     * Retrieves a specific tag
@@ -98,8 +99,15 @@ class TagRepository @Inject() (override val db: Database) extends RepositoryMixi
 
       Query
         .simple(
-          List(BaseParameter(s"tc.${Tag.FIELD_CHALLENGE_ID}", id, Operator.IN)),
-          "SELECT * FROM tags AS t INNER JOIN tags_on_challenges AS tc ON t.id = tc.tag_id"
+          List(
+            BaseParameter(
+              Tag.FIELD_CHALLENGE_ID,
+              id,
+              Operator.IN,
+              table = Some(Tag.TABLE_TAGS_ON_CHALLENGES)
+            )
+          ),
+          "SELECT * FROM tags INNER JOIN tags_on_challenges ON tags.id = tags_on_challenges.tag_id"
         )
         .build()
         .as(challengeTagParser.*)

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -10,6 +10,7 @@ import java.sql.Connection
 import anorm.SqlParser.get
 import anorm.{RowParser, ~}
 import javax.inject.{Inject, Singleton}
+import org.maproulette.framework.model.TaskReview
 import org.maproulette.framework.psql.Query
 import org.maproulette.models.Task
 import play.api.db.Database
@@ -19,6 +20,8 @@ import play.api.db.Database
   */
 @Singleton
 class TaskReviewRepository @Inject() (override val db: Database) extends RepositoryMixin {
+  implicit val baseTable:String = TaskReview.TABLE
+
   def getTaskReviewCounts(query: Query)(implicit c: Option[Connection] = None): Map[String, Int] = {
     this.withMRTransaction { implicit c =>
       val reviewCountsParser: RowParser[Map[String, Int]] = {

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -20,7 +20,7 @@ import play.api.db.Database
   */
 @Singleton
 class TaskReviewRepository @Inject() (override val db: Database) extends RepositoryMixin {
-  implicit val baseTable:String = TaskReview.TABLE
+  implicit val baseTable: String = TaskReview.TABLE
 
   def getTaskReviewCounts(query: Query)(implicit c: Option[Connection] = None): Map[String, Int] = {
     this.withMRTransaction { implicit c =>

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -10,7 +10,12 @@ import java.sql.Connection
 import anorm.SQL
 import javax.inject.{Inject, Singleton}
 import org.maproulette.framework.model.{Challenge, SavedChallenge, SavedTasks}
-import org.maproulette.framework.psql.filter.{BaseParameter, FilterParameter, Operator, SubQueryFilter}
+import org.maproulette.framework.psql.filter.{
+  BaseParameter,
+  FilterParameter,
+  Operator,
+  SubQueryFilter
+}
 import org.maproulette.framework.psql._
 import org.maproulette.models.Task
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
@@ -28,7 +33,7 @@ class UserSavedObjectsRepository @Inject() (
     challengeDAL: ChallengeDAL,
     taskDAL: TaskDAL
 ) extends RepositoryMixin {
-  implicit val baseTable:String = SavedChallenge.TABLE
+  implicit val baseTable: String = SavedChallenge.TABLE
 
   /**
     * Retreives all the challenges saved to a user profile

--- a/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
+++ b/app/org/maproulette/framework/repository/UserSavedObjectsRepository.scala
@@ -9,13 +9,8 @@ import java.sql.Connection
 
 import anorm.SQL
 import javax.inject.{Inject, Singleton}
-import org.maproulette.framework.model.{Challenge, SavedTasks}
-import org.maproulette.framework.psql.filter.{
-  BaseParameter,
-  FilterParameter,
-  Operator,
-  SubQueryFilter
-}
+import org.maproulette.framework.model.{Challenge, SavedChallenge, SavedTasks}
+import org.maproulette.framework.psql.filter.{BaseParameter, FilterParameter, Operator, SubQueryFilter}
 import org.maproulette.framework.psql._
 import org.maproulette.models.Task
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
@@ -33,6 +28,7 @@ class UserSavedObjectsRepository @Inject() (
     challengeDAL: ChallengeDAL,
     taskDAL: TaskDAL
 ) extends RepositoryMixin {
+  implicit val baseTable:String = SavedChallenge.TABLE
 
   /**
     * Retreives all the challenges saved to a user profile
@@ -122,7 +118,7 @@ class UserSavedObjectsRepository @Inject() (
         .simple(
           List(
             SubQueryFilter(
-              "tasks.id",
+              "id",
               Query
                 .simple(
                   List(
@@ -144,7 +140,7 @@ class UserSavedObjectsRepository @Inject() (
         .build(s"""
           |SELECT ${taskDAL.retrieveColumnsWithReview} FROM tasks
           |LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
-          |""".stripMargin)
+          |""".stripMargin)(baseTable = "tasks")
         .as(taskDAL.parser.*)
     }
   }
@@ -186,7 +182,7 @@ class UserSavedObjectsRepository @Inject() (
         .simple(
           List(BaseParameter("user_id", userId), BaseParameter("task_id", taskId))
         )
-        .build("DELETE FROM saved_tasks")
+        .build("DELETE FROM saved_tasks")(baseTable = SavedTasks.TABLE)
         .execute()
     }
   }

--- a/app/org/maproulette/framework/repository/VirtualProjectRepository.scala
+++ b/app/org/maproulette/framework/repository/VirtualProjectRepository.scala
@@ -21,7 +21,7 @@ import play.api.db.Database
   */
 @Singleton
 class VirtualProjectRepository @Inject() (override val db: Database) extends RepositoryMixin {
-  implicit val baseTable:String = VirtualProject.TABLE
+  implicit val baseTable: String = VirtualProject.TABLE
 
   def addChallenge(projectId: Long, challengeId: Long)(
       implicit c: Option[Connection] = None

--- a/app/org/maproulette/framework/repository/VirtualProjectRepository.scala
+++ b/app/org/maproulette/framework/repository/VirtualProjectRepository.scala
@@ -10,6 +10,7 @@ import java.sql.Connection
 import anorm.SQL
 import javax.inject.{Inject, Singleton}
 import org.maproulette.exception.InvalidException
+import org.maproulette.framework.model.{Project, VirtualProject}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
 import org.postgresql.util.PSQLException
@@ -20,6 +21,8 @@ import play.api.db.Database
   */
 @Singleton
 class VirtualProjectRepository @Inject() (override val db: Database) extends RepositoryMixin {
+  implicit val baseTable:String = VirtualProject.TABLE
+
   def addChallenge(projectId: Long, challengeId: Long)(
       implicit c: Option[Connection] = None
   ): Boolean = {

--- a/app/org/maproulette/framework/service/ChallengeListingService.scala
+++ b/app/org/maproulette/framework/service/ChallengeListingService.scala
@@ -6,14 +6,11 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import org.maproulette.models.Task
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.Query
-import org.maproulette.framework.psql.filter.BaseParameter
+import org.maproulette.framework.psql.{Query, _}
+import org.maproulette.framework.psql.filter.{BaseParameter, _}
 import org.maproulette.framework.repository.ChallengeListingRepository
-import org.maproulette.framework.psql.filter._
-import org.maproulette.framework.psql._
-import org.maproulette.framework.service.ServiceHelper
+import org.maproulette.models.Task
 
 /**
   * Service layer for ChallengeListings to handle all the challenge listing business logic
@@ -26,8 +23,6 @@ class ChallengeListingService @Inject() (repository: ChallengeListingRepository)
     with ServiceMixin[ChallengeListing] {
   def retrieve(parentId: Long): Option[ChallengeListing] =
     this.query(Query.simple(List(BaseParameter(Challenge.FIELD_PARENT_ID, parentId)))).headOption
-
-  def query(query: Query): List[ChallengeListing] = this.repository.query(query)
 
   /**
     * Returns a list of challenges that have reviews/review requests.
@@ -46,50 +41,57 @@ class ChallengeListingService @Inject() (repository: ChallengeListingRepository)
       paging: Paging = Paging()
   ): List[ChallengeListing] = {
 
-    val reviewedBy        = "task_review.reviewed_by"
-    val reviewRequestedBy = "task_review.review_requested_by"
-    val reviewStatus      = "task_review.review_status"
-
     val filter =
       Filter(
         List(
           FilterGroup(
             List(
               // Has a task review
-              BaseParameter("task_review.id", "", Operator.NULL, negate = true),
+              BaseParameter(
+                TaskReview.FIELD_ID,
+                "",
+                Operator.NULL,
+                negate = true,
+                table = Some(TaskReview.TABLE)
+              ),
               // Task Status in list if given a list of task statuses
               FilterParameter.conditional(
-                "t.status",
+                "status",
                 taskStatus.getOrElse(List.empty),
                 Operator.IN,
-                includeOnlyIfTrue = taskStatus.nonEmpty
+                includeOnlyIfTrue = taskStatus.nonEmpty,
+                table = Some("tasks")
               ),
               // review_requested_by != user.id unless a super user
               // to be reviewed tasks (review type = 1)
               FilterParameter.conditional(
-                reviewRequestedBy,
+                TaskReview.FIELD_REVIEW_REQUESTED_BY,
                 user.id,
                 negate = true,
-                includeOnlyIfTrue = (reviewTasksType == 1) && !user.isSuperUser
+                includeOnlyIfTrue = (reviewTasksType == 1) && !user.isSuperUser,
+                table = Some(TaskReview.TABLE)
               ),
               // reviewed_by == user.id for 'tasks reviewed by me' (review type = 3)
               FilterParameter.conditional(
-                reviewedBy,
+                TaskReview.FIELD_REVIEWED_BY,
                 user.id,
-                includeOnlyIfTrue = (reviewTasksType == 2)
+                includeOnlyIfTrue = reviewTasksType == 2,
+                table = Some(TaskReview.TABLE)
               ),
               // reviewed_by == user.id for 'my reviewed tasks' (review type = 2)
               FilterParameter.conditional(
-                reviewRequestedBy,
+                TaskReview.FIELD_REVIEW_REQUESTED_BY,
                 user.id,
-                includeOnlyIfTrue = (reviewTasksType == 3)
+                includeOnlyIfTrue = reviewTasksType == 3,
+                table = Some(TaskReview.TABLE)
               ),
               // review status = requested or disputed if reviewTasksType = 1
               FilterParameter.conditional(
-                reviewStatus,
+                TaskReview.FIELD_REVIEW_STATUS,
                 List(Task.REVIEW_STATUS_REQUESTED, Task.REVIEW_STATUS_DISPUTED),
                 Operator.IN,
-                includeOnlyIfTrue = (reviewTasksType == 1)
+                includeOnlyIfTrue = reviewTasksType == 1,
+                table = Some(TaskReview.TABLE)
               )
             )
           ),
@@ -98,11 +100,11 @@ class ChallengeListingService @Inject() (repository: ChallengeListingRepository)
           // reviewed_by is empty or user.id if excludeOtherReviewers
           FilterGroup(
             List(
-              BaseParameter(reviewedBy, "", Operator.NULL),
-              BaseParameter(reviewedBy, user.id)
+              BaseParameter(TaskReview.FIELD_REVIEWED_BY, "", Operator.NULL, table = Some(TaskReview.TABLE)),
+              BaseParameter(TaskReview.FIELD_REVIEWED_BY, user.id, table = Some(TaskReview.TABLE))
             ),
             OR(),
-            (excludeOtherReviewers && reviewTasksType == 1)
+            excludeOtherReviewers && reviewTasksType == 1
           )
         )
       )
@@ -110,8 +112,10 @@ class ChallengeListingService @Inject() (repository: ChallengeListingRepository)
     val query = Query(
       filter,
       paging = paging,
-      grouping = Grouping("c.id")
+      grouping = Grouping > "id"
     )
     this.query(query)
   }
+
+  def query(query: Query): List[ChallengeListing] = this.repository.query(query)
 }

--- a/app/org/maproulette/framework/service/ChallengeListingService.scala
+++ b/app/org/maproulette/framework/service/ChallengeListingService.scala
@@ -100,7 +100,12 @@ class ChallengeListingService @Inject() (repository: ChallengeListingRepository)
           // reviewed_by is empty or user.id if excludeOtherReviewers
           FilterGroup(
             List(
-              BaseParameter(TaskReview.FIELD_REVIEWED_BY, "", Operator.NULL, table = Some(TaskReview.TABLE)),
+              BaseParameter(
+                TaskReview.FIELD_REVIEWED_BY,
+                "",
+                Operator.NULL,
+                table = Some(TaskReview.TABLE)
+              ),
               BaseParameter(TaskReview.FIELD_REVIEWED_BY, user.id, table = Some(TaskReview.TABLE))
             ),
             OR(),

--- a/app/org/maproulette/framework/service/CommentService.scala
+++ b/app/org/maproulette/framework/service/CommentService.scala
@@ -78,12 +78,12 @@ class CommentService @Inject() (
   /**
     * Deletes a comment from the database
     *
-    * @param commentId The identifier of the comment
     * @param taskId The identifier of the task parent
+    * @param commentId The identifier of the comment
     * @param user The user deleting the comment
     * @return Boolean if delete was successful
     */
-  def delete(commentId: Long, taskId: Long, user: User): Boolean = {
+  def delete(taskId: Long, commentId: Long, user: User): Boolean = {
     this.taskDAL.retrieveById(taskId) match {
       case Some(task) =>
         this.permission.hasObjectAdminAccess(task, user)

--- a/app/org/maproulette/framework/service/CommentService.scala
+++ b/app/org/maproulette/framework/service/CommentService.scala
@@ -69,7 +69,7 @@ class CommentService @Inject() (
     this.repository
       .query(
         Query.simple(
-          List(BaseParameter(s"task_comments.${Comment.FIELD_ID}", id))
+          List(BaseParameter(Comment.FIELD_ID, id, table = Some(Comment.TABLE)))
         )
       )
       .headOption
@@ -168,8 +168,8 @@ class CommentService @Inject() (
         ConditionalFilterParameter(
           CustomParameter(
             s"""1 IN (SELECT 1 FROM unnest(ARRAY[${projectIdList.mkString(",")}]) AS pIds
-                         WHERE pIds IN (SELECT vp.project_id FROM virtual_project_challenges vp
-                                        WHERE vp.challenge_id = task_comments.challenge_id))"""
+                         WHERE pIds IN (SELECT virtual_project_challenges.project_id FROM virtual_project_challenges
+                                        WHERE virtual_project_challenges.challenge_id = task_comments.challenge_id))"""
           ),
           projectIdList.nonEmpty
         ),
@@ -202,7 +202,7 @@ class CommentService @Inject() (
         List(
           OrderField(Comment.FIELD_PROJECT_ID),
           OrderField(Comment.FIELD_CHALLENGE_ID),
-          OrderField(s"task_comments.${Comment.FIELD_CREATED}")
+          OrderField(Comment.FIELD_CREATED, table = Some(Comment.TABLE))
         )
       )
     )

--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -425,8 +425,9 @@ class ProjectService @Inject() (
   def getClusteredPoints(
       projectId: Option[Long] = None,
       challengeIds: List[Long] = List.empty,
-      enabledOnly: Boolean = true
+      enabledOnly: Boolean = true,
+      paging: Paging = Paging()
   ): List[ClusteredPoint] = {
-    this.repository.getClusteredPoints(projectId, challengeIds, enabledOnly)
+    this.repository.getClusteredPoints(projectId, challengeIds, enabledOnly, paging)
   }
 }

--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -42,7 +42,7 @@ class ProjectService @Inject() (
       searchString: String = "",
       onlyEnabled: Boolean = false,
       paging: Paging = Paging(Config.DEFAULT_LIST_SIZE),
-      order: Order = Order > s"challenges.${Challenge.FIELD_ID}"
+      order: Order = Order(List(OrderField(Challenge.FIELD_ID, table = Some(Challenge.TABLE))))
   ): List[Challenge] = {
     // I am in two minds about handling it this way. Firstly one of the tenants of splitting up the
     // work between service and repository layer is that we limit the SQL code to the repository and
@@ -57,12 +57,12 @@ class ProjectService @Inject() (
           List(
             FilterGroup(
               List(
-                BaseParameter(s"challenges.${Challenge.FIELD_PARENT_ID}", id),
+                BaseParameter(Challenge.FIELD_PARENT_ID, id, table = Some(Challenge.TABLE)),
                 SubQueryFilter(
-                  s"challenges.${Challenge.FIELD_ID}",
+                  Challenge.FIELD_ID,
                   Query.simple(
-                    List(BaseParameter(s"vp2.${VirtualProject.FIELD_PROJECT_ID}", id)),
-                    "SELECT vp2.challenge_id FROM virtual_project_challenges vp2"
+                    List(BaseParameter(VirtualProject.FIELD_PROJECT_ID, id)),
+                    "SELECT challenge_id FROM virtual_project_challenges"
                   )
                 )
               ),
@@ -86,11 +86,13 @@ class ProjectService @Inject() (
             )
           )
         ),
-        s"""SELECT challenges.${ChallengeRepository.standardColumns}, ARRAY_REMOVE(ARRAY_AGG(vp.project_id), NULL) AS virtual_parent_ids FROM challenges
-          | LEFT OUTER JOIN virtual_project_challenges vp ON challenges.id = vp.challenge_id""".stripMargin,
+        s"""SELECT challenges.${ChallengeRepository.standardColumns},
+            |ARRAY_REMOVE(ARRAY_AGG(virtual_project_challenges.project_id), NULL) AS virtual_parent_ids
+            |FROM challenges
+            |LEFT OUTER JOIN virtual_project_challenges ON challenges.id = virtual_project_challenges.challenge_id""".stripMargin,
         paging,
         order,
-        Grouping(s"challenges.${Challenge.FIELD_ID}")
+        Grouping > Challenge.FIELD_ID
       )
     )
   }
@@ -146,25 +148,26 @@ class ProjectService @Inject() (
         List.empty
       } else {
         // TODO No sql should exist in the service layer
-        val customQuery = s"""SELECT distinct p.*, LOWER(p.name), LOWER(p.display_name)
-                FROM projects p
-                INNER JOIN groups g on g.project_id = p.id"""
+        val customQuery =
+          s"""SELECT distinct projects.*, LOWER(projects.name), LOWER(projects.display_name)
+                              FROM projects INNER JOIN groups on groups.project_id = projects.id"""
         val permissionFilterGroup =
           FilterGroup(
             List(
-              BaseParameter(s"p.${Project.FIELD_OWNER}", user.osmProfile.id),
+              BaseParameter(Project.FIELD_OWNER, user.osmProfile.id),
               FilterParameter.conditional(
-                s"g.${Group.FIELD_ID}",
+                Group.FIELD_ID,
                 user.groups.map(_.id),
                 Operator.IN,
-                includeOnlyIfTrue = !onlyOwned
+                includeOnlyIfTrue = !onlyOwned,
+                table = Some(Group.TABLE)
               )
             ),
             OR()
           )
         val baseFilterGroup = FilterGroup(
           List(
-            BaseParameter(s"p.${Project.FIELD_NAME}", SQLUtils.search(searchString), Operator.LIKE),
+            BaseParameter(Project.FIELD_NAME, SQLUtils.search(searchString), Operator.LIKE),
             FilterParameter.conditional(
               Project.FIELD_ENABLED,
               onlyEnabled,
@@ -220,7 +223,16 @@ class ProjectService @Inject() (
             ),
             OR()
           ),
-          FilterGroup(List(BaseParameter(Project.FIELD_ENABLED, true)))
+          FilterGroup(
+            List(
+              FilterParameter.conditional(
+                Project.FIELD_ENABLED,
+                true,
+                Operator.BOOL,
+                includeOnlyIfTrue = onlyEnabled
+              )
+            )
+          )
         )
       ),
       paging = paging,
@@ -254,6 +266,8 @@ class ProjectService @Inject() (
       )
     )
   }
+
+  def query(query: Query): List[Project] = this.repository.query(query)
 
   /**
     * Updates a project with the given input JSON
@@ -309,6 +323,20 @@ class ProjectService @Inject() (
   }
 
   /**
+    * Retrieves a Project based on the given id
+    *
+    * @param id The id of the project
+    * @return An optional Project, None if not found.
+    */
+  def retrieve(id: Long): Option[Project] = {
+    this.cacheManager.withCaching { () =>
+      this.repository
+        .query(Query.simple(List(BaseParameter(Project.FIELD_ID, id))))
+        .headOption
+    }(id = id)
+  }
+
+  /**
     * Deletes a project
     *
     * @param id The id of the project
@@ -323,20 +351,6 @@ class ProjectService @Inject() (
       Some(deletedItem)
     }(id = id)
     true
-  }
-
-  /**
-    * Retrieves a Project based on the given id
-    *
-    * @param id The id of the project
-    * @return An optional Project, None if not found.
-    */
-  def retrieve(id: Long): Option[Project] = {
-    this.cacheManager.withCaching { () =>
-      this.repository
-        .query(Query.simple(List(BaseParameter(Project.FIELD_ID, id))))
-        .headOption
-    }(id = id)
   }
 
   /**
@@ -358,8 +372,6 @@ class ProjectService @Inject() (
       )
       .headOption
   }
-
-  def query(query: Query): List[Project] = this.repository.query(query)
 
   def list(
       ids: List[Long],

--- a/app/org/maproulette/framework/service/ServiceHelper.scala
+++ b/app/org/maproulette/framework/service/ServiceHelper.scala
@@ -6,7 +6,7 @@ package org.maproulette.framework.service
 
 import org.maproulette.framework.model._
 import org.maproulette.framework.psql.filter._
-import org.maproulette.framework.psql.{Query, OR}
+import org.maproulette.framework.psql.{OR, Query}
 
 /**
   * Helper functions for services
@@ -36,23 +36,39 @@ trait ServiceHelper {
           "",
           Query.simple(
             List(
-              BaseParameter("p.enabled", "", Operator.BOOL),
-              BaseParameter("c.enabled", "", Operator.BOOL)
+              BaseParameter(Project.FIELD_ENABLED, "", Operator.BOOL, table = Some(Project.TABLE)),
+              BaseParameter(
+                Challenge.FIELD_ENABLED,
+                "",
+                Operator.BOOL,
+                table = Some(Challenge.TABLE)
+              )
             ),
             includeWhere = false
           ),
           operator = Operator.CUSTOM
         ),
-        BaseParameter("p.owner_id", user.osmProfile.id),
+        BaseParameter(Project.FIELD_OWNER, user.osmProfile.id, table = Some(Project.TABLE)),
         SubQueryFilter(
           user.osmProfile.id.toString,
           Query.simple(
             List(
-              BaseParameter("ug.group_id", "g.id", useValueDirectly = true),
-              BaseParameter("g.project_id", "p.id", useValueDirectly = true)
+              BaseParameter(
+                Group.FIELD_UG_GROUP_ID,
+                "groups.id",
+                useValueDirectly = true,
+                table = Some(Group.TABLE_USER_GROUP)
+              ),
+              BaseParameter(
+                Group.FIELD_PROJECT_ID,
+                "projects.id",
+                useValueDirectly = true,
+                table = Some(Group.TABLE)
+              )
             ),
-            base = "SELECT ug.osm_user_id FROM user_groups ug, groups g "
-          )
+            base = "SELECT ug.osm_user_id FROM user_groups, groups "
+          ),
+          table = Some("")
         )
       ),
       OR(),

--- a/app/org/maproulette/framework/service/TagService.scala
+++ b/app/org/maproulette/framework/service/TagService.scala
@@ -158,20 +158,12 @@ class TagService @Inject() (
     this.cacheManager.withIDListCaching { implicit uncached =>
       this.query(
         Query.simple(
-          List(BaseParameter(s"tt.${Tag.FIELD_TASK_ID}", id)),
-          "SELECT * FROM tags AS t INNER JOIN tags_on_tasks AS tt ON t.id = tt.tag_id"
+          List(BaseParameter(Tag.FIELD_TASK_ID, id, table = Some(Tag.TABLE_TAGS_ON_TASKS))),
+          "SELECT * FROM tags INNER JOIN tags_on_tasks ON tags.id = tags_on_tasks.tag_id"
         )
       )
     }
   }
-
-  /**
-    * Retrieves all the objects based on the search criteria
-    *
-    * @param query The query to match against to retrieve the objects
-    * @return The list of objects
-    */
-  override def query(query: Query): List[Tag] = this.repository.query(query)
 
   /**
     * This is an "upsert" function that will try and insert tags into the database based on a list,
@@ -225,4 +217,12 @@ class TagService @Inject() (
       }(names.map(_.toLowerCase))
     }
   }
+
+  /**
+    * Retrieves all the objects based on the search criteria
+    *
+    * @param query The query to match against to retrieve the objects
+    * @return The list of objects
+    */
+  override def query(query: Query): List[Tag] = this.repository.query(query)
 }

--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -166,21 +166,21 @@ class UserMetricService @Inject() (
     duration match {
       case _ if dates._1.isDefined =>
         DateParameter(
-          s"$field",
+          field,
           dates._1.get,
           dates._2.get,
           Operator.BETWEEN
         )
       case 0 =>
         DateParameter(
-          s"$field",
+          field,
           DateTime.now.withDayOfMonth(1),
           DateTime.now,
           Operator.BETWEEN
         )
       case _ =>
         DateParameter(
-          s"$field",
+          field,
           DateTime.now.minus(Months.ONE),
           DateTime.now,
           Operator.BETWEEN

--- a/app/org/maproulette/framework/service/VirtualProjectService.scala
+++ b/app/org/maproulette/framework/service/VirtualProjectService.scala
@@ -63,7 +63,13 @@ class VirtualProjectService @Inject() (
           SubQueryFilter(
             Challenge.FIELD_ID,
             Query.simple(
-              List(BaseParameter(VirtualProject.FIELD_PROJECT_ID, projectId)),
+              List(
+                BaseParameter(
+                  VirtualProject.FIELD_PROJECT_ID,
+                  projectId,
+                  table = Some(VirtualProject.TABLE)
+                )
+              ),
               "SELECT challenge_id FROM virtual_project_challenges"
             )
           )

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1523,7 +1523,7 @@ class ChallengeDAL @Inject() (
       val joinClause    = new StringBuilder()
       var orderByClause = ""
 
-      parameters ++= addSearchToQuery(searchParameters, whereClause)(false)
+      parameters ++= addSearchToQuery(searchParameters, whereClause)
 
       parameters ++= addChallengeTagMatchingToQuery(searchParameters, whereClause, joinClause)
 
@@ -1582,9 +1582,9 @@ class ChallengeDAL @Inject() (
       }
 
       searchParameters.challengeParams.requiresLocal match {
-        case SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE =>
+        case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE) =>
           this.appendInWhereClause(whereClause, s"c.requires_local = false")
-        case SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY =>
+        case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY) =>
           this.appendInWhereClause(whereClause, s"c.requires_local = true")
         case _ =>
       }

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1250,8 +1250,8 @@ class TaskDAL @Inject() (
             User.FIELD_OSM_ID,
             Query.simple(
               List(BaseParameter(StatusActions.FIELD_TASK_ID, id)),
-              "SELECT osm_user_id FROM status_action",
-              order = Order > ("created"),
+              "SELECT osm_user_id FROM status_actions",
+              order = Order > "created",
               paging = Paging(limit)
             )
           )

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -445,7 +445,7 @@ class TaskReviewDAL @Inject() (
     }
 
     val parameters = new ListBuffer[NamedParameter]()
-    parameters ++= addSearchToQuery(searchParameters, whereClause)(false)
+    parameters ++= addSearchToQuery(searchParameters, whereClause)
 
     setupReviewSearchClause(whereClause, joinClause, searchParameters, startDate, endDate)
 

--- a/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
+++ b/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
@@ -182,9 +182,9 @@ trait SearchParametersMixin extends DALHelper {
       // specific challenge ids
       case _ =>
         params.challengeParams.requiresLocal match {
-          case SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE =>
+          case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE) =>
             this.appendInWhereClause(whereClause, s"c.requires_local = false")
-          case SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY =>
+          case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY) =>
             this.appendInWhereClause(whereClause, s"c.requires_local = true")
           case _ =>
           // allow everything

--- a/app/org/maproulette/models/utils/DALHelper.scala
+++ b/app/org/maproulette/models/utils/DALHelper.scala
@@ -205,7 +205,7 @@ trait DALHelper {
   )(implicit projectSearch: Boolean = true): ListBuffer[NamedParameter] = {
     val parameters = new ListBuffer[NamedParameter]()
 
-    if (!projectSearch) {
+    if (projectSearch) {
       params.getProjectIds match {
         case Some(p) if p.nonEmpty =>
           appendInWhereClause(whereClause, s"$challengePrefix.parent_id IN (${p.mkString(",")})")

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -6,13 +6,10 @@ package org.maproulette.session
 
 import java.net.URLDecoder
 
-import org.maproulette.utils.Utils
-import play.api.mvc.{AnyContent, Request, AnyContentAsFormUrlEncoded}
-import play.api.data.format.Formats
-import play.api.libs.json._
-import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
 import org.maproulette.exception.InvalidException
+import org.maproulette.utils.Utils
+import play.api.libs.json._
+import play.api.mvc.{AnyContent, AnyContentAsFormUrlEncoded, Request}
 
 /**
   * This holds the search parameters that are used to define task sets for retrieving random tasks
@@ -32,7 +29,7 @@ case class SearchChallengeParameters(
     challengeEnabled: Option[Boolean] = None,
     challengeDifficulty: Option[Int] = None,
     challengeStatus: Option[List[Int]] = None,
-    requiresLocal: Int = SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE
+    requiresLocal: Option[Int] = Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE)
 )
 
 case class SearchParameters(
@@ -154,8 +151,13 @@ object SearchParameters {
         case Some(r) => Utils.insertIntoJson(updated, "challengeStatus", r, true)
         case None    => updated
       }
-      updated =
-        Utils.insertIntoJson(updated, "requiresLocal", o.challengeParams.requiresLocal, true)
+      updated = Utils.insertIntoJson(
+        updated,
+        "requiresLocal",
+        o.challengeParams.requiresLocal
+          .getOrElse(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE),
+        true
+      )
 
       updated = updated.as[JsObject] - "challengeParams"
       updated
@@ -308,8 +310,7 @@ object SearchParameters {
           case None => params.challengeParams.challengeStatus
         },
         //requiresLocal
-        this.getIntParameter(request.getQueryString("cLocal"),
-          Some(params.challengeParams.requiresLocal)).getOrElse(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE)
+        this.getIntParameter(request.getQueryString("cLocal"), Some(params.challengeParams.requiresLocal.getOrElse(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE)))
       ),
       //taskTags
       request.getQueryString("tt") match {

--- a/conf/evolutions/default/61.sql
+++ b/conf/evolutions/default/61.sql
@@ -8,6 +8,8 @@ ALTER TABLE challenges ALTER cooperative_type DROP DEFAULT;;
 ALTER TABLE challenges ALTER cooperative_type TYPE INTEGER USING CASE WHEN cooperative_type=TRUE THEN 1 ELSE 0 END;;
 ALTER TABLE challenges ALTER cooperative_type SET DEFAULT 0;;
 
+SELECT add_drop_column('locked', 'changeset_id', 'integer not null default(-1)');;
+
 -- Creates or updates and task. Will also check if task status needs to be updated
 -- This change makes sure not to reset the task status if a task is disabled or declared a false positive
 DROP FUNCTION IF EXISTS update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp without time zone,integer,integer,integer,timestamp without time zone);;
@@ -156,6 +158,8 @@ ALTER TABLE challenges RENAME COLUMN cooperative_type to has_suggested_fixes;;
 ALTER TABLE challenges ALTER has_suggested_fixes DROP DEFAULT;;
 ALTER TABLE challenges ALTER has_suggested_fixes TYPE BOOLEAN USING CASE WHEN has_suggested_fixes > 0 then TRUE ELSE FALSE END;;
 ALTER TABLE challenges ALTER has_suggested_fixes SET DEFAULT FALSE;;
+
+SELECT add_drop_column('locked', 'changeset_id', '', false);;
 
 -- Creates or updates and task. Will also check if task status needs to be updated
 -- This change makes sure not to reset the task status if a task is disabled or declared a false positive

--- a/conf/v2_route/project.api
+++ b/conf/v2_route/project.api
@@ -266,8 +266,14 @@ GET     /projects/managed                           @org.maproulette.framework.c
 #   - name: challenges
 #     in: query
 #     description: The challenge search string. Retrieve only challenge clustered points that have the search string contained within the challenge name. Match is case insensitive.
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
-GET     /project/clustered/:id                      @org.maproulette.framework.controller.ProjectController.getClusteredPoints(id:Long, challenges:String ?= "")
+GET     /project/clustered/:id                      @org.maproulette.framework.controller.ProjectController.getClusteredPoints(id:Long, challenges:String ?= "", limit:Int ?= 0, page:Int ?= 0)
 ###
 # tags: [ Project ]
 # summary: Retrieves clustered challenge points
@@ -283,8 +289,14 @@ GET     /project/clustered/:id                      @org.maproulette.framework.c
 #   - name: search
 #     in: cookie
 #     description: The challenge search parameters. This is a URL encoded JSON object containing multiple different search parameters. See SearchParameter model.
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 10.
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
 ###
-GET     /project/search/clustered                   @org.maproulette.framework.controller.ProjectController.getSearchedClusteredPoints(search ?= "")
+GET     /project/search/clustered                   @org.maproulette.framework.controller.ProjectController.getSearchedClusteredPoints(limit:Int ?= 0, page:Int ?= 0)
 ###
 # tags: [ Project ]
 # summary: List all the projects challenges.

--- a/test/org/maproulette/framework/FrameworkMasterSuite.scala
+++ b/test/org/maproulette/framework/FrameworkMasterSuite.scala
@@ -7,7 +7,7 @@ package org.maproulette.framework
 
 import org.maproulette.framework.repository._
 import org.maproulette.framework.service._
-import org.maproulette.framework.util.{TestDatabase, UserTag}
+import org.maproulette.framework.util._
 import org.scalatest.{BeforeAndAfterAll, Suite, Suites, Tag}
 
 /**

--- a/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
@@ -18,96 +18,96 @@ class FilterOperatorSpec extends PlaySpec {
 
   "FilterOperator" should {
     "format EQ operator correctly" in {
-      Operator.format(KEY, Operator.EQ) mustEqual s"$KEY = {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.EQ) mustEqual s"$KEY = {$parameterKey}"
     }
 
     "format NOT EQ operator correctly" in {
-      Operator.format(KEY, Operator.EQ, true) mustEqual s"NOT $KEY = {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.EQ, true) mustEqual s"NOT $KEY = {$parameterKey}"
     }
 
     "format GT operator correctly" in {
-      Operator.format(KEY, Operator.GT) mustEqual s"$KEY > {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.GT) mustEqual s"$KEY > {$parameterKey}"
     }
 
     "format NOT GT operator correctly" in {
-      Operator.format(KEY, Operator.GT, true) mustEqual s"NOT $KEY > {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.GT, true) mustEqual s"NOT $KEY > {$parameterKey}"
     }
 
     "format GTE operator correctly" in {
-      Operator.format(KEY, Operator.GTE) mustEqual s"$KEY >= {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.GTE) mustEqual s"$KEY >= {$parameterKey}"
     }
 
     "format NOT GTE operator correctly" in {
-      Operator.format(KEY, Operator.GTE, true) mustEqual s"NOT $KEY >= {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.GTE, true) mustEqual s"NOT $KEY >= {$parameterKey}"
     }
 
     "format LT operator correctly" in {
-      Operator.format(KEY, Operator.LT) mustEqual s"$KEY < {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.LT) mustEqual s"$KEY < {$parameterKey}"
     }
 
     "format NOT LT operator correctly" in {
-      Operator.format(KEY, Operator.LT, true) mustEqual s"NOT $KEY < {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.LT, true) mustEqual s"NOT $KEY < {$parameterKey}"
     }
 
     "format LTE operator correctly" in {
-      Operator.format(KEY, Operator.LTE) mustEqual s"$KEY <= {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.LTE) mustEqual s"$KEY <= {$parameterKey}"
     }
 
     "format NOT LTE operator correctly" in {
-      Operator.format(KEY, Operator.LTE, negate = true) mustEqual s"NOT $KEY <= {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.LTE, negate = true) mustEqual s"NOT $KEY <= {$parameterKey}"
     }
 
     "format IN operator correctly" in {
-      Operator.format(KEY, Operator.IN) mustEqual s"$KEY IN ({$parameterKey$KEY})"
+      Operator.format(KEY, parameterKey, Operator.IN) mustEqual s"$KEY IN ({$parameterKey})"
     }
 
     "format NOT IN operator correctly" in {
-      Operator.format(KEY, Operator.IN, negate = true) mustEqual s"NOT $KEY IN ({$parameterKey$KEY})"
+      Operator.format(KEY, parameterKey, Operator.IN, negate = true) mustEqual s"NOT $KEY IN ({$parameterKey})"
     }
 
     "format LIKE operator correctly" in {
-      Operator.format(KEY, Operator.LIKE) mustEqual s"$KEY LIKE {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.LIKE) mustEqual s"$KEY LIKE {$parameterKey}"
     }
 
     "format NOT LIKE operator correctly" in {
-      Operator.format(KEY, Operator.LIKE, negate = true) mustEqual s"NOT $KEY LIKE {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.LIKE, negate = true) mustEqual s"NOT $KEY LIKE {$parameterKey}"
     }
 
     "format ILIKE operator correctly" in {
-      Operator.format(KEY, Operator.ILIKE) mustEqual s"$KEY ILIKE {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.ILIKE) mustEqual s"$KEY ILIKE {$parameterKey}"
     }
 
     "format NOT ILIKE operator correctly" in {
-      Operator.format(KEY, Operator.ILIKE, negate = true) mustEqual s"NOT $KEY ILIKE {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.ILIKE, negate = true) mustEqual s"NOT $KEY ILIKE {$parameterKey}"
     }
 
     "format SIMILAR TO operator correctly" in {
-      Operator.format(KEY, Operator.SIMILAR_TO) mustEqual s"$KEY SIMILAR TO {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.SIMILAR_TO) mustEqual s"$KEY SIMILAR TO {$parameterKey}"
     }
 
     "format NOT SIMILAR TO operator correctly" in {
-      Operator.format(KEY, Operator.SIMILAR_TO, negate = true) mustEqual s"NOT $KEY SIMILAR TO {$parameterKey$KEY}"
+      Operator.format(KEY, parameterKey, Operator.SIMILAR_TO, negate = true) mustEqual s"NOT $KEY SIMILAR TO {$parameterKey}"
     }
 
     "format EXISTS operator correctly" in {
-      Operator.format(KEY, Operator.EXISTS) mustEqual s"EXISTS ({$parameterKey$KEY})"
+      Operator.format(KEY, parameterKey, Operator.EXISTS) mustEqual s"EXISTS ({$parameterKey})"
     }
 
     "format NOT EXISTS operator correctly" in {
-      Operator.format(KEY, Operator.EXISTS, negate = true) mustEqual s"NOT EXISTS ({$parameterKey$KEY})"
+      Operator.format(KEY, parameterKey, Operator.EXISTS, negate = true) mustEqual s"NOT EXISTS ({$parameterKey})"
     }
 
     "format BOOL operator correctly" in {
-      Operator.format(KEY, Operator.BOOL) mustEqual s"key"
+      Operator.format(KEY, parameterKey, Operator.BOOL) mustEqual s"key"
     }
 
     "format rightValue correctly if set" in {
-      Operator.format(KEY, Operator.EQ, value = Some("test.key")) mustEqual s"$KEY = test.key"
+      Operator.format(KEY, parameterKey, Operator.EQ, value = Some("test.key")) mustEqual s"$KEY = test.key"
     }
 
     "between should throw invalidException" in {
       intercept[InvalidException] {
-        Operator.format(KEY, Operator.BETWEEN)
+        Operator.format(KEY, parameterKey, Operator.BETWEEN)
       }
     }
   }

--- a/test/org/maproulette/framework/psql/GroupingSpec.scala
+++ b/test/org/maproulette/framework/psql/GroupingSpec.scala
@@ -19,16 +19,16 @@ class GroupingSpec extends PlaySpec {
     }
 
     "generate the correct group by value" in {
-      Grouping("test").sql() mustEqual "GROUP BY test"
+      (Grouping > "test").sql() mustEqual "GROUP BY test"
     }
 
     "generate multiple groups correctly" in {
-      Grouping("test1", "test2").sql() mustEqual "GROUP BY test1,test2"
+      (Grouping > ("test1", "test2")).sql() mustEqual "GROUP BY test1,test2"
     }
 
     "fail if provide invalid column name" in {
       intercept[SQLException] {
-        Grouping("$%invalud.name").sql()
+        (Grouping > "$%invalud.name").sql()
       }
     }
   }

--- a/test/org/maproulette/framework/psql/QuerySpec.scala
+++ b/test/org/maproulette/framework/psql/QuerySpec.scala
@@ -118,10 +118,11 @@ class QuerySpec extends PlaySpec {
     )
 
     query
-      .sql() mustEqual s"""SELECT * FROM table WHERE (KEY = {$setKey} OR key2 = {${parameter2.getKey}}) AND (a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2}) AND (${FilterParameterSpec.DEFAULT_FUZZY_SQL(
-      "fuzzy",
-      keyPrefix = parameter5.randomPrefix
-    )} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {${parameter6.getKey}} LIMIT {${paging1.randomPrefix}limit} OFFSET {${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"""
+      .sql() mustEqual s"""SELECT * FROM table WHERE (KEY = {$setKey} OR key2 = {${parameter2.getKey}}) AND (a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2}) AND (${FilterParameterSpec
+      .DEFAULT_FUZZY_SQL(
+        "fuzzy",
+        keyPrefix = parameter5.randomPrefix
+      )} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {${parameter6.getKey}} LIMIT {${paging1.randomPrefix}limit} OFFSET {${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"""
     val params = query.parameters()
     params.size mustEqual 10
     params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)

--- a/test/org/maproulette/framework/psql/QuerySpec.scala
+++ b/test/org/maproulette/framework/psql/QuerySpec.scala
@@ -55,7 +55,7 @@ class QuerySpec extends PlaySpec {
     val query = Query.simple(
       List(parameter),
       "SELECT * FROM table",
-      grouping = Grouping("test1", "test2")
+      grouping = Grouping > ("test1", "test2")
     )
     query.sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey} GROUP BY test1,test2"
     query.parameters().size mustEqual 1
@@ -70,7 +70,7 @@ class QuerySpec extends PlaySpec {
       AND(),
       paging,
       Order > "order",
-      Grouping("test1")
+      Grouping > "test1"
     )
     query
       .sql() mustEqual s"SELECT * FROM table WHERE KEY = {$setKey} GROUP BY test1 ORDER BY order DESC LIMIT {${pagingPrefix}limit} OFFSET {${pagingPrefix}offset}"
@@ -118,8 +118,10 @@ class QuerySpec extends PlaySpec {
     )
 
     query
-      .sql() mustEqual s"SELECT * FROM table WHERE (KEY = {$setKey} OR key2 = {${parameter2.getKey}}) AND (a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2}) AND (${FilterParameterSpec
-      .DEFAULT_FUZZY_SQL("fuzzy", keyPrefix = parameter5.randomPrefix)} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {secondary${parameter6.getKey}} LIMIT {secondary${paging1.randomPrefix}limit} OFFSET {secondary${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"
+      .sql() mustEqual s"""SELECT * FROM table WHERE (KEY = {$setKey} OR key2 = {${parameter2.getKey}}) AND (a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2}) AND (${FilterParameterSpec.DEFAULT_FUZZY_SQL(
+      "fuzzy",
+      keyPrefix = parameter5.randomPrefix
+    )} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {${parameter6.getKey}} LIMIT {${paging1.randomPrefix}limit} OFFSET {${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"""
     val params = query.parameters()
     params.size mustEqual 10
     params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
@@ -131,11 +133,11 @@ class QuerySpec extends PlaySpec {
       "fuzzyValue"
     )
     params(5) mustEqual SQLUtils.buildNamedParameter(
-      s"secondary${parameter6.getKey}",
+      s"${parameter6.getKey}",
       "subsubValue"
     )
-    params(6) mustEqual SQLUtils.buildNamedParameter(s"secondary${paging1.randomPrefix}limit", 10)
-    params(7) mustEqual SQLUtils.buildNamedParameter(s"secondary${paging1.randomPrefix}offset", 0)
+    params(6) mustEqual SQLUtils.buildNamedParameter(s"${paging1.randomPrefix}limit", 10)
+    params(7) mustEqual SQLUtils.buildNamedParameter(s"${paging1.randomPrefix}offset", 0)
     params(8) mustEqual SQLUtils.buildNamedParameter(s"${paging2.randomPrefix}limit", 35)
     params(9) mustEqual SQLUtils.buildNamedParameter(s"${paging2.randomPrefix}offset", 525)
   }

--- a/test/org/maproulette/framework/repository/ChallengeListingRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/ChallengeListingRepositorySpec.scala
@@ -22,7 +22,7 @@ class ChallengeListingRepositorySpec(implicit val application: Application)
 
   "ChallengeListingRepository" should {
     "make a basic query" taggedAs ChallengeListingRepoTag in {
-      val challenges = this.repository.query(Query.simple(List(), grouping = Grouping("c.id")))
+      val challenges = this.repository.query(Query.simple(List(), grouping = Grouping > "c.id"))
       challenges.size mustEqual 11
     }
   }

--- a/test/org/maproulette/framework/repository/CommentRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/CommentRepositorySpec.scala
@@ -91,7 +91,7 @@ class CommentRepositorySpec(implicit val application: Application) extends Frame
     this.commentRepository
       .query(
         Query.simple(
-          List(BaseParameter(s"task_comments.${Comment.FIELD_ID}", id))
+          List(BaseParameter(Comment.FIELD_ID, id))
         )
       )
       .headOption

--- a/test/org/maproulette/framework/service/ChallengeListingSpec.scala
+++ b/test/org/maproulette/framework/service/ChallengeListingSpec.scala
@@ -8,7 +8,7 @@ package org.maproulette.framework.service
 import java.util.UUID
 
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Grouping, Query}
+import org.maproulette.framework.psql.{GroupField, Grouping, Query}
 import org.maproulette.framework.util.{ChallengeListingTag, FrameworkHelper}
 import org.maproulette.models.Task
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
@@ -24,7 +24,10 @@ class ChallengeListingSpec(implicit val application: Application) extends Framew
   "ChallengeListingService" should {
     "make a basic query" taggedAs (ChallengeListingTag) in {
       val challenges = this.service.query(
-        Query.simple(List(), grouping = Grouping("c.id"))
+        Query.simple(
+          List(),
+          grouping = Grouping(GroupField(Challenge.FIELD_ID, Some(Challenge.TABLE)))
+        )
       )
       challenges.size mustEqual 11
     }

--- a/test/org/maproulette/framework/service/CommentServiceSpec.scala
+++ b/test/org/maproulette/framework/service/CommentServiceSpec.scala
@@ -32,7 +32,7 @@ class CommentServiceSpec(implicit val application: Application) extends Framewor
 
     "delete a comment in the database" taggedAs CommentTag in {
       val comment = this.commentService.create(User.superUser, defaultTask.id, "GP delete", None)
-      this.commentService.delete(comment.id, comment.taskId, User.superUser)
+      this.commentService.delete(comment.taskId, comment.id, User.superUser)
       this.commentService.retrieve(comment.id).isEmpty mustEqual true
     }
 
@@ -40,7 +40,7 @@ class CommentServiceSpec(implicit val application: Application) extends Framewor
       intercept[NotFoundException] {
         val comment =
           this.commentService.create(User.superUser, defaultTask.id, "GP delete attempt", None)
-        this.commentService.delete(comment.id, 12355, User.superUser)
+        this.commentService.delete(12355, comment.id, User.superUser)
       }
     }
 

--- a/test/org/maproulette/framework/service/UserServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserServiceSpec.scala
@@ -243,7 +243,8 @@ class UserServiceSpec(implicit val application: Application) extends FrameworkHe
                     BaseParameter("ug.group_id", "g.id", useValueDirectly = true),
                     BaseParameter("g.project_id", "p.id")
                   )
-                )
+                ),
+                table = Some("")
               )
             ),
             OR(),


### PR DESCRIPTION
The Query object suffered from the same issue as the previous DAL's which was basically due to multiple joins on tables and then having potential issues with ambiguous columns. To address this each repository must define an implicit table string. The query object uses this implicit value to automatically prefix all its filters with the prefix. When using Filters on different tables, then you can explicitly set the value of the table you want to use. No alias' are used the full table prefix is used.

So for example if you create a filter like:
```BaseParameter("key", "value")```
it will produce SQL as such
```SELECT * FROM table1 WHERE table1.key = 'value'```
Where the SELECT clause is part of the base query in the Query object. And this would assume that the string `table1` is implicitly set in the repository, which is now required by repositories.

However if you want to write some sql like this:
```
SELECT * FROM table1
INNER JOIN table2 ON table1.id = table2.id
WHERE table1.key1 = 'value1' and table2.key2 = 'value2'
```
You would create your filters like this:
```
Query.simple(List(
    BaseParameter("key1", "value1"),
    BaseParameter("key2", "value2", table = Some("table2"))
  ),
  """SELECT * FROM table1 
       |INNER JOIN table2 ON table1.id = table2.id""".stripMargin
)
```