### PR TITLE
fix issue 'no user found using id [-1]' if try to change status

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -677,13 +677,18 @@ class TaskDAL @Inject() (
                      VALUES (${task.id}, ${user.id}, ${task.review.reviewedBy},
                              ${Task.REVIEW_STATUS_REQUESTED}, ${Instant.now()},
                              ${task.review.reviewStartedAt})""".executeUpdate()
-              this.manager.notification.createReviewNotification(
-                user,
-                task.review.reviewedBy.getOrElse(-1),
-                Task.REVIEW_STATUS_REQUESTED,
-                task,
-                None
-              )
+
+              // Create notification only if task has reviewer
+              val reviewedBy: Long = task.review.reviewedBy.getOrElse(-1)
+              if (reviewedBy != -1) {
+                this.manager.notification.createReviewNotification(
+                  user,
+                  reviewedBy,
+                  Task.REVIEW_STATUS_REQUESTED,
+                  task,
+                  None
+                )
+              }
             case None =>
               SQL"""INSERT INTO task_review (task_id, review_status, review_requested_by)
                       VALUES (${task.id}, ${Task.REVIEW_STATUS_REQUESTED}, ${user.id})"""


### PR DESCRIPTION
This is fix error "No User found using id [-1] to check read access" on attempt to change task status when review was requested but nobody has reviewed it yet.

In case when new record is created in `task_review` table then `reviewed_by is null` initially. After that if user tries to change task status, error `No User found using id [-1] to check read access` will occur. This is because we are trying to add a notification for an unknown user.