### PR TITLE
Exclude task skip times in user metrics time spent

### DIFF
--- a/app/org/maproulette/framework/repository/UserRepository.scala
+++ b/app/org/maproulette/framework/repository/UserRepository.scala
@@ -288,11 +288,13 @@ class UserRepository @Inject() (
              COALESCE(SUM(CASE WHEN status_actions.status = ${Task.STATUS_TOO_HARD} then 1 else 0 end), 0) total_too_hard,
              COALESCE(SUM(CASE WHEN status_actions.status = ${Task.STATUS_SKIPPED} then 1 else 0 end), 0) total_skipped,
              COALESCE(SUM(CASE WHEN (status_actions.created IS NOT NULL AND
-                                     status_actions.started_at IS NOT NULL)
+                                     status_actions.started_at IS NOT NULL AND
+                                     status_actions.status != ${Task.STATUS_SKIPPED})
                       THEN (EXTRACT(EPOCH FROM (status_actions.created - status_actions.started_at)) * 1000)
                       ELSE 0 END), 0) as total_time_spent,
              COALESCE(SUM(CASE WHEN (status_actions.created IS NOT NULL AND
-                                     status_actions.started_at IS NOT NULL)
+                                     status_actions.started_at IS NOT NULL AND
+                                     status_actions.status != ${Task.STATUS_SKIPPED})
                       THEN 1 ELSE 0 END), 0) as tasks_with_time
            FROM tasks
            INNER JOIN status_actions ON status_actions.task_id = tasks.id AND status_actions.status = tasks.status

--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -286,13 +286,16 @@ class UserMetricService @Inject() (
             case None => // not a review
           }
         } else {
-          taskTimeSpent match {
-            case Some(time) =>
-              insertBuffer.addOne(this.customFilter(UserMetrics.FIELD_TASKS_WITH_TIME))
-              insertBuffer.addOne(
-                this.customFilter(UserMetrics.FIELD_TOTAL_TIME_SPENT, value = time)
-              )
-            case _ => // not updating time
+          // Only update time if user isn't "skipping"
+          if (taskStatus.getOrElse(0) != Task.STATUS_SKIPPED) {
+            taskTimeSpent match {
+              case Some(time) =>
+                insertBuffer.addOne(this.customFilter(UserMetrics.FIELD_TASKS_WITH_TIME))
+                insertBuffer.addOne(
+                  this.customFilter(UserMetrics.FIELD_TOTAL_TIME_SPENT, value = time)
+                )
+              case _ => // not updating time
+            }
           }
         }
         this.repository.updateUserScore(userId, insertBuffer.toList)

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -651,9 +651,12 @@ class TaskDAL @Inject() (
         if (!skipStatusUpdate) {
           startedLock match {
             case Some(l) =>
-              SQL"""UPDATE tasks SET completed_time_spent = (SELECT (extract(epoch from NOW()) * 1000 - ${l
-                .getMillis()}))
-                    WHERE id = ${task.id}""".executeUpdate()
+              completedTimeSpent = Some(
+                SQL"""UPDATE tasks SET completed_time_spent = (SELECT (extract(epoch from NOW()) * 1000 - ${l
+                  .getMillis()}))
+                     WHERE id = ${task.id} RETURNING completed_time_spent"""
+                  .as(SqlParser.long("completed_time_spent").single)
+              )
             case _ => // do nothing
           }
         }


### PR DESCRIPTION
* When calculating user metrics avg time spent exclude skipped tasks

* Don't update user metrics 'total_time_spent' and 'total_tasks_with_time'
  fields if task is skipped

* Fix bug when taskDAL.setTaskStatus was calculating completedTimeSpent