### PR TITLE
Clean up empty task tags

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -860,7 +860,7 @@ class TaskController @Inject() (
       this.serviceManager.comment.create(user, task.id, comment, actionId)
     }
 
-    val tagList = tags.split(",").toList
+    val tagList = if (tags == "") List() else tags.split(",").toList
     if (tagList.nonEmpty) {
       this.addTagstoItem(taskId, tagList.map(new Tag(-1, _, tagType = this.dal.tableName)), user)
     }

--- a/conf/evolutions/default/62.sql
+++ b/conf/evolutions/default/62.sql
@@ -1,6 +1,10 @@
 # --- MapRoulette Scheme
 
 # --- !Ups
+-- Clean up empty task tags.
+-- (This will also clean up the join tables as well. tags_on_tasks/tags_on_challenges)
+DELETE FROM tags where name='';
+
 -- Combine groups and user_groups into new grants table
 CREATE TABLE IF NOT EXISTS grants
 (


### PR DESCRIPTION
When skipping a task and not adding any tags, an empty tag was
being inserted for the task.