### PR TITLE
Improving Comments query

### DIFF
--- a/test/org/maproulette/framework/util/TestDatabase.scala
+++ b/test/org/maproulette/framework/util/TestDatabase.scala
@@ -17,7 +17,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 trait TestDatabase {
   implicit val application = GuiceApplicationBuilder()
     .configure(
-      "db.default.url"                 -> "jdbc:postgresql://localhost:5432/mr_test",
+      "db.default.url"                 -> "jdbc:postgresql://localhost:5433/mr_test",
       "db.default.username"            -> "osm",
       "db.default.password"            -> "osm",
       "db.default.logSql"              -> false,

--- a/test/org/maproulette/framework/util/TestDatabase.scala
+++ b/test/org/maproulette/framework/util/TestDatabase.scala
@@ -17,7 +17,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 trait TestDatabase {
   implicit val application = GuiceApplicationBuilder()
     .configure(
-      "db.default.url"                 -> "jdbc:postgresql://localhost:5433/mr_test",
+      "db.default.url"                 -> "jdbc:postgresql://localhost:5432/mr_test",
       "db.default.username"            -> "osm",
       "db.default.password"            -> "osm",
       "db.default.logSql"              -> false,


### PR DESCRIPTION
This PR improves the performance of the specific query executed when you call the find function in the CommentService it was executing this query against the database:
```sql
SELECT * FROM task_comments
INNER JOIN users ON users.osm_id = task_comments.osm_id
WHERE task_comments.project_id IN (<PROJECT_IDS>) OR 
1 IN (SELECT 1 FROM unnest(ARRAY[<PROJECT_IDS>]) AS pIds
		WHERE pIds IN (SELECT virtual_project_challenges.project_id FROM virtual_project_challenges
                		WHERE virtual_project_challenges.challenge_id = task_comments.challenge_id)) OR 
task_comments.project_id IN (<PROJECT_IDS>) 
ORDER BY task_comments.project_id,task_comments.challenge_id,task_comments.created DESC 
LIMIT 10 OFFSET 0
```
which would take roughly 35 seconds to complete. This PR updates it so that it will execute this query:
```sql
SELECT * FROM task_comments
INNER JOIN users ON users.osm_id = task_comments.osm_id
LEFT OUTER JOIN virtual_project_challenges ON virtual_project_challenges.challenge_id = task_comments.challenge_id
WHERE task_comments.project_id IN (<PROJECT_IDS>) OR 
virtual_project_challenges.project_id IN (<PROJECT_IDS>) OR
task_comments.project_id IN (<PROJECT_IDS>) 
ORDER BY task_comments.project_id,task_comments.challenge_id,task_comments.created DESC 
LIMIT 10 OFFSET 0
```

This reduces the time taken to execute the query from roughly 35 seconds to 200 milliseconds. The query should be equivalent, and is basically creating a left outer join on an indexed field and then filtering on one of the fields of that outer join. The reason why this is so fast is that the join happens once (on an indexed field) instead of running once for every single comment in the system which even if that select is fast, running it so may times will slow the query a lot especially as the task_comments table grows. 