### PR TITLE
Add ability to retrieve tags when fetching task lists

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -425,12 +425,13 @@ class TaskController @Inject() (
       right: Double,
       top: Double,
       limit: Int,
-      offset: Int,
+      page: Int,
       excludeLocked: Boolean,
       sort: String = "",
       order: String = "ASC",
       includeTotal: Boolean = false,
-      includeGeometries: Boolean = false
+      includeGeometries: Boolean = false,
+      includeTags: Boolean = false
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { p =>
@@ -439,13 +440,13 @@ class TaskController @Inject() (
           User.userOrMocked(user),
           params,
           limit,
-          offset,
+          page,
           excludeLocked,
           sort,
           order
         )
 
-        val resultJson = _insertExtraJSON(result, includeGeometries)
+        val resultJson = _insertExtraJSON(result, includeGeometries, includeTags)
 
         if (includeTotal) {
           Ok(Json.obj("total" -> count, "tasks" -> resultJson))
@@ -462,7 +463,8 @@ class TaskController @Inject() (
     */
   private def _insertExtraJSON(
       tasks: List[ClusteredPoint],
-      includeGeometries: Boolean = false
+      includeGeometries: Boolean = false,
+      includeTags: Boolean = false
   ): JsValue = {
     if (tasks.isEmpty) {
       Json.toJson(List[JsValue]())
@@ -496,6 +498,11 @@ class TaskController @Inject() (
           case false => null
         }
 
+      val tagsMap: Map[Long, List[Tag]] = includeTags match {
+        case true => this.serviceManager.tag.listByTasks(tasks.map(t => t.id))
+        case _    => null
+      }
+
       val jsonList = tasks.map { task =>
         var updated         = Json.toJson(task)
         var reviewPointJson = Json.toJson(task.pointReview).as[JsObject]
@@ -525,6 +532,13 @@ class TaskController @Inject() (
         if (includeGeometries) {
           val geometries = Json.parse(taskDetailsMap(task.id).geometries)
           updated = Utils.insertIntoJson(updated, "geometries", geometries, true)
+        }
+
+        if (includeTags) {
+          if (tagsMap.contains(task.id)) {
+            val tagsJson = Json.toJson(tagsMap(task.id))
+            updated = Utils.insertIntoJson(updated, "tags", tagsJson, true)
+          }
         }
 
         updated

--- a/app/org/maproulette/framework/model/Tag.scala
+++ b/app/org/maproulette/framework/model/Tag.scala
@@ -27,6 +27,14 @@ case class Tag(
     tagType: String = "challenges"
 ) extends CacheObject[Long]
 
+/**
+  * Mapping between Task and Tag
+  */
+case class TaskTag(
+    taskId: Long,
+    tag: Tag
+)
+
 object Tag extends CommonField {
   implicit val tagWrites: Writes[Tag] = Json.writes[Tag]
   implicit val tagReads: Reads[Tag]   = Json.reads[Tag]

--- a/app/org/maproulette/framework/service/TagService.scala
+++ b/app/org/maproulette/framework/service/TagService.scala
@@ -166,6 +166,29 @@ class TagService @Inject() (
   }
 
   /**
+    * Get all the tags for a specific task
+    *
+    * @param id The id fo the task
+    * @return List of tags for the task
+    */
+  def listByTasks(taskIds: List[Long]): Map[Long, List[Tag]] = {
+    this.repository.queryTaskTags(
+      Query.simple(
+        List(
+          BaseParameter(
+            Tag.FIELD_TASK_ID,
+            taskIds,
+            operator = Operator.IN,
+            table = Some(Tag.TABLE_TAGS_ON_TASKS)
+          )
+        ),
+        """SELECT *, task_id FROM tags
+           INNER JOIN tags_on_tasks ON tags.id = tags_on_tasks.tag_id"""
+      )
+    )
+  }
+
+  /**
     * This is an "upsert" function that will try and insert tags into the database based on a list,
     * it will either update the data for the tag if the tag already exists or create a new tag if
     * the tag does not exist. A tag is considered to exist if the id or the name is found in the

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -977,6 +977,7 @@ class TaskReviewDAL @Inject() (
     this.paramsProjectSearch(searchParameters, whereClause)
     this.paramsTaskId(searchParameters, whereClause)
     this.paramsPriority(searchParameters, whereClause)
+    this.paramsTaskTags(searchParameters, whereClause)
 
     if (startDate != null && startDate.matches("[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]")) {
       this.appendInWhereClause(whereClause, "reviewed_at >= '" + startDate + " 00:00:00'")

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -67,6 +67,9 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #   - name: excludeOtherReviewers
 #     in: query
 #     description: exclude tasks that have been reviewed by someone else
+#   - name: includeTags
+#     in: query
+#     description: In response include list of tags for each task
 #   - name: cs
 #     in: query
 #     description: The search string used to match the Challenge names. Default value is empty string, ie. will match all challenges.
@@ -74,7 +77,7 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #     in: query
 #     description: The search string used to match the name of the person requesting the review. (review_requested_by)
 ###
-GET     /tasks/review                          @org.maproulette.controllers.api.TaskReviewController.getReviewRequestedTasks(startDate: String ?= null, endDate: String ?= null, onlySaved: Boolean ?= false, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", excludeOtherReviewers: Boolean ?= false)
+GET     /tasks/review                          @org.maproulette.controllers.api.TaskReviewController.getReviewRequestedTasks(startDate: String ?= null, endDate: String ?= null, onlySaved: Boolean ?= false, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", excludeOtherReviewers: Boolean ?= false, includeTags: Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves reviewed tasks that have been reviewed either by this user or where the user requested
@@ -123,8 +126,11 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #   - name: r
 #     in: query
 #     description: The search string used to match the Reviewer names. (reviewed_by)
+#   - name: includeTags
+#     in: query
+#     description: In response include list of tags for each task
 ###
-GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(mappers:String ?= "", reviewers:String ?= "", startDate: String ?= null, endDate: String ?= null, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC")
+GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(mappers:String ?= "", reviewers:String ?= "", startDate: String ?= null, endDate: String ?= null, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", includeTags:Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves and claims a the next review needed Task

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -520,8 +520,11 @@ GET     /tasks/random                               @org.maproulette.controllers
 #   - name: includeGeometries
 #     in: query
 #     description: Optional flag to have geometries data returned for each task.
+#   - name: includeTags
+#     in: query
+#     description: Optional flag to have tag data returned for each task.
 ###
-PUT     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false)
+PUT     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false, includeTags:Boolean ?= false)
 ###
 # tags: [ Task ]
 # summary: Update Task Changeset
@@ -730,7 +733,7 @@ PUT     /taskCluster                                @org.maproulette.controllers
 # summary: Retrieves Tasks within a bounding box
 # deprecated: true
 ###
-GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false)
+GET     /tasks/box/:left/:bottom/:right/:top        @org.maproulette.controllers.api.TaskController.getTasksInBoundingBox(left:Double, bottom:Double, right:Double, top:Double, limit:Int ?= 10000, page:Int ?= 0, excludeLocked:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", includeTotal:Boolean ?= false, includeGeometries:Boolean ?=false, includeTags:Boolean ?= false)
 ###
 # tags: [ Task ]
 # summary: Retrieves task clusters. USE PUT METHOD

--- a/test/org/maproulette/framework/service/TagServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TagServiceSpec.scala
@@ -108,5 +108,19 @@ class TagServiceSpec(implicit val application: Application) extends FrameworkHel
       retrievedTags.size mustEqual 4
       retrievedTags.foreach(tag => tag.name.startsWith("challengetag") mustEqual true)
     }
+
+    "list all tags by a list of tasks" taggedAs KeywordTag in {
+      val tagList     = (1 to 4).map(index => Tag(-1, s"TaskTag$index")).toList
+      val createdTags = this.service.updateTagList(tagList, User.superUser)
+      this.taskDAL.updateItemTags(
+        this.defaultTask.id,
+        createdTags.map(_.id),
+        this.defaultUser,
+        true
+      )
+      val tagMap = this.service.listByTasks(List(this.defaultTask.id))
+      tagMap(this.defaultTask.id).size mustEqual 4
+      tagMap(this.defaultTask.id).foreach(tag => tag.name.startsWith("tasktag") mustEqual true)
+    }
   }
 }


### PR DESCRIPTION
* When fetching tasks in bounding box add optional flag
  to also include tag data

* When fetching reviewNeeded or reviewed tasks add
  optional flag to also include tag data

* Add support for searching by task tags ('tt') when
  fetching review tasks and bounded/clustered tasks.