### PR TITLE
Fix user group table name on permission query.

### DIFF
--- a/app/org/maproulette/framework/service/ServiceHelper.scala
+++ b/app/org/maproulette/framework/service/ServiceHelper.scala
@@ -66,7 +66,7 @@ trait ServiceHelper {
                 table = Some(Group.TABLE)
               )
             ),
-            base = "SELECT ug.osm_user_id FROM user_groups, groups "
+            base = s"SELECT ${Group.TABLE_USER_GROUP}.osm_user_id FROM user_groups, groups "
           ),
           table = Some("")
         )


### PR DESCRIPTION
Query was still using usergroup table name as "ug" instead of new constant Group.TABLE_USER_GROUP