### PR TITLE
Populate challenge virtualParents, requiresLocal

### DIFF
--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -86,7 +86,7 @@ class ProjectService @Inject() (
             )
           )
         ),
-        s"""SELECT challenges.${ChallengeRepository.standardColumns},
+        s"""SELECT ${ChallengeRepository.standardColumns},
             |ARRAY_REMOVE(ARRAY_AGG(virtual_project_challenges.project_id), NULL) AS virtual_parent_ids
             |FROM challenges
             |LEFT OUTER JOIN virtual_project_challenges ON challenges.id = virtual_project_challenges.challenge_id""".stripMargin,


### PR DESCRIPTION
* Populate `virtualParents` field in challenges retrieved through the
new framework. This requires adding a join into the basic challenges
query

* Support an optional default Grouping in Query class that allows an
overrideable default grouping to be specified for base queries that
require a group by

* Populate the `requiresLocal` field in challenges

* Fixes osmlab/maproulette3#1208