### PR TITLE
Add api to export mapper review metrics CSV

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -206,7 +206,9 @@ class ChallengeController @Inject() (
         val filter = if (StringUtils.isEmpty(statusFilter)) {
           None
         } else {
-          searchParams = params.copy(taskStatus = Some(Utils.split(statusFilter).map(_.toInt)))
+          searchParams = params.copy(taskParams =
+            params.taskParams.copy(taskStatus = Some(Utils.split(statusFilter).map(_.toInt)))
+          )
         }
 
         val result = this.dal.getClusteredPoints(
@@ -282,8 +284,10 @@ class ChallengeController @Inject() (
       SearchParameters.withSearch { p =>
         val params = p.copy(
           challengeParams = p.challengeParams.copy(challengeIds = Some(List(challengeId))),
-          taskSearch = Some(taskSearch),
-          taskTags = Some(Utils.split(tags))
+          taskParams = p.taskParams.copy(
+            taskSearch = Some(taskSearch),
+            taskTags = Some(Utils.split(tags))
+          )
         )
         val result = this.dalManager.task.getRandomTasksWithPriority(
           User.userOrMocked(user),
@@ -320,8 +324,10 @@ class ChallengeController @Inject() (
       SearchParameters.withSearch { p =>
         val params = p.copy(
           challengeParams = p.challengeParams.copy(challengeIds = Some(List(challengeId))),
-          taskSearch = Some(taskSearch),
-          taskTags = Some(Utils.split(tags))
+          taskParams = p.taskParams.copy(
+            taskSearch = Some(taskSearch),
+            taskTags = Some(Utils.split(tags))
+          )
         )
         val result = this.dalManager.task.getRandomTasks(
           User.userOrMocked(user),
@@ -658,9 +664,8 @@ class ChallengeController @Inject() (
         val allParams =
           params.copy(
             challengeParams = params.challengeParams.copy(challengeIds = Some(challengeIds)),
-            taskStatus = status,
-            taskReviewStatus = reviewStatus,
-            taskPriorities = priority
+            taskParams = params.taskParams
+              .copy(taskStatus = status, taskReviewStatus = reviewStatus, taskPriorities = priority)
           )
 
         val (tasks, allComments) =

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -27,6 +27,7 @@ import org.maproulette.provider.osm._
 import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
 import org.maproulette.session.{
   SearchChallengeParameters,
+  SearchTaskParameters,
   SearchLocation,
   SearchParameters,
   SessionManager
@@ -335,8 +336,10 @@ class TaskController @Inject() (
           challengeSearch = Some(challengeSearch),
           challengeTags = Some(challengeTags.split(",").toList)
         ),
-        taskTags = Some(tags.split(",").toList),
-        taskSearch = Some(taskSearch)
+        taskParams = SearchTaskParameters(
+          taskTags = Some(tags.split(",").toList),
+          taskSearch = Some(taskSearch)
+        )
       )
       val result = this.dal.getRandomTasks(
         User.userOrMocked(user),

--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -134,8 +134,6 @@ class TaskReviewController @Inject() (
   /**
     * Gets tasks where a review is requested
     *
-    * @param startDate Optional start date to filter by reviewedAt date
-    * @param endDate Optional end date to filter by reviewedAt date
     * @param limit The number of tasks to return
     * @param page The page number for the results
     * @param sort The column to sort
@@ -144,8 +142,6 @@ class TaskReviewController @Inject() (
     * @return
     */
   def getReviewRequestedTasks(
-      startDate: String = null,
-      endDate: String = null,
       onlySaved: Boolean = false,
       limit: Int,
       page: Int,
@@ -162,8 +158,6 @@ class TaskReviewController @Inject() (
         val (count, result) = this.taskReviewDAL.getReviewRequestedTasks(
           User.userOrMocked(user),
           params,
-          startDate,
-          endDate,
           onlySaved,
           limit,
           page,
@@ -180,9 +174,6 @@ class TaskReviewController @Inject() (
   /**
     * Gets reviewed tasks where the user has reviewed or requested review
     *
-    * @param startDate Optional start date to filter by reviewedAt date
-    * @param endDate Optional end date to filter by reviewedAt date
-    * @param reviewers Whether we should return tasks reviewed by this user or reqested by this user
     * @param allowReviewNeeded Whether we should return tasks where status is review requested also
     * @param limit The number of tasks to return
     * @param page The page number for the results
@@ -191,10 +182,6 @@ class TaskReviewController @Inject() (
     * @return
     */
   def getReviewedTasks(
-      mappers: String = "",
-      reviewers: String = "",
-      startDate: String = null,
-      endDate: String = null,
       allowReviewNeeded: Boolean = false,
       limit: Int,
       page: Int,
@@ -207,10 +194,6 @@ class TaskReviewController @Inject() (
         val (count, result) = this.taskReviewDAL.getReviewedTasks(
           User.userOrMocked(user),
           params,
-          Some(Utils.split(mappers)),
-          Some(Utils.split(reviewers)),
-          startDate,
-          endDate,
           allowReviewNeeded,
           limit,
           page,
@@ -302,8 +285,6 @@ class TaskReviewController @Inject() (
     *
     * @param reviewTasksType Type of review tasks (1: To Be Reviewed 2: User's reviewed Tasks 3: All reviewed by users)
     * @param numberOfPoints Number of clustered points you wish to have returned
-    * @param startDate Optional start date to filter by reviewedAt date
-    * @param endDate Optional end date to filter by reviewedAt date
     * @param onlySaved include challenges that have been saved
     * @param excludeOtherReviewers exclude tasks that have been reviewed by someone else
     *
@@ -312,8 +293,6 @@ class TaskReviewController @Inject() (
   def getReviewTaskClusters(
       reviewTasksType: Int,
       numberOfPoints: Int,
-      startDate: String = null,
-      endDate: String = null,
       onlySaved: Boolean = false,
       excludeOtherReviewers: Boolean = false
   ): Action[AnyContent] = Action.async { implicit request =>
@@ -326,8 +305,6 @@ class TaskReviewController @Inject() (
               reviewTasksType,
               params,
               numberOfPoints,
-              startDate,
-              endDate,
               onlySaved,
               excludeOtherReviewers
             )

--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -16,6 +16,8 @@ import org.maproulette.models.dal.{TaskDAL, VirtualChallengeDAL}
 import org.maproulette.models.{ClusteredPoint, Task, VirtualChallenge}
 import org.maproulette.session.{
   SearchChallengeParameters,
+  SearchTaskParameters,
+  SearchReviewParameters,
   SearchLocation,
   SearchParameters,
   SessionManager,
@@ -55,6 +57,10 @@ class VirtualChallengeController @Inject() (
   implicit val taskPropertySearchReads  = Json.reads[TaskPropertySearch]
   implicit val challengeParamsWrites    = Json.writes[SearchChallengeParameters]
   implicit val challengeParamsReads     = Json.reads[SearchChallengeParameters]
+  implicit val taskParamsWrites         = Json.writes[SearchTaskParameters]
+  implicit val taskParamsReads          = Json.reads[SearchTaskParameters]
+  implicit val reviewParamsWrites       = Json.writes[SearchReviewParameters]
+  implicit val reviewParamsReads        = Json.reads[SearchReviewParameters]
   implicit val paramsWrites             = Json.writes[SearchParameters]
   implicit val paramsReads              = Json.reads[SearchParameters]
 

--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -379,13 +379,13 @@ class DataManager @Inject() (config: Config, db: Database, boundingBoxFinder: Bo
 
       params match {
         case Some(search) =>
-          search.taskStatus match {
+          search.taskParams.taskStatus match {
             case Some(s) if s.nonEmpty =>
               searchFilters.append(s" AND t.status IN (${s.mkString(",")}) ")
             case _ =>
           }
 
-          search.taskReviewStatus match {
+          search.taskParams.taskReviewStatus match {
             case Some(statuses) if statuses.nonEmpty =>
               val filter = new StringBuilder(s"""AND (t.id IN (SELECT task_id FROM task_review tr
                                                           WHERE tr.task_id = t.id AND tr.review_status
@@ -421,7 +421,7 @@ class DataManager @Inject() (config: Config, db: Database, boundingBoxFinder: Bo
             case _ => // ignore
           }
 
-          search.taskId match {
+          search.taskParams.taskId match {
             case Some(tid) =>
               searchFilters.append(s" AND CAST(t.id AS TEXT) LIKE '${tid}%' ")
             case _ => // ignore

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -121,19 +121,12 @@ class TaskReviewController @Inject() (
     * Gets reviewed tasks where the user has reviewed or requested review
     *
     * @param reviewTasksType - 1: To Be Reviewed 2: User's reviewed Tasks 3: All reviewed by users
-    * @param startDate Optional start date to filter by reviewedAt date
-    * @param endDate Optional end date to filter by reviewedAt date
     * @param onlySaved Only include saved challenges
     * @param excludeOtherReviewers exclude tasks that have been reviewed by someone else
     * @return
     */
   def getReviewMetrics(
       reviewTasksType: Int,
-      mappers: String = "",
-      reviewers: String = "",
-      priorities: String = "",
-      startDate: String = null,
-      endDate: String = null,
       onlySaved: Boolean = false,
       excludeOtherReviewers: Boolean = false,
       includeByPriority: Boolean = false,
@@ -145,11 +138,6 @@ class TaskReviewController @Inject() (
           User.userOrMocked(user),
           reviewTasksType,
           params,
-          Some(Utils.split(mappers)),
-          Some(Utils.split(reviewers)),
-          Utils.toIntList(priorities),
-          startDate,
-          endDate,
           onlySaved,
           excludeOtherReviewers
         )
@@ -164,10 +152,6 @@ class TaskReviewController @Inject() (
               User.userOrMocked(user),
               reviewTasksType,
               params,
-              Some(Utils.split(mappers)),
-              Some(Utils.split(reviewers)),
-              startDate,
-              endDate,
               onlySaved,
               excludeOtherReviewers
             )
@@ -181,11 +165,6 @@ class TaskReviewController @Inject() (
               User.userOrMocked(user),
               reviewTasksType,
               params,
-              Some(Utils.split(mappers)),
-              Some(Utils.split(reviewers)),
-              Utils.toIntList(priorities),
-              startDate,
-              endDate,
               onlySaved,
               excludeOtherReviewers
             )
@@ -206,10 +185,6 @@ class TaskReviewController @Inject() (
       user: User,
       reviewTasksType: Int,
       params: SearchParameters,
-      mappers: Option[List[String]],
-      reviewers: Option[List[String]],
-      startDate: String,
-      endDate: String,
       onlySaved: Boolean,
       excludeOtherReviewers: Boolean
   ): scala.collection.mutable.Map[String, JsValue] = {
@@ -219,15 +194,13 @@ class TaskReviewController @Inject() (
     val priorityMap = scala.collection.mutable.Map[String, JsValue]()
 
     prioritiesToFetch.foreach(p => {
+      val newParams =
+        params.copy(reviewParams = params.reviewParams.copy(priorities = Some(List(p))))
+
       val pResult = this.service.getReviewMetrics(
         user,
         reviewTasksType,
-        params,
-        mappers,
-        reviewers,
-        Some(List(p)),
-        startDate,
-        endDate,
+        newParams,
         onlySaved,
         excludeOtherReviewers
       )
@@ -242,11 +215,6 @@ class TaskReviewController @Inject() (
       user: User,
       reviewTasksType: Int,
       params: SearchParameters,
-      mappers: Option[List[String]],
-      reviewers: Option[List[String]],
-      priorities: Option[List[Int]] = None,
-      startDate: String,
-      endDate: String,
       onlySaved: Boolean,
       excludeOtherReviewers: Boolean
   ): scala.collection.mutable.Map[String, JsValue] = {
@@ -262,18 +230,13 @@ class TaskReviewController @Inject() (
 
     statusesToFetch.foreach(m => {
       val newParams = params.copy(
-        taskStatus = Some(List(m))
+        taskParams = params.taskParams.copy(taskStatus = Some(List(m)))
       )
 
       val mResult = this.service.getReviewMetrics(
         user,
         reviewTasksType,
         newParams,
-        mappers,
-        reviewers,
-        priorities,
-        startDate,
-        endDate,
         onlySaved,
         excludeOtherReviewers
       )
@@ -287,20 +250,16 @@ class TaskReviewController @Inject() (
   /**
     * Returns a CSV export of review metrics per mapper.
     *
-    * @param mappers Optional limit to reviews of tasks by specific mappers
-    * @param reviewers Optional limit reviews done by specific reviewers
-    * @param priorities Optional limit to only these priorities
-    * @param startDate Optional start date to filter by reviewedAt date
-    * @param endDate Optional end date to filter by reviewedAt date
+    * SearchParameters:
+    *   mappers Optional limit to reviews of tasks by specific mappers
+    *   reviewers Optional limit reviews done by specific reviewers
+    *   priorities Optional limit to only these priorities
+    *   startDate Optional start date to filter by reviewedAt date
+    *   endDate Optional end date to filter by reviewedAt date
     * @param onlySaved Only include saved challenges
     * @return
     */
   def extractMapperMetrics(
-      mappers: String = "",
-      reviewers: String = "",
-      priorities: String = "",
-      startDate: String = null,
-      endDate: String = null,
       onlySaved: Boolean = false
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
@@ -308,11 +267,6 @@ class TaskReviewController @Inject() (
         val metrics = this.service.getMapperMetrics(
           User.userOrMocked(user),
           params,
-          Some(Utils.split(mappers)),
-          Some(Utils.split(reviewers)),
-          Utils.toIntList(priorities),
-          startDate,
-          endDate,
           onlySaved
         )
 

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -5,11 +5,13 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
+import akka.util.ByteString
 import org.maproulette.data.ActionManager
 import org.maproulette.framework.service.{
   ChallengeListingService,
   ProjectService,
-  TaskReviewService
+  TaskReviewService,
+  UserService
 }
 import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.model.{Challenge, ChallengeListing, Project, User}
@@ -17,6 +19,7 @@ import org.maproulette.session.{SessionManager, SearchParameters}
 import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
+import play.api.http.HttpEntity
 
 import org.maproulette.models.Task
 
@@ -33,6 +36,7 @@ class TaskReviewController @Inject() (
     service: TaskReviewService,
     challengeListingService: ChallengeListingService,
     projectService: ProjectService,
+    userService: UserService,
     components: ControllerComponents
 ) extends AbstractController(components)
     with MapRouletteController {
@@ -278,5 +282,69 @@ class TaskReviewController @Inject() (
     })
 
     statusMap
+  }
+
+  /**
+    * Returns a CSV export of review metrics per mapper.
+    *
+    * @param mappers Optional limit to reviews of tasks by specific mappers
+    * @param reviewers Optional limit reviews done by specific reviewers
+    * @param priorities Optional limit to only these priorities
+    * @param startDate Optional start date to filter by reviewedAt date
+    * @param endDate Optional end date to filter by reviewedAt date
+    * @param onlySaved Only include saved challenges
+    * @return
+    */
+  def extractMapperMetrics(
+      mappers: String = "",
+      reviewers: String = "",
+      priorities: String = "",
+      startDate: String = null,
+      endDate: String = null,
+      onlySaved: Boolean = false
+  ): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      SearchParameters.withSearch { implicit params =>
+        val metrics = this.service.getMapperMetrics(
+          User.userOrMocked(user),
+          params,
+          Some(Utils.split(mappers)),
+          Some(Utils.split(reviewers)),
+          Utils.toIntList(priorities),
+          startDate,
+          endDate,
+          onlySaved
+        )
+
+        val mapperNames =
+          this.userService
+            .retrieveListById(metrics.map(m => m.userId.get), Paging())
+            .map(u => u.id -> u.name)
+            .toMap
+
+        val seqString = metrics.map(row => {
+          var mapper = mapperNames.get(row.userId.get)
+
+          val reviewTimeSeconds = Math.round(row.avgReviewTime / 1000)
+
+          s"${mapper.get},${row.total},${reviewTimeSeconds},${row.reviewRequested}," +
+            s"${row.reviewApproved},${row.reviewRejected},${row.reviewAssisted}," +
+            s"${row.reviewDisputed}"
+        })
+
+        Result(
+          header = ResponseHeader(
+            OK,
+            Map(CONTENT_DISPOSITION -> s"attachment; filename=mapper_review_metrics.csv")
+          ),
+          body = HttpEntity.Strict(
+            ByteString(
+              s"""Mapper,Total Review Tasks,Avg Review Time (seconds),Review Requested,Approved,Needs Revision,Approved w/Fixes,Contested\n"""
+            ).concat(ByteString(seqString.mkString("\n"))),
+            Some("text/csv; header=present")
+          )
+        )
+      }
+    }
   }
 }

--- a/app/org/maproulette/framework/model/TaskReview.scala
+++ b/app/org/maproulette/framework/model/TaskReview.scala
@@ -59,7 +59,8 @@ case class ReviewMetrics(
     skipped: Int,
     alreadyFixed: Int,
     tooHard: Int,
-    avgReviewTime: Double
+    avgReviewTime: Double,
+    userId: Option[Long] = None // If these metrics apply to a particular user
 )
 object ReviewMetrics {
   implicit val reviewMetricsWrites = Json.writes[ReviewMetrics]

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -41,31 +41,19 @@ class TaskReviewService @Inject() (repository: TaskReviewRepository, taskReviewD
     * @param user      The user executing the request
     * @param reviewTasksType
     * @param searchParameters
-    * @param startDate Limit tasks to reviewed after date (YYYY-MM-DD)
-    * @param endDate   Limit tasks to reviewed before date (YYYY-MM-DD)
     * @return A list of tasks
     */
   def getReviewMetrics(
       user: User,
       reviewTasksType: Int,
-      searchParameters: SearchParameters,
-      mappers: Option[List[String]] = None,
-      reviewers: Option[List[String]] = None,
-      priorities: Option[List[Int]] = None,
-      startDate: String,
-      endDate: String,
+      params: SearchParameters,
       onlySaved: Boolean = false,
       excludeOtherReviewers: Boolean = false
   ): ReviewMetrics = {
     this.taskReviewDAL.getReviewMetrics(
       user,
       reviewTasksType,
-      searchParameters,
-      mappers,
-      reviewers,
-      priorities,
-      startDate,
-      endDate,
+      params,
       onlySaved,
       excludeOtherReviewers
     )
@@ -76,32 +64,17 @@ class TaskReviewService @Inject() (repository: TaskReviewRepository, taskReviewD
     *
     * @param user      The user executing the request
     * @param searchParameters
-    * @param mappers Optional limit to mappers
-    * @param reviewers Optional limit to reviewers
-    * @param priorities Optional limit to only these priorities
-    * @param startDate Limit tasks to reviewed after date (YYYY-MM-DD)
-    * @param endDate   Limit tasks to reviewed before date (YYYY-MM-DD)
     * @param onlySaved Only include saved challenges
     * @return A list of review metrics by mapper
     */
   def getMapperMetrics(
       user: User,
-      searchParameters: SearchParameters,
-      mappers: Option[List[String]] = None,
-      reviewers: Option[List[String]] = None,
-      priorities: Option[List[Int]] = None,
-      startDate: String,
-      endDate: String,
+      params: SearchParameters,
       onlySaved: Boolean = false
   ): List[ReviewMetrics] = {
     this.taskReviewDAL.getMapperMetrics(
       user,
-      searchParameters,
-      mappers,
-      reviewers,
-      priorities,
-      startDate,
-      endDate,
+      params,
       onlySaved
     )
   }

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -71,4 +71,39 @@ class TaskReviewService @Inject() (repository: TaskReviewRepository, taskReviewD
     )
   }
 
+  /**
+    * Gets a list of tasks that have been reviewed (either by this user or requested by this user)
+    *
+    * @param user      The user executing the request
+    * @param searchParameters
+    * @param mappers Optional limit to mappers
+    * @param reviewers Optional limit to reviewers
+    * @param priorities Optional limit to only these priorities
+    * @param startDate Limit tasks to reviewed after date (YYYY-MM-DD)
+    * @param endDate   Limit tasks to reviewed before date (YYYY-MM-DD)
+    * @param onlySaved Only include saved challenges
+    * @return A list of review metrics by mapper
+    */
+  def getMapperMetrics(
+      user: User,
+      searchParameters: SearchParameters,
+      mappers: Option[List[String]] = None,
+      reviewers: Option[List[String]] = None,
+      priorities: Option[List[Int]] = None,
+      startDate: String,
+      endDate: String,
+      onlySaved: Boolean = false
+  ): List[ReviewMetrics] = {
+    this.taskReviewDAL.getMapperMetrics(
+      user,
+      searchParameters,
+      mappers,
+      reviewers,
+      priorities,
+      startDate,
+      endDate,
+      onlySaved
+    )
+  }
+
 }

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -973,7 +973,7 @@ class ChallengeDAL @Inject() (
 
       params match {
         case Some(p) =>
-          p.taskPropertySearch match {
+          p.taskParams.taskPropertySearch match {
             case Some(tps) =>
               filters.append(s""" AND t.id IN (
                   SELECT id FROM tasks,
@@ -984,7 +984,7 @@ class ChallengeDAL @Inject() (
             case None => // do nothing
           }
 
-          p.taskId match {
+          p.taskParams.taskId match {
             case Some(tid) => filters.append(s" AND CAST(t.id AS TEXT) LIKE '${tid}%'")
             case _         => // do nothing
           }
@@ -1146,7 +1146,7 @@ class ChallengeDAL @Inject() (
         """
       )
 
-      params.taskStatus match {
+      params.taskParams.taskStatus match {
         case Some(s) => this.appendInWhereClause(whereClause, s"t.status IN (${s.mkString(",")})")
         case None    => ""
       }

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1063,7 +1063,9 @@ class TaskDAL @Inject() (
     getRandomChallenge(params) match {
       case Some(challengeId) =>
         val taskTagIds = if (params.hasTaskTags) {
-          this.tagService.retrieveListByName(params.taskTags.get.map(_.toLowerCase)).map(_.id)
+          this.tagService
+            .retrieveListByName(params.taskParams.taskTags.get.map(_.toLowerCase))
+            .map(_.id)
         } else {
           List.empty
         }
@@ -1079,7 +1081,7 @@ class TaskDAL @Inject() (
         // The default where clause will check to see if the parents are enabled, that the task is
         // not locked (or if it is, it is locked by the current user) and that the status of the task
         // is either Created or Skipped
-        val taskStatusList = params.taskStatus match {
+        val taskStatusList = params.taskParams.taskStatus match {
           case Some(l) if l.nonEmpty => l
           case _ => {
             config.skipTooHard match {
@@ -1122,9 +1124,9 @@ class TaskDAL @Inject() (
           appendInWhereClause(whereClause, "tt.tag_id IN ({tagids})")
           parameters += (Symbol("tagids") -> ToParameterValue.apply[List[Long]].apply(taskTagIds))
         }
-        if (params.taskSearch.nonEmpty) {
+        if (params.taskParams.taskSearch.nonEmpty) {
           appendInWhereClause(whereClause, s"${searchField("tasks.name", "taskSearch")(None)}")
-          parameters += (Symbol("taskSearch") -> search(params.taskSearch.getOrElse("")))
+          parameters += (Symbol("taskSearch") -> search(params.taskParams.taskSearch.getOrElse("")))
         }
 
         val proximityOrdering = proximityId match {

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -566,7 +566,7 @@ class TaskReviewDAL @Inject() (
     var orderByClause = ""
     val whereClause = new StringBuilder(
       "(tasks.bundle_id is NULL OR tasks.is_bundle_primary = true) AND " +
-        s"task_review.review_status != ${Task.REVIEW_STATUS_UNNECESSARY} AND "
+        s"task_review.review_status != ${Task.REVIEW_STATUS_UNNECESSARY} "
     )
     val joinClause = new StringBuilder("INNER JOIN challenges c ON c.id = tasks.parent_id ")
     joinClause ++= "LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id "

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -267,7 +267,7 @@ class VirtualChallengeDAL @Inject() (
     // The default where clause will check to see if the parents are enabled, that the task is
     // not locked (or if it is, it is locked by the current user) and that the status of the task
     // is either Created or Skipped
-    val taskStatusList = params.taskStatus match {
+    val taskStatusList = params.taskParams.taskStatus match {
       case Some(l) if l.nonEmpty => l
       case _ => {
         config.skipTooHard match {

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -33,8 +33,8 @@ case class SearchChallengeParameters(
 )
 
 case class SearchReviewParameters(
-    mappers: Option[List[String]] = None,
-    reviewers: Option[List[String]] = None,
+    mappers: Option[List[Long]] = None,
+    reviewers: Option[List[Long]] = None,
     priorities: Option[List[Int]] = None,
     startDate: Option[String] = None,
     endDate: Option[String] = None
@@ -434,11 +434,11 @@ object SearchParameters {
       // Search Review Parameters
       new SearchReviewParameters(
         request.getQueryString("mappers") match {
-          case Some(r) => Utils.toStringList(r)
+          case Some(r) => Utils.toLongList(r)
           case None => params.reviewParams.mappers
         },
         request.getQueryString("reviewers") match {
-          case Some(r) => Utils.toStringList(r)
+          case Some(r) => Utils.toLongList(r)
           case None => params.reviewParams.reviewers
         },
         request.getQueryString("priorities") match {

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -249,3 +249,31 @@ GET     /tasks/review/metrics                          @org.maproulette.framewor
 #     description: exclude tasks that have been reviewed by someone else
 ###
 GET     /taskCluster/review                                @org.maproulette.controllers.api.TaskReviewController.getReviewTaskClusters(reviewTasksType:Int, points:Int ?= 100, startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers:Boolean ?= false)
+###
+# tags: [ Review ]
+# summary: Retrieve a summary of review coverage for mappers
+# description: This will retrieve a summary of review coverage for each mapper and respond with a csv
+# response:
+#   '200':
+#     description: A CSV file containing the following data "Mapper,Requested,Approved,Rejected,ApprovedWithFixes,Disputed,Total"
+# parameters:
+#   - name: mappers
+#     in: query
+#     description: the mapper ids to search by (review_requested_by)
+#   - name: reviewers
+#     in: query
+#     description: the reviewer ids to search by (reviewed_by)
+#   - name: priorities
+#     in: query
+#     description: the priorities to search by
+#   - name: startDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed after this date (format 'YYYY-MM-DD')
+#   - name: endDate
+#     in: query
+#     description: Whether results should be tasks that have been reviewed before this date (format 'YYYY-MM-DD')
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
+###
+GET     /tasks/review/mappers/export                          @org.maproulette.framework.controller.TaskReviewController.extractMapperMetrics(mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -77,7 +77,7 @@ GET     /task/:id/review/cancel                       @org.maproulette.controlle
 #     in: query
 #     description: The search string used to match the name of the person requesting the review. (review_requested_by)
 ###
-GET     /tasks/review                          @org.maproulette.controllers.api.TaskReviewController.getReviewRequestedTasks(startDate: String ?= null, endDate: String ?= null, onlySaved: Boolean ?= false, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", excludeOtherReviewers: Boolean ?= false, includeTags: Boolean ?= false)
+GET     /tasks/review                          @org.maproulette.controllers.api.TaskReviewController.getReviewRequestedTasks(onlySaved: Boolean ?= false, limit:Int ?= -1, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", excludeOtherReviewers: Boolean ?= false, includeTags: Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves reviewed tasks that have been reviewed either by this user or where the user requested
@@ -130,7 +130,7 @@ GET     /tasks/review                          @org.maproulette.controllers.api.
 #     in: query
 #     description: In response include list of tags for each task
 ###
-GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(mappers:String ?= "", reviewers:String ?= "", startDate: String ?= null, endDate: String ?= null, allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", includeTags:Boolean ?= false)
+GET     /tasks/reviewed                          @org.maproulette.controllers.api.TaskReviewController.getReviewedTasks(allowReviewNeeded:Boolean ?= false, limit:Int ?= 10, page:Int ?= 0, sort:String ?= "", order:String ?= "ASC", includeTags:Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves and claims a the next review needed Task
@@ -214,7 +214,7 @@ GET     /tasks/review/next                       @org.maproulette.controllers.ap
 #     in: query
 #     description: Also include a breakdown of review status by task status
 ###
-GET     /tasks/review/metrics                          @org.maproulette.framework.controller.TaskReviewController.getReviewMetrics(reviewTasksType: Int, mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers: Boolean ?= false, includeByPriority:Boolean ?= false, includeByTaskStatus:Boolean ?= false)
+GET     /tasks/review/metrics                          @org.maproulette.framework.controller.TaskReviewController.getReviewMetrics(reviewTasksType: Int, onlySaved:Boolean ?= false, excludeOtherReviewers: Boolean ?= false, includeByPriority:Boolean ?= false, includeByTaskStatus:Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieves task review clusters
@@ -248,7 +248,7 @@ GET     /tasks/review/metrics                          @org.maproulette.framewor
 #     in: query
 #     description: exclude tasks that have been reviewed by someone else
 ###
-GET     /taskCluster/review                                @org.maproulette.controllers.api.TaskReviewController.getReviewTaskClusters(reviewTasksType:Int, points:Int ?= 100, startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false, excludeOtherReviewers:Boolean ?= false)
+GET     /taskCluster/review                                @org.maproulette.controllers.api.TaskReviewController.getReviewTaskClusters(reviewTasksType:Int, points:Int ?= 100, onlySaved:Boolean ?= false, excludeOtherReviewers:Boolean ?= false)
 ###
 # tags: [ Review ]
 # summary: Retrieve a summary of review coverage for mappers
@@ -276,4 +276,4 @@ GET     /taskCluster/review                                @org.maproulette.cont
 #     in: query
 #     description: Only show challenges that have been saved.
 ###
-GET     /tasks/review/mappers/export                          @org.maproulette.framework.controller.TaskReviewController.extractMapperMetrics(mappers: String ?= "", reviewers: String ?= "", priorities:String ?= "", startDate: String ?= null, endDate: String ?= null, onlySaved:Boolean ?= false)
+GET     /tasks/review/mappers/export                          @org.maproulette.framework.controller.TaskReviewController.extractMapperMetrics(onlySaved:Boolean ?= false)

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -9,10 +9,12 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
+import org.maproulette.session.{SearchParameters, SearchChallengeParameters, SearchReviewParameters}
 import org.maproulette.framework.model._
 import org.maproulette.framework.psql.{GroupField, Grouping, Query}
 import org.maproulette.framework.util.{TaskReviewTag, FrameworkHelper}
 import org.maproulette.models.Task
+import org.maproulette.models.dal.{ChallengeDAL, TaskDAL, TaskReviewDAL}
 import play.api.Application
 
 /**
@@ -20,6 +22,8 @@ import play.api.Application
   */
 class TaskReviewServiceSpec(implicit val application: Application) extends FrameworkHelper {
   val service: TaskReviewService = this.serviceManager.taskReview
+  var randomChallenge: Challenge = null
+  var randomUser: User           = null
 
   "TaskReviewService" should {
     "expire old task reviews" taggedAs (TaskReviewTag) in {
@@ -27,7 +31,149 @@ class TaskReviewServiceSpec(implicit val application: Application) extends Frame
         this.service.expireTaskReviews(FiniteDuration(1000, TimeUnit.MILLISECONDS))
       expiredTaskReviews mustEqual 0
     }
+
+    "get Review Metrics" taggedAs (TaskReviewTag) in {
+      val result = this.service.getReviewMetrics(User.superUser, 4, new SearchParameters())
+      result.total mustEqual 2
+      result.reviewRequested mustEqual 1
+      result.reviewApproved mustEqual 1
+    }
+
+    "get Review Metrics filter on challenge" taggedAs (TaskReviewTag) in {
+      val params = new SearchParameters(
+        challengeParams = new SearchChallengeParameters(
+          challengeIds = Some(List(randomChallenge.id))
+        )
+      )
+      val result = this.service.getReviewMetrics(User.superUser, 4, params)
+      result.total mustEqual 1
+      result.reviewRequested mustEqual 1
+    }
+
+    "get Review Metrics filter by ReviewTasksType" taggedAs (TaskReviewTag) in {
+      // Limit to only requested tasks (exclude approved)
+      val result = this.service.getReviewMetrics(User.superUser, 1, new SearchParameters())
+      result.total mustEqual 1
+      result.reviewRequested mustEqual 1
+      result.reviewApproved mustEqual 0
+    }
+
+    "get Mapper Metrics" taggedAs (TaskReviewTag) in {
+      val result = this.service.getMapperMetrics(User.superUser, new SearchParameters())
+
+      // Expecting review metrics for 2 users
+      result.length mustEqual 2
+
+      // Each user expected to have one task they want reviewed
+      result(0).total mustEqual 1
+      result(1).total mustEqual 1
+    }
+
+    "get Mapper Metrics filter by mappers" taggedAs (TaskReviewTag) in {
+      val params = new SearchParameters(
+        reviewParams = new SearchReviewParameters(
+          mappers = Some(List(randomUser.id))
+        )
+      )
+      val result = this.service.getMapperMetrics(User.superUser, params)
+
+      // Expecting review metrics for only 1 user
+      result.length mustEqual 1
+
+      // User expected to have one task they want reviewed
+      result(0).total mustEqual 1
+      result(0).userId mustEqual Some(randomUser.id)
+    }
   }
 
   override implicit val projectTestName: String = "TaskReviewSpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    val (c, u) =
+      TaskReviewServiceSpec.setup(
+        this.challengeDAL,
+        this.taskDAL,
+        this.taskReviewDAL,
+        this.serviceManager,
+        this.defaultProject.id,
+        this.getTestTask,
+        this.getTestUser
+      )
+    randomChallenge = c
+    randomUser = u
+  }
+}
+
+object TaskReviewServiceSpec {
+  def setup(
+      challengeDAL: ChallengeDAL,
+      taskDAL: TaskDAL,
+      taskReviewDAL: TaskReviewDAL,
+      serviceManager: ServiceManager,
+      projectId: Long,
+      taskFunc: (String, Long) => Task,
+      userFunc: (Long, String) => User
+  ): (Challenge, User) = {
+    val createdReviewChallenge = challengeDAL
+      .insert(
+        Challenge(
+          -1,
+          "reviewChallenge",
+          null,
+          null,
+          general = ChallengeGeneral(
+            User.superUser.osmProfile.id,
+            projectId,
+            "TestChallengeInstruction"
+          ),
+          creation = ChallengeCreation(),
+          priority = ChallengePriority(),
+          extra = ChallengeExtra()
+        ),
+        User.superUser
+      )
+    val task = taskDAL
+      .insert(
+        taskFunc(UUID.randomUUID().toString, createdReviewChallenge.id),
+        User.superUser
+      )
+
+    val createdReviewChallenge2 = challengeDAL
+      .insert(
+        Challenge(
+          -1,
+          "reviewChallenge2",
+          null,
+          null,
+          general = ChallengeGeneral(
+            User.superUser.osmProfile.id,
+            projectId,
+            "TestChallengeInstruction"
+          ),
+          creation = ChallengeCreation(),
+          priority = ChallengePriority(),
+          extra = ChallengeExtra()
+        ),
+        User.superUser
+      )
+    var task2 = taskDAL
+      .insert(
+        taskFunc(UUID.randomUUID().toString, createdReviewChallenge2.id),
+        User.superUser
+      )
+
+    val randomUser = serviceManager.user.create(
+      userFunc(12345, "RandomOUser"),
+      User.superUser
+    )
+
+    taskDAL.setTaskStatus(List(task), Task.STATUS_FIXED, randomUser, Some(true))
+    taskDAL.setTaskStatus(List(task2), Task.STATUS_FIXED, User.superUser, Some(true))
+
+    task2 = taskDAL.retrieveById(task2.id).get
+    taskReviewDAL.setTaskReviewStatus(task2, Task.REVIEW_STATUS_APPROVED, User.superUser, None)
+
+    (createdReviewChallenge, randomUser)
+  }
 }

--- a/test/org/maproulette/framework/util/FrameworkHelper.scala
+++ b/test/org/maproulette/framework/util/FrameworkHelper.scala
@@ -11,7 +11,7 @@ import org.joda.time.DateTime
 import org.maproulette.framework.model._
 import org.maproulette.framework.service.ServiceManager
 import org.maproulette.models.Task
-import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
+import org.maproulette.models.dal.{ChallengeDAL, TaskDAL, TaskReviewDAL}
 import org.scalatest.{BeforeAndAfterAll, Tag}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -28,6 +28,7 @@ trait FrameworkHelper extends PlaySpec with BeforeAndAfterAll with MockitoSugar 
   val serviceManager: ServiceManager = application.injector.instanceOf(classOf[ServiceManager])
   val challengeDAL: ChallengeDAL     = application.injector.instanceOf(classOf[ChallengeDAL])
   val taskDAL: TaskDAL               = application.injector.instanceOf(classOf[TaskDAL])
+  val taskReviewDAL: TaskReviewDAL   = application.injector.instanceOf(classOf[TaskReviewDAL])
 
   // To be removed when all of SnapshotManager has been converted
   val snapshotManager: SnapshotManager = application.injector.instanceOf(classOf[SnapshotManager])


### PR DESCRIPTION
Add api to export mapper review metrics as a csv. Supports
the same search parameters as getting all review metrics.

GET     /tasks/review/mappers/export

Also, created sub class on SearchParameters (SearchTaskParameters and SearchReviewParameters) to get around scala 22 parameter limit.