### PR TITLE
Improve sql performance of 'preferred' api

### DIFF
--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -377,6 +377,9 @@ class ProjectService @Inject() (
       ids: List[Long],
       paging: Paging = Paging()
   ): List[Project] = {
+    if (ids.isEmpty) {
+      return List()
+    }
     this.query(
       Query.simple(
         List(

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -869,12 +869,8 @@ class ChallengeDAL @Inject() (
                       WHERE c.featured = TRUE ${this.enabled(enabledOnly, "c")} ${this
           .enabled(enabledOnly, "p")}
                       AND c.deleted = false and p.deleted = false
-                      AND (c.status <> ${Challenge.STATUS_BUILDING} AND
-                           c.status <> ${Challenge.STATUS_DELETING_TASKS} AND
-                           c.status <> ${Challenge.STATUS_FAILED} AND
-                           c.status <> ${Challenge.STATUS_FINISHED})
+                      AND (c.status = ${Challenge.STATUS_READY})
                       AND c.requires_local = false
-                      AND 0 < (SELECT COUNT(*) FROM tasks WHERE parent_id = c.id)
                       LIMIT ${this.sqlLimit(limit)} OFFSET $offset"""
       SQL(query).as(this.parser.*)
     }
@@ -898,12 +894,8 @@ class ChallengeDAL @Inject() (
                       INNER JOIN projects p ON p.id = c.parent_id
                       WHERE c.deleted = false and p.deleted = false
                       ${this.enabled(enabledOnly, "c")} ${this.enabled(enabledOnly, "p")}
-                      AND (c.status <> ${Challenge.STATUS_BUILDING} AND
-                           c.status <> ${Challenge.STATUS_DELETING_TASKS} AND
-                           c.status <> ${Challenge.STATUS_FAILED} AND
-                           c.status <> ${Challenge.STATUS_FINISHED})
+                      AND (c.status = ${Challenge.STATUS_READY})
                       AND c.requires_local = false
-                      AND 0 < (SELECT COUNT(*) FROM tasks WHERE parent_id = c.id)
                       ORDER BY popularity DESC LIMIT ${this.sqlLimit(limit)} OFFSET $offset"""
       SQL(query).as(this.parser.*)
     }
@@ -927,10 +919,7 @@ class ChallengeDAL @Inject() (
                       WHERE ${this.enabled(enabledOnly, "c")(None)} ${this
           .enabled(enabledOnly, "p")}
                       AND c.deleted = false and p.deleted = false
-                      AND (c.status <> ${Challenge.STATUS_BUILDING} AND
-                           c.status <> ${Challenge.STATUS_DELETING_TASKS} AND
-                           c.status <> ${Challenge.STATUS_FAILED} AND
-                           c.status <> ${Challenge.STATUS_FINISHED})
+                      AND (c.status = ${Challenge.STATUS_READY})
                       AND c.requires_local = false
                       ${this.order(Some("created"), "DESC", "c", true)}
                       LIMIT ${this.sqlLimit(limit)} OFFSET $offset"""


### PR DESCRIPTION
* Change sql queries when fetching "hot", "new" and "featured"

* In fetching projects list to not retrieve all projects if
  given a list of empty ids.