### PR TITLE
Fix user metrics

### DIFF
--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -77,7 +77,7 @@ class UserMetricService @Inject() (
       taskMonthDuration,
       startDate,
       endDate,
-      s"sa1.${StatusActions.FIELD_CREATED}"
+      s"${StatusActions.FIELD_CREATED}"
     )
     val taskCounts = this.repository.getUserTaskCounts(userId, timeClause)
 
@@ -175,6 +175,14 @@ class UserMetricService @Inject() (
         DateParameter(
           field,
           DateTime.now.withDayOfMonth(1),
+          DateTime.now,
+          Operator.BETWEEN
+        )
+      case -1 =>
+        // All time.
+        DateParameter(
+          field,
+          new DateTime(2000, 1, 1, 0, 0, 0, 0),
           DateTime.now,
           Operator.BETWEEN
         )

--- a/test/org/maproulette/framework/service/UserMetricsServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserMetricsServiceSpec.scala
@@ -19,7 +19,12 @@ class UserMetricsServiceSpec(implicit val application: Application) extends Fram
 
   "UserMetricService" should {
     "get metrics for a user" taggedAs UserMetricsTag in {
-      //TODO
+      //TODO expand these tests.
+      val insertedUser =
+        this.userService.create(this.getTestUser(19, "UpdateUserService"), User.superUser)
+      val userMetrics =
+        this.service.getMetricsForUser(
+          insertedUser.id, insertedUser, -1, -1, -1, "", "", "", "", "", "")
     }
 
     "updates the users score" taggedAs UserMetricsTag in {

--- a/test/org/maproulette/framework/service/UserMetricsServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserMetricsServiceSpec.scala
@@ -24,7 +24,18 @@ class UserMetricsServiceSpec(implicit val application: Application) extends Fram
         this.userService.create(this.getTestUser(19, "UpdateUserService"), User.superUser)
       val userMetrics =
         this.service.getMetricsForUser(
-          insertedUser.id, insertedUser, -1, -1, -1, "", "", "", "", "", "")
+          insertedUser.id,
+          insertedUser,
+          -1,
+          -1,
+          -1,
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        )
     }
 
     "updates the users score" taggedAs UserMetricsTag in {


### PR DESCRIPTION
* User metrics attemping to use table "sa1" instead of letting
  new table naming be appended automatically

* User metrics date clause calculation ingoring time durations
  of -1 which should represent "all time"

* Created simple test that just exercises the method