### PR TITLE
Groups and Teams

### DIFF
--- a/app/org/maproulette/data/Actions.scala
+++ b/app/org/maproulette/data/Actions.scala
@@ -39,6 +39,7 @@ class ItemType(id: Int) {
       case t: TaskType              => new TaskItem(itemId)
       case ta: TagType              => new TagItem(itemId)
       case u: UserType              => new UserItem(itemId)
+      case group: GroupType         => new GroupItem(itemId)
       case vc: VirtualChallengeType => new VirtualChallengeItem(itemId)
       case b: BundleType            => new BundleItem(itemId)
     }
@@ -59,6 +60,8 @@ case class TagType() extends ItemType(Actions.ITEM_TYPE_TAG)
 
 case class UserType() extends ItemType(Actions.ITEM_TYPE_USER)
 
+case class GroupType() extends ItemType(Actions.ITEM_TYPE_GROUP)
+
 case class VirtualChallengeType() extends ItemType(Actions.ITEM_TYPE_VIRTUAL_CHALLENGE)
 
 case class BundleType() extends ItemType(Actions.ITEM_TYPE_BUNDLE)
@@ -72,6 +75,8 @@ class TaskItem(override val itemId: Long) extends TaskType with Item
 class TagItem(override val itemId: Long) extends TagType with Item
 
 class UserItem(override val itemId: Long) extends UserType with Item
+
+class GroupItem(override val itemId: Long) extends GroupType with Item
 
 class VirtualChallengeItem(override val itemId: Long) extends VirtualChallengeType with Item
 
@@ -117,6 +122,8 @@ object Actions {
   val ITEM_TYPE_SURVEY_NAME            = "Survey"
   val ITEM_TYPE_USER                   = 5
   val ITEM_TYPE_USER_NAME              = "User"
+  val ITEM_TYPE_GROUP                  = 6
+  val ITEM_TYPE_GROUP_NAME             = "Group"
   val ITEM_TYPE_VIRTUAL_CHALLENGE      = 7
   val ITEM_TYPE_VIRTUAL_CHALLENGE_NAME = "VirtualChallenge"
   val ITEM_TYPE_BUNDLE                 = 8
@@ -129,6 +136,7 @@ object Actions {
     ITEM_TYPE_TASK              -> (ITEM_TYPE_TASK_NAME, TaskType()),
     ITEM_TYPE_TAG               -> (ITEM_TYPE_TAG_NAME, TagType()),
     ITEM_TYPE_USER              -> (ITEM_TYPE_USER_NAME, UserType()),
+    ITEM_TYPE_GROUP             -> (ITEM_TYPE_GROUP_NAME, GroupType()),
     ITEM_TYPE_VIRTUAL_CHALLENGE -> (ITEM_TYPE_VIRTUAL_CHALLENGE_NAME, VirtualChallengeType()),
     ITEM_TYPE_BUNDLE            -> (ITEM_TYPE_BUNDLE_NAME, BundleType()),
     ITEM_TYPE_GRANT             -> (ITEM_TYPE_GRANT_NAME, GrantType())

--- a/app/org/maproulette/framework/controller/GraphQLController.scala
+++ b/app/org/maproulette/framework/controller/GraphQLController.scala
@@ -11,6 +11,7 @@ import javax.inject.{Inject, Singleton}
 import org.maproulette.exception.InvalidException
 import org.maproulette.framework.graphql.{GraphQL, UserContext}
 import org.maproulette.framework.model.User
+import org.maproulette.framework.service.ServiceManager
 import org.maproulette.session.SessionManager
 import org.slf4j.LoggerFactory
 import play.api.libs.json._
@@ -32,6 +33,7 @@ class GraphQLController @Inject() (
     graphQL: GraphQL,
     sessionManager: SessionManager,
     components: ControllerComponents,
+    services: ServiceManager,
     implicit val executionContext: ExecutionContext
 ) extends AbstractController(components) {
   val exceptionHandler = ExceptionHandler {
@@ -89,9 +91,10 @@ class GraphQLController @Inject() (
       Executor
         .execute(
           schema = graphQL.schema,
+          deferredResolver = graphQL.resolver,
           queryAst = queryAst,
           variables = variables.getOrElse(Json.obj()),
-          userContext = UserContext(sessionManager, user),
+          userContext = UserContext(sessionManager, user, services),
           exceptionHandler = exceptionHandler
         )
         .map(Ok(_))

--- a/app/org/maproulette/framework/controller/TeamController.scala
+++ b/app/org/maproulette/framework/controller/TeamController.scala
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.controller
+
+import java.net.URLDecoder
+
+import javax.inject.Inject
+import org.maproulette.data.ActionManager
+import org.maproulette.framework.service.TeamService
+import org.maproulette.framework.model.{User, TeamMember, TeamUser, MemberObject, Group}
+import org.maproulette.framework.psql.{Paging}
+import org.maproulette.session.SessionManager
+import play.api.libs.json._
+import play.api.mvc._
+
+/**
+  * @author nrotstan
+  */
+class TeamController @Inject() (
+    override val sessionManager: SessionManager,
+    override val actionManager: ActionManager,
+    override val bodyParsers: PlayBodyParsers,
+    teamService: TeamService,
+    components: ControllerComponents
+) extends AbstractController(components)
+    with MapRouletteController {
+
+  /**
+    * Create a new team
+    */
+  def createTeam(): Action[JsValue] = Action.async(bodyParsers.json) { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Created(
+        Json.toJson(
+          this.teamService
+            .create(
+              Group(
+                -1,
+                (request.body \ "name").as[String],
+                (request.body \ "description").asOpt[String],
+                (request.body \ "avatarURL").asOpt[String],
+                Group.GROUP_TYPE_TEAM
+              ),
+              MemberObject.user(user.id),
+              user
+            )
+            .get
+        )
+      )
+    }
+  }
+
+  /**
+    * Retrieve a specific team
+    *
+    * @param teamId The id of the team to retrieve
+    * @return The team
+    */
+  def retrieve(teamId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      this.teamService.retrieve(teamId, user.getOrElse(User.guestUser)) match {
+        case Some(team) => Ok(Json.toJson(team))
+        case None       => NotFound
+      }
+    }
+  }
+
+  /**
+    * Search teams by name, returning matching results
+    *
+    * @param name  A name fragment to search by
+    * @param limit Maximum number of results to return
+    * @param page  Page of results to return
+    * @return Matching teams
+    */
+  def find(name: String, limit: Int, page: Int): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.userAwareRequest { implicit user =>
+        Ok(
+          Json.toJson(
+            this.teamService.search(name, Paging(limit, page), user.getOrElse(User.guestUser))
+          )
+        )
+      }
+  }
+
+  /**
+    * Retrieves all of a user's team memberships
+    *
+    * @return A list of TeamUser instances
+    */
+  def userTeamMemberships(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(
+        Json.toJson(
+          this.teamService.teamUsersByUserIds(List(userId), user.getOrElse(User.guestUser))
+        )
+      )
+    }
+  }
+
+  /**
+    * Retrieve all the users who are members of a team, including users who
+    * have an invitation pending
+    *
+    * @param teamId The id of the team
+    * @return A list of teams
+    */
+  def teamUsers(teamId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(
+        Json.toJson(
+          this.teamService.teamUsers(teamId, user.getOrElse(User.guestUser))
+        )
+      )
+    }
+  }
+
+  /**
+    * Invite a user to join a team
+    *
+    * @param teamId    The team onto which to invite the user
+    * @param inviteeId The id of the user to invite
+    * @param role      The role to be granted to user on the team if they accept the invitation
+    */
+  def inviteUser(teamId: Long, inviteeId: Long, role: Int): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        Ok(Json.toJson(this.teamService.inviteTeamUser(teamId, inviteeId, role, user)))
+      }
+  }
+
+  /**
+    * Accept an invitation the logged-in user received to join a team
+    *
+    * @param teamId The id of the team the user is invited to join
+    */
+  def acceptInvite(teamId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      Ok(Json.toJson(this.teamService.acceptUserInvitation(teamId, user.id, user)))
+    }
+  }
+
+  /**
+    * Decline an invitation the logged-in user received to join a team
+    *
+    * @param teamId The id of the team the user was invited to join
+    */
+  def declineInvite(teamId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.teamService.declineInvitation(teamId, MemberObject.user(user.id), user)
+      Ok
+    }
+  }
+
+  /**
+    * Update role granted to member on team
+    *
+    * @param teamId   The id of the team on which the role is granted
+    * @param memberId The id of the user who is to have their role updated
+    * @param role     The new role
+    */
+  def updateMemberRole(teamId: Long, memberId: Long, role: Int): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        Ok(Json.toJson(this.teamService.updateUserRole(teamId, memberId, role, user)))
+      }
+  }
+
+  /**
+    * Remove a member from a team
+    *
+    * @param teamId   The id of the team from which the member is being removed
+    * @param memberId The id of the member who is to be removed
+    */
+  def removeTeamMember(teamId: Long, memberId: Long): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        this.teamService.retrieve(teamId, user) match {
+          case Some(team) =>
+            this.teamService.removeTeamMember(team, MemberObject.user(memberId), user)
+            Ok
+          case None => NotFound
+        }
+      }
+  }
+
+  /**
+    * Adds a team to a project, granting it the given role on the project.  All
+    * members of the team will be indirectly granted that role on the project
+    *
+    * @param teamId    The id of the team to add to the project
+    * @param projectId The id of the project to which the team is to be added
+    * @param role      The role to grant the team on the project
+    */
+  def addTeamToProject(teamId: Long, projectId: Long, role: Int): Action[AnyContent] =
+    Action.async { implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        this.teamService.addTeamToProject(teamId, projectId, role, user)
+        Ok
+      }
+    }
+
+  /**
+    * Sets a team's granted role on a project, clearing any prior granted roles.
+    * All members of the team will be indirectly granted the role on the
+    * project
+    *
+    * @param teamId    The id of the team to receive the role on the project
+    * @param projectId The id of the project
+    * @param role      The role to grant the team on the project
+    */
+  def setTeamProjectRole(teamId: Long, projectId: Long, role: Int): Action[AnyContent] =
+    Action.async { implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        this.teamService.addTeamToProject(teamId, projectId, role, user, true)
+        Ok
+      }
+    }
+
+  /**
+    * Removes a team from a project, clearing any roles it was granted on the
+    * project
+    *
+    * @param teamId    The id of the team to remove from the project
+    * @param projectId The id of the project from which the team is to be removed
+    */
+  def removeTeamFromProject(teamId: Long, projectId: Long): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        this.teamService.removeTeamFromProject(teamId, projectId, user)
+        Ok
+      }
+  }
+
+  /**
+    * Gets any teams that have been granted roles on a project
+    *
+    * @param projectId The id of the project for which teams are desired
+    */
+  def getTeamsManagingProject(projectId: Long): Action[AnyContent] =
+    Action.async { implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        Ok(
+          Json.toJson(
+            this.teamService.getTeamsManagingProject(projectId, user)
+          )
+        )
+      }
+    }
+
+  /**
+    * Update a team's name, description, and/or avatar URL
+    *
+    * @param teamId      The id of the team to update
+    */
+  def updateTeam(teamId: Long): Action[JsValue] = Action.async(bodyParsers.json) {
+    implicit request =>
+      this.sessionManager.authenticatedRequest { implicit user =>
+        this.teamService.retrieve(teamId, user) match {
+          case Some(team: Group) =>
+            val oldDescription: Option[String] = team.description
+            Ok(
+              Json.toJson(
+                this.teamService
+                  .updateTeam(
+                    team.copy(
+                      name = (request.body \ "name").asOpt[String] match {
+                        case Some(name) => name
+                        case None       => team.name
+                      },
+                      description = (request.body \ "description").asOpt[String] match {
+                        case Some(description) => Some(description)
+                        case None              => team.description
+                      },
+                      avatarURL = (request.body \ "avatarURL").asOpt[String] match {
+                        case Some(avatarURL) => Some(avatarURL)
+                        case None            => team.avatarURL
+                      }
+                    ),
+                    user
+                  )
+                  .get
+              )
+            )
+          case None => NotFound
+        }
+      }
+  }
+
+  /**
+    * Delete a team
+    *
+    * @param teamId The id of the team to delete
+    * @return Ok if successful
+    */
+  def deleteTeam(teamId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.teamService.retrieve(teamId, user) match {
+        case Some(team) =>
+          this.teamService.deleteTeam(team, user)
+          Ok
+        case None => NotFound
+      }
+    }
+  }
+}

--- a/app/org/maproulette/framework/graphql/GraphQL.scala
+++ b/app/org/maproulette/framework/graphql/GraphQL.scala
@@ -7,7 +7,9 @@ package org.maproulette.framework.graphql
 
 import javax.inject.Inject
 import org.maproulette.framework.graphql.schemas._
+import org.maproulette.framework.graphql.fetchers._
 import sangria.schema.{ObjectType, fields}
+import sangria.execution.deferred.{Fetcher, DeferredResolver}
 
 /**
   * @author mcuthbert
@@ -18,7 +20,8 @@ class GraphQL @Inject() (
     commentSchema: CommentSchema,
     grantSchema: GrantSchema,
     userSchema: UserSchema,
-    tagSchema: TagSchema
+    tagSchema: TagSchema,
+    teamSchema: TeamSchema
 ) {
   private val queries =
     MRSchema.baseQueries ++
@@ -27,7 +30,8 @@ class GraphQL @Inject() (
       commentSchema.queries ++
       grantSchema.queries ++
       userSchema.queries ++
-      tagSchema.queries
+      tagSchema.queries ++
+      teamSchema.queries
 
   private val mutations =
     MRSchema.baseMutations ++
@@ -36,10 +40,16 @@ class GraphQL @Inject() (
       commentSchema.mutations ++
       grantSchema.mutations ++
       userSchema.mutations ++
-      tagSchema.mutations
+      tagSchema.mutations ++
+      teamSchema.mutations
+
+  private val fetchers =
+    TeamFetchers.fetchers
 
   val schema: sangria.schema.Schema[UserContext, Unit] = sangria.schema.Schema[UserContext, Unit](
     query = ObjectType("Query", fields(queries: _*)),
     mutation = Some(ObjectType("Mutation", fields(mutations: _*)))
   )
+
+  val resolver = DeferredResolver.fetchers(fetchers: _*)
 }

--- a/app/org/maproulette/framework/graphql/UserContext.scala
+++ b/app/org/maproulette/framework/graphql/UserContext.scala
@@ -6,12 +6,13 @@
 package org.maproulette.framework.graphql
 
 import org.maproulette.framework.model.User
+import org.maproulette.framework.service.ServiceManager
 import org.maproulette.session.SessionManager
 
 /**
   * @author mcuthbert
   */
-case class UserContext(sessionManager: SessionManager, user: User) {
+case class UserContext(sessionManager: SessionManager, user: User, services: ServiceManager) {
   def getUser(apiKey: String): User =
     sessionManager.getSessionByApiKey(Some(apiKey)).getOrElse(User.guestUser)
 }

--- a/app/org/maproulette/framework/graphql/fetchers/TeamFetchers.scala
+++ b/app/org/maproulette/framework/graphql/fetchers/TeamFetchers.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.graphql.fetchers
+
+import org.maproulette.framework.model.{TeamUser}
+import org.maproulette.framework.graphql.UserContext
+import sangria.execution.deferred.{Fetcher, Relation, RelationIds}
+import scala.concurrent.{Future}
+
+/**
+  * @author nrotstan
+  */
+trait TeamFetchers {}
+object TeamFetchers {
+  val teamsFetcher = Fetcher((ctx: UserContext, ids: Seq[Long]) =>
+    Future.successful(
+      ctx.services.team.list(ids.toList, ctx.user).toSeq
+    )
+  )
+
+  val teamUsersByTeamRel = Relation[TeamUser, Long]("onTeam", u => Seq(u.teamId))
+  val teamUsersFetcher = Fetcher.rel(
+    (ctx: UserContext, ids: Seq[Long]) =>
+      Future.successful(ctx.services.team.listTeamUsers(ids.toList, ctx.user).toSeq),
+    (ctx: UserContext, ids: RelationIds[TeamUser]) =>
+      Future.successful(
+        ctx.services.team.teamUsersByTeamIds(ids(teamUsersByTeamRel).toList, ctx.user).toSeq
+      )
+  )
+
+  val teamUsersByUserRel = Relation[TeamUser, Long]("withTeam", u => Seq(u.userId))
+  val userTeamsFetcher = Fetcher.rel(
+    (ctx: UserContext, ids: Seq[Long]) =>
+      Future.successful(ctx.services.team.listTeamUsers(ids.toList, ctx.user).toSeq),
+    (ctx: UserContext, ids: RelationIds[TeamUser]) =>
+      Future.successful(
+        ctx.services.team.teamUsersByUserIds(ids(teamUsersByUserRel).toList, ctx.user).toSeq
+      )
+  )
+
+  val fetchers = List(teamsFetcher, teamUsersFetcher, userTeamsFetcher)
+}

--- a/app/org/maproulette/framework/graphql/schemas/GrantSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/GrantSchema.scala
@@ -50,7 +50,7 @@ class GrantSchema @Inject() (override val service: GrantService)
 }
 
 object GrantSchema {
-  val roleArgument = Argument(
+  val roleArg = Argument(
     "role",
     IntType,
     "The granted role: -1 = SUPER USER, 1 = ADMIN, 2 = WRITE, 3 = READ"

--- a/app/org/maproulette/framework/graphql/schemas/TeamSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/TeamSchema.scala
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.graphql.schemas
+
+import javax.inject.Inject
+import org.maproulette.exception.NotFoundException
+import org.maproulette.framework.graphql.fetchers.TeamFetchers
+import org.maproulette.framework.graphql.UserContext
+import org.maproulette.framework.model._
+import org.maproulette.framework.service.TeamService
+import play.api.libs.json.{DefaultWrites, Json, Reads, Writes}
+import sangria.macros.derive._
+import sangria.schema._
+
+/**
+  * @author nrotstan
+  */
+class TeamSchema @Inject() (override val service: TeamService)
+    extends MRSchema[Group]
+    with MRSchemaTypes {
+  val queries: List[Field[UserContext, Unit]] = List(
+    Field(
+      name = "team",
+      description = Some("Retrieve team with ID"),
+      fieldType = OptionType(GroupType),
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => TeamFetchers.teamsFetcher.deferOpt(context.arg(MRSchema.idArg))
+    ),
+    Field(
+      name = "teams",
+      description = Some("Retrieve teams matching IDs"),
+      fieldType = ListType(GroupType),
+      arguments = MRSchema.idsArg :: Nil,
+      resolve = context => TeamFetchers.teamsFetcher.deferSeq(context.arg(MRSchema.idsArg))
+    ),
+    Field(
+      name = "teamUsers",
+      description = Some("Retrieve users on a team"),
+      fieldType = ListType(TeamUserType),
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context =>
+        TeamFetchers.teamUsersFetcher.deferRelSeq(
+          TeamFetchers.teamUsersByTeamRel,
+          context.arg(MRSchema.idArg)
+        )
+    ),
+    Field(
+      name = "userTeams",
+      description = Some("Retrieve team memberships for users matching IDs"),
+      fieldType = ListType(TeamUserType),
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context =>
+        TeamFetchers.userTeamsFetcher.deferRelSeq(
+          TeamFetchers.teamUsersByUserRel,
+          context.arg(MRSchema.idArg)
+        )
+    )
+  )
+
+  val mutations: List[Field[UserContext, Unit]] = List(
+    Field(
+      name = "createTeam",
+      description = Some("Creates a new Team"),
+      fieldType = OptionType(GroupType),
+      arguments = MRSchema.nameArg :: TeamSchema.descriptionArg :: TeamSchema.avatarUrlArg :: Nil,
+      resolve = context => {
+        val user = context.ctx.user
+        this.service.create(
+          Group(
+            -1,
+            context.arg(MRSchema.nameArg),
+            context.arg(TeamSchema.descriptionArg),
+            context.arg(TeamSchema.avatarUrlArg),
+            Group.GROUP_TYPE_TEAM
+          ),
+          MemberObject.user(user.id),
+          user
+        )
+      }
+    ),
+    Field(
+      name = "updateTeam",
+      description = Some("Updates a team"),
+      fieldType = OptionType(GroupType),
+      arguments = MRSchema.idArg :: TeamSchema.optionalNameArg :: TeamSchema.descriptionArg :: TeamSchema.avatarUrlArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        val team = this.service.retrieve(teamId, user) match {
+          case Some(t) => t
+          case None    => throw new NotFoundException(s"No team with id ${teamId} found")
+        }
+        this.service.updateTeam(
+          team.copy(
+            name = context.arg(TeamSchema.optionalNameArg) match {
+              case Some(name) => name
+              case None       => team.name
+            },
+            description = context.arg(TeamSchema.descriptionArg) match {
+              case Some(description) => Some(description)
+              case None              => team.description
+            },
+            avatarURL = context.arg(TeamSchema.avatarUrlArg) match {
+              case Some(avatarURL) => Some(avatarURL)
+              case None            => team.avatarURL
+            }
+          ),
+          user
+        )
+      }
+    ),
+    Field(
+      name = "deleteTeam",
+      description = Some("Deletes a team"),
+      fieldType = BooleanType,
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        val team = this.service.retrieve(teamId, user) match {
+          case Some(t) => t
+          case None =>
+            throw new NotFoundException(s"No team with id $teamId found")
+        }
+        this.service.deleteTeam(team, user)
+      }
+    ),
+    Field(
+      name = "inviteTeamUser",
+      description = Some("Invite a user to join a team with a role"),
+      fieldType = OptionType(TeamUserType),
+      arguments = MRSchema.idArg :: UserSchema.userIdArg :: GrantSchema.roleArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        val userId = context.arg(UserSchema.userIdArg)
+        val role   = context.arg(GrantSchema.roleArg)
+        this.service.inviteTeamUser(teamId, userId, role, user)
+      }
+    ),
+    Field(
+      name = "acceptTeamInvite",
+      description = Some("Accept an invitation to join a team"),
+      fieldType = OptionType(TeamUserType),
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        this.service.acceptUserInvitation(teamId, user.id, User.superUser)
+      }
+    ),
+    Field(
+      name = "declineTeamInvite",
+      description = Some("Decline an invitation to join a team"),
+      fieldType = BooleanType,
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        this.service.declineInvitation(teamId, MemberObject.user(user.id), User.superUser)
+      }
+    ),
+    Field(
+      name = "updateMemberRole",
+      description = Some("Update the role granted to a user member on a team"),
+      fieldType = TeamUserType,
+      arguments = MRSchema.idArg :: UserSchema.userIdArg :: GrantSchema.roleArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        val userId = context.arg(UserSchema.userIdArg)
+        val role   = context.arg(GrantSchema.roleArg)
+        this.service.updateUserRole(teamId, userId, role, user)
+      }
+    ),
+    Field(
+      name = "removeTeamUser",
+      description = Some("Remove a member user from a team"),
+      fieldType = BooleanType,
+      arguments = MRSchema.idArg :: UserSchema.userIdArg :: Nil,
+      resolve = context => {
+        val user   = context.ctx.user
+        val teamId = context.arg(MRSchema.idArg)
+        val userId = context.arg(UserSchema.userIdArg)
+        val team = this.service.retrieve(teamId, user) match {
+          case Some(t) => t
+          case None    => throw new NotFoundException(s"No team with id $teamId found")
+        }
+        this.service.removeTeamMember(team, MemberObject.user(userId), user)
+      }
+    )
+  )
+}
+
+object TeamSchema extends DefaultWrites {
+  val optionalNameArg: Argument[Option[String]] =
+    Argument(
+      "name",
+      OptionInputType(StringType),
+      "Name of object"
+    )
+
+  val descriptionArg: Argument[Option[String]] =
+    Argument(
+      "description",
+      OptionInputType(StringType),
+      "The description of the object"
+    )
+  val avatarUrlArg: Argument[Option[String]] =
+    Argument(
+      "avatarURL",
+      OptionInputType(StringType),
+      "An avatar URL representing the object"
+    )
+}

--- a/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
@@ -168,14 +168,14 @@ class UserSchema @Inject() (override val service: UserService)
       name = "removeUserFromProject",
       description = Some("Removes a user from a specific project"),
       fieldType = BooleanType,
-      arguments = MRSchema.osmIdArg :: ProjectSchema.projectIdArg :: GrantSchema.roleArgument :: Nil,
+      arguments = MRSchema.osmIdArg :: ProjectSchema.projectIdArg :: GrantSchema.roleArg :: Nil,
       resolve = context => {
         // -1 indicates all roles, represented as an absence of a role filter
         val roleFilter =
-          if (context.arg(GrantSchema.roleArgument) == -1)
+          if (context.arg(GrantSchema.roleArg) == -1)
             None
           else
-            Some(context.arg(GrantSchema.roleArgument))
+            Some(context.arg(GrantSchema.roleArg))
 
         this.service.removeUserFromProject(
           context.arg(MRSchema.osmIdArg),
@@ -190,12 +190,12 @@ class UserSchema @Inject() (override val service: UserService)
       name = "addUserToProject",
       description = Some("Adds a user to a specified project"),
       fieldType = UserType,
-      arguments = MRSchema.osmIdArg :: ProjectSchema.projectIdArg :: GrantSchema.roleArgument :: Nil,
+      arguments = MRSchema.osmIdArg :: ProjectSchema.projectIdArg :: GrantSchema.roleArg :: Nil,
       resolve = context =>
         this.service.addUserToProject(
           context.arg(MRSchema.osmIdArg),
           context.arg(ProjectSchema.projectIdArg),
-          context.arg(GrantSchema.roleArgument),
+          context.arg(GrantSchema.roleArg),
           context.ctx.user
         )
     ),
@@ -281,6 +281,7 @@ object UserSchema extends DefaultWrites {
       InputObjectTypeDescription("Settings for a user object")
     )
 
+  val userIdArg: Argument[Long] = Argument("userId", LongType, "The user identifier")
   val userSettingsArg: Argument[UserSettings] = Argument(
     "settings",
     UserSettingsInputType,

--- a/app/org/maproulette/framework/model/Grant.scala
+++ b/app/org/maproulette/framework/model/Grant.scala
@@ -5,7 +5,7 @@
 package org.maproulette.framework.model
 
 import org.maproulette.cache.CacheObject
-import org.maproulette.data.{ItemType, UserType, ProjectType, Actions}
+import org.maproulette.data.{ItemType, UserType, ProjectType, GroupType, Actions}
 import org.maproulette.framework.psql.CommonField
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
@@ -42,7 +42,8 @@ object Grantee {
       (JsPath \ "granteeId").read[Long]
   )(Grantee.withItemType _)
 
-  def user(userId: Long) = Grantee(UserType(), userId)
+  def user(userId: Long)   = Grantee(UserType(), userId)
+  def group(groupId: Long) = Grantee(GroupType(), groupId)
 }
 
 /**
@@ -74,7 +75,9 @@ object GrantTarget {
       (JsPath \ "objectId").read[Long]
   )(GrantTarget.withItemType _)
 
+  // Convenience methods for generating GrantTarget instances for common types
   def project(projectId: Long) = GrantTarget(ProjectType(), projectId)
+  def group(groupId: Long)     = GrantTarget(GroupType(), groupId)
 }
 
 case class Grant(
@@ -118,4 +121,10 @@ object Grant extends CommonField {
     ROLE_WRITE_ACCESS -> ROLE_WRITE_ACCESS_NAME,
     ROLE_READ_ONLY    -> ROLE_READ_ONLY_NAME
   )
+
+  def hasLesserPrivilege(proposedRole: Int, benchmarkRole: Int) =
+    proposedRole > benchmarkRole
+
+  def hasGreaterPrivilege(proposedRole: Int, benchmarkRole: Int) =
+    proposedRole < benchmarkRole
 }

--- a/app/org/maproulette/framework/model/Group.scala
+++ b/app/org/maproulette/framework/model/Group.scala
@@ -7,6 +7,7 @@ package org.maproulette.framework.model
 import org.joda.time.DateTime
 import org.maproulette.framework.psql.CommonField
 import org.maproulette.data.{UserType}
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
@@ -29,7 +30,15 @@ case class Group(
 
 object Group extends CommonField {
   implicit val writes: Writes[Group] = Json.writes[Group]
-  implicit val reads: Reads[Group]   = Json.reads[Group]
+  implicit val reads: Reads[Group] = (
+    (JsPath \ "id").read[Long] and
+      (JsPath \ "name").read[String] and
+      (JsPath \ "description").readNullable[String] and
+      (JsPath \ "avatarURL").readNullable[String] and
+      (JsPath \ "groupType").read[Int] and
+      ((JsPath \ "created").read[DateTime] or Reads.pure(DateTime.now())) and
+      ((JsPath \ "modified").read[DateTime] or Reads.pure(DateTime.now()))
+  )(Group.apply _)
 
   val TABLE            = "groups"
   val FIELD_GROUP_TYPE = "group_type"

--- a/app/org/maproulette/framework/model/Group.scala
+++ b/app/org/maproulette/framework/model/Group.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.model
+
+import org.joda.time.DateTime
+import org.maproulette.framework.psql.CommonField
+import org.maproulette.data.{UserType}
+import play.api.libs.json._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+
+/**
+  * Groups represent simple collections of member objects, such teams of users.
+  * Group members are referenced by both type and id for flexiblity
+  *
+  * @author nrotstan
+  */
+case class Group(
+    id: Long,
+    name: String,
+    description: Option[String] = None,
+    avatarURL: Option[String] = None,
+    groupType: Int = Group.GROUP_TYPE_STANDARD,
+    created: DateTime = DateTime.now(),
+    modified: DateTime = DateTime.now()
+) extends Identifiable
+
+object Group extends CommonField {
+  implicit val writes: Writes[Group] = Json.writes[Group]
+  implicit val reads: Reads[Group]   = Json.reads[Group]
+
+  val TABLE            = "groups"
+  val FIELD_GROUP_TYPE = "group_type"
+
+  // Types of groups
+  val GROUP_TYPE_STANDARD = 0
+  val GROUP_TYPE_TEAM     = 1
+}
+
+/**
+  * GroupMember represents an object that belongs to a Group
+  */
+case class GroupMember(
+    id: Long,
+    groupId: Long,
+    memberType: Int,
+    memberId: Long,
+    status: Int,
+    created: DateTime = DateTime.now(),
+    modified: DateTime = DateTime.now()
+) extends Identifiable {
+  def asMemberObject(): MemberObject =
+    MemberObject(this.memberType, this.memberId)
+}
+
+object GroupMember extends CommonField {
+  implicit val writes: Writes[GroupMember] = Json.writes[GroupMember]
+  implicit val reads: Reads[GroupMember]   = Json.reads[GroupMember]
+
+  val TABLE             = "group_members"
+  val FIELD_GROUP_ID    = "group_id"
+  val FIELD_MEMBER_TYPE = "member_type"
+  val FIELD_MEMBER_ID   = "member_id"
+  val FIELD_STATUS      = "status"
+
+  // Member statuses are specific to the type of group, but a baseline "member"
+  // status is defined here as a default
+  val STATUS_MEMBER = 0
+}
+
+case class MemberObject(
+    objectType: Int,
+    objectId: Long
+)
+
+object MemberObject {
+  def user(userId: Long) = MemberObject(UserType().typeId, userId)
+}

--- a/app/org/maproulette/framework/model/Identifiable.scala
+++ b/app/org/maproulette/framework/model/Identifiable.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.model
+
+import sangria.execution.deferred.HasId
+
+/**
+  * Represents models that have an id, defining an implicit `hasId` needed for
+  * graphQL queries
+  *
+  * @author nrotstan
+  */
+trait Identifiable {
+  val id: Long
+}
+object Identifiable {
+  implicit def hasId[T <: Identifiable]: HasId[T, Long] = HasId(_.id)
+}

--- a/app/org/maproulette/framework/model/Project.scala
+++ b/app/org/maproulette/framework/model/Project.scala
@@ -6,6 +6,7 @@ package org.maproulette.framework.model
 
 import org.joda.time.DateTime
 import org.maproulette.cache.CacheObject
+import org.maproulette.data.{ItemType}
 import org.maproulette.framework.psql.CommonField
 import play.api.libs.json.{Json, Reads, Writes}
 import play.api.libs.json.JodaWrites._
@@ -31,7 +32,10 @@ case class Project(
     deleted: Boolean = false,
     isVirtual: Option[Boolean] = Some(false),
     featured: Boolean = false
-) extends CacheObject[Long]
+) extends CacheObject[Long] {
+  def grantsToType(granteeType: ItemType) =
+    this.grants.filter(_.grantee.granteeType == granteeType)
+}
 
 object Project extends CommonField {
   implicit val grantWrites: Writes[Grant] = Grant.writes

--- a/app/org/maproulette/framework/model/Team.scala
+++ b/app/org/maproulette/framework/model/Team.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.model
+
+import play.api.libs.json._
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+
+/**
+  * @author nrotstan
+  */
+trait TeamMember {}
+object TeamMember {
+  val STATUS_MEMBER  = GroupMember.STATUS_MEMBER
+  val STATUS_INVITED = 1
+}
+
+/**
+  * Represents basic user fields relevant to team membership
+  */
+case class TeamUser(
+    id: Long,
+    userId: Long,
+    osmId: Long,
+    name: String,
+    teamId: Long,
+    teamGrants: List[Grant],
+    status: Int
+) extends Identifiable
+
+object TeamUser {
+  implicit val writes: Writes[TeamUser] = Json.writes[TeamUser]
+  implicit val reads: Reads[TeamUser]   = Json.reads[TeamUser]
+
+  def fromUser(teamId: Long, member: GroupMember, user: User) = {
+    val teamTarget = GrantTarget.group(teamId)
+    val teamGrants = user.grants.filter(g => g.target == teamTarget)
+    TeamUser(
+      member.id,
+      user.id,
+      user.osmProfile.id,
+      user.osmProfile.displayName,
+      teamId,
+      teamGrants,
+      member.status
+    )
+  }
+}
+
+/**
+  * Bundles together a team with grants
+  */
+case class ManagingTeam(
+    team: Group,
+    grants: List[Grant]
+)
+object ManagingTeam {
+  implicit val writes: Writes[ManagingTeam] = Json.writes[ManagingTeam]
+  implicit val reads: Reads[ManagingTeam]   = Json.reads[ManagingTeam]
+}

--- a/app/org/maproulette/framework/psql/Query.scala
+++ b/app/org/maproulette/framework/psql/Query.scala
@@ -41,6 +41,8 @@ object Query {
       includeWhere,
       appendBase
     )
+
+  def empty = Query.simple(List())
 }
 
 case class Query(
@@ -63,6 +65,17 @@ case class Query(
     } else {
       SQL(sql).asSimple[Row]()
     }
+  }
+
+  def addFilterGroup(group: FilterGroup) = {
+    Query(
+      Filter(group :: filter.groups),
+      base,
+      paging,
+      order,
+      grouping,
+      includeWhere
+    )
   }
 
   override def parameters(): List[NamedParameter] = filter.parameters() ++ paging.parameters()

--- a/app/org/maproulette/framework/psql/filter/Operator.scala
+++ b/app/org/maproulette/framework/psql/filter/Operator.scala
@@ -13,7 +13,8 @@ import org.maproulette.framework.psql.SQLUtils
   */
 object Operator extends Enumeration {
   type Operator = Value
-  val EQ, GT, GTE, LT, LTE, IN, LIKE, ILIKE, CUSTOM, BETWEEN, NULL, SIMILAR_TO, EXISTS, BOOL = Value
+  val EQ, NE, GT, GTE, LT, LTE, IN, LIKE, ILIKE, CUSTOM, BETWEEN, NULL, SIMILAR_TO, EXISTS, BOOL =
+    Value
 
   def format(
       key: String,
@@ -34,6 +35,7 @@ object Operator extends Enumeration {
     }
     operator match {
       case EQ         => s"$negation$key = $rightValue"
+      case NE         => s"$negation$key <> $rightValue"
       case GT         => s"$negation$key > $rightValue"
       case GTE        => s"$negation$key >= $rightValue"
       case LT         => s"$negation$key < $rightValue"

--- a/app/org/maproulette/framework/repository/GroupMemberRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupMemberRepository.scala
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.repository
+
+import java.sql.Connection
+
+import anorm.Macro.ColumnNaming
+import anorm._
+import javax.inject.{Inject, Singleton}
+import org.maproulette.framework.model.{Group, GroupMember, MemberObject}
+import org.maproulette.framework.repository.{UserRepository}
+import org.maproulette.framework.psql.Query
+import org.maproulette.framework.psql.filter._
+import play.api.db.Database
+
+/**
+  * @author nrotstan
+  */
+@Singleton
+class GroupMemberRepository @Inject() (
+    override val db: Database
+) extends RepositoryMixin {
+  implicit val baseTable: String = GroupMember.TABLE
+
+  /**
+    * Finds 0 or more group members that match the filter criteria
+    *
+    * @param query The psql query object containing all the filtering, paging and ordering information
+    * @param c An implicit connection, that defaults to None
+    * @return The list of group members that match the filter criteria
+    */
+  def query(query: Query)(implicit c: Option[Connection] = None): List[GroupMember] = {
+    withMRConnection { implicit c =>
+      query.build(s"SELECT * FROM group_members").as(GroupMemberRepository.parser.*)
+    }
+  }
+
+  /**
+    * Gets all the members with matching ids
+    *
+    * @param ids The ids of desired group members
+    * @param query query object containing any additional filtering, paging and ordering information
+    * @return A list of members
+    */
+  def list(ids: List[Long], query: Query = Query.empty): List[GroupMember] = {
+    this.query(
+      query.addFilterGroup(
+        FilterGroup(
+          List(BaseParameter(GroupMember.FIELD_ID, ids, Operator.IN))
+        )
+      )
+    )
+  }
+
+  /**
+    * Gets all the members that belong to a Group
+    *
+    * @param group The group for which members are desired
+    * @param query query object containing any additional filtering, paging and ordering information
+    * @return A list of members that belong to the group
+    */
+  def getGroupMembers(group: Group, query: Query = Query.empty): List[GroupMember] = {
+    this.getGroupMembersForGroupIds(List(group.id), query)
+  }
+
+  /**
+    * Gets all the members that belong to any of the matching Group ids
+    *
+    * @param id The ids of groups for which members are desired
+    * @param query query object containing any additional filtering, paging and ordering information
+    * @return A list of members that belong to the group
+    */
+  def getGroupMembersForGroupIds(ids: List[Long], query: Query = Query.empty): List[GroupMember] = {
+    this.query(
+      query.addFilterGroup(
+        FilterGroup(
+          List(BaseParameter(GroupMember.FIELD_GROUP_ID, ids, Operator.IN))
+        )
+      )
+    )
+  }
+
+  /**
+    * Gets GroupMember instances representing all group memberships for the
+    * given member
+    *
+    * @param member The member for which group memberships are desired
+    * @return A list of memberships that belong to the member
+    */
+  def getMemberships(member: MemberObject): List[GroupMember] = {
+    this.query(
+      Query.simple(
+        List(
+          BaseParameter(GroupMember.FIELD_MEMBER_TYPE, member.objectType),
+          BaseParameter(GroupMember.FIELD_MEMBER_ID, member.objectId)
+        )
+      )
+    )
+  }
+
+  /**
+    * Retrieves GroupMember instances representing all group memberships for all
+    * the given member ids of the same member type
+    *
+    * @param memberType The type of the members (must all be the same)
+    * @param memberIds The member ids of the members
+    * @return A list of memberships belonging to the members
+    */
+  def getMembershipsForMembers(memberType: Int, memberIds: List[Long]): List[GroupMember] = {
+    this.query(
+      Query.simple(
+        List(
+          BaseParameter(GroupMember.FIELD_MEMBER_TYPE, memberType),
+          BaseParameter(GroupMember.FIELD_MEMBER_ID, memberIds, Operator.IN)
+        )
+      )
+    )
+  }
+
+  /**
+    * Gets all the groups to which a member belongs
+    *
+    * @param member The member for which groups are desired
+    * @param query query object containing any additional filtering, paging and ordering information
+    * @return A list of groups to which the member belongs
+    */
+  def getMemberGroups(member: MemberObject, query: Query = Query.empty): List[Group] = {
+    withMRTransaction { implicit c =>
+      query
+        .addFilterGroup(
+          FilterGroup(
+            List(
+              BaseParameter(GroupMember.FIELD_MEMBER_TYPE, member.objectType),
+              BaseParameter(GroupMember.FIELD_MEMBER_ID, member.objectId)
+            )
+          )
+        )
+        .build(
+          """
+        |SELECT groups.* FROM groups
+        |INNER JOIN group_members ON group_members.group_id = groups.id
+        """.stripMargin
+        )
+        .as(GroupRepository.parser.*)
+    }
+  }
+
+  /**
+    * Add a new member to a group
+    *
+    * @param group  The group to which to add the member
+    * @param member The new member to be added to the group
+    * @param c      Implicit provided optional connection
+    * @return       The new GroupMember or None
+    */
+  def addGroupMember(group: Group, member: MemberObject, status: Int = GroupMember.STATUS_MEMBER)(
+      implicit c: Option[Connection] = None
+  ): Option[GroupMember] = {
+    this.withMRTransaction { implicit c =>
+      SQL(
+        """
+        |INSERT INTO group_members (group_id, member_type, member_id, status)
+        |VALUES ({groupId}, {memberType}, {memberId}, {status})
+        |RETURNING *
+        """.stripMargin
+      ).on(
+          Symbol("groupId")    -> group.id,
+          Symbol("memberType") -> member.objectType,
+          Symbol("memberId")   -> member.objectId,
+          Symbol("status")     -> status
+        )
+        .as(GroupMemberRepository.parser.*)
+        .headOption
+    }
+  }
+
+  /**
+    * Update a group member. Note that status is the only updateable field and
+    * others will be ignored
+    *
+    * @param groupMember The updated GroupMember data
+    * @param c           Implicit provided optional connection
+    * @return            The updated GroupMember
+    */
+  def updateGroupMember(groupMember: GroupMember)(
+      implicit c: Option[Connection] = None
+  ): Option[GroupMember] = {
+    withMRTransaction { implicit c =>
+      SQL(
+        """
+        |UPDATE group_members
+        |SET status = {status}
+        |WHERE id = {id}
+        |RETURNING *
+        """.stripMargin
+      ).on(
+          Symbol("id")     -> groupMember.id,
+          Symbol("status") -> groupMember.status
+        )
+        .as(GroupMemberRepository.parser.*)
+        .headOption
+    }
+  }
+
+  /**
+    * Retrieve a single GroupMember representation for the given group and member,
+    * or None if not found
+    *
+    * @param group  The group to which the member belongs
+    * @param member The member for which a GroupMember is desired
+    */
+  def getGroupMember(group: Group, member: MemberObject)(
+      implicit c: Option[Connection] = None
+  ): Option[GroupMember] = {
+    this
+      .query(
+        Query.simple(
+          List(
+            BaseParameter(GroupMember.FIELD_GROUP_ID, group.id),
+            BaseParameter(GroupMember.FIELD_MEMBER_TYPE, member.objectType),
+            BaseParameter(GroupMember.FIELD_MEMBER_ID, member.objectId)
+          )
+        )
+      )
+      .headOption
+  }
+
+  /**
+    * Delete a member from a group
+    *
+    * @param group  The group to which the member belongs
+    * @param member The member to be removed
+    */
+  def deleteGroupMember(group: Group, member: MemberObject)(
+      implicit c: Option[Connection] = None
+  ): Boolean = {
+    this.delete(
+      Query.simple(
+        List(
+          BaseParameter(GroupMember.FIELD_GROUP_ID, group.id),
+          BaseParameter(GroupMember.FIELD_MEMBER_TYPE, member.objectType),
+          BaseParameter(GroupMember.FIELD_MEMBER_ID, member.objectId)
+        )
+      )
+    )
+  }
+
+  /**
+    * Delete group members
+    *
+    * @param query The psql query object containing all the filtering, paging and ordering information
+    * @param c An implicit connection, that defaults to None
+    */
+  def delete(query: Query)(implicit c: Option[Connection] = None): Boolean = {
+    withMRConnection { implicit c =>
+      query.build(s"DELETE FROM group_members").execute()
+    }
+  }
+}
+
+object GroupMemberRepository {
+  // The anorm row parser to convert group_member records from the database to GroupMember objects
+  val parser: RowParser[GroupMember] = Macro.namedParser[GroupMember](ColumnNaming.SnakeCase)
+}

--- a/app/org/maproulette/framework/repository/GroupRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupRepository.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.repository
+
+import java.sql.Connection
+
+import anorm.SqlParser.{get, long}
+import anorm._
+import javax.inject.Inject
+import org.joda.time.DateTime
+import org.maproulette.framework.model.{Group, GroupMember}
+import org.maproulette.framework.repository.{GroupMemberRepository}
+import org.maproulette.framework.psql.{Query, Paging}
+import org.maproulette.framework.psql.filter.{BaseParameter, Operator}
+import play.api.db.Database
+
+/**
+  * Repository to handle all the database queries for the Group object
+  *
+  * @author nrotstan
+  */
+class GroupRepository @Inject() (
+    override val db: Database,
+    groupMemberRepository: GroupMemberRepository
+) extends RepositoryMixin {
+  implicit val baseTable: String = Group.TABLE
+
+  /**
+    * Finds 0 or more groups that match the filter criteria
+    *
+    * @param query The psql query object containing all the filtering, paging and ordering information
+    * @param c An implicit connection, that defaults to None
+    * @return The list of groups that match the filter criteria
+    */
+  def query(query: Query)(implicit c: Option[Connection] = None): List[Group] = {
+    withMRConnection { implicit c =>
+      query.build(s"SELECT * FROM groups").as(GroupRepository.parser.*)
+    }
+  }
+
+  /**
+    * For a given id returns the group
+    *
+    * @param id The id of the group you are looking for
+    * @param c An implicit connection, defaults to none and one will be created automatically
+    * @return None if not found, otherwise the Group
+    */
+  def retrieve(id: Long)(implicit c: Option[Connection] = None): Option[Group] = {
+    this.withMRTransaction { implicit c =>
+      Query
+        .simple(List(BaseParameter(Group.FIELD_ID, id)))
+        .build("SELECT * FROM groups")
+        .as(GroupRepository.parser.*)
+        .headOption
+    }
+  }
+
+  /**
+    * Retrieve all groups matching the ids
+    */
+  def list(ids: List[Long], paging: Paging = Paging()): List[Group] = {
+    if (ids.isEmpty) {
+      return List()
+    }
+
+    this.query(
+      Query.simple(
+        List(
+          BaseParameter(Group.FIELD_ID, ids, Operator.IN)
+        ),
+        paging = paging
+      )
+    )
+  }
+
+  /**
+    * Insert a group into the database
+    *
+    * @param group The group to insert into the database. The group will fail to be inserted
+    *             if a group with the same name already exists. If the id field is set on the
+    *             provided group it will be ignored
+    * @param c An implicit connection, that defaults to None
+    * @return The group that was inserted now with the generated id or None
+    */
+  def create(group: Group)(implicit c: Option[Connection] = None): Option[Group] = {
+    this.withMRTransaction { implicit c =>
+      SQL(
+        """
+        |INSERT INTO groups (name, description, avatar_url, group_type)
+        |VALUES ({name}, {description}, {avatarURL}, {groupType})
+        |RETURNING *
+        """.stripMargin
+      ).on(
+          Symbol("name")        -> group.name,
+          Symbol("description") -> group.description,
+          Symbol("avatarURL")   -> group.avatarURL,
+          Symbol("groupType")   -> group.groupType
+        )
+        .as(GroupRepository.parser.*)
+        .headOption
+    }
+  }
+
+  /**
+    * Updates an existing Group
+    *
+    * @param group The properties of the Group to update
+    * @param c    Implicit provided optional connection
+    * @return The updated group
+    */
+  def update(group: Group)(
+      implicit c: Option[Connection] = None
+  ): Option[Group] = {
+    withMRTransaction { implicit c =>
+      SQL(
+        """
+        |UPDATE groups
+        |SET name = {name}, description = {description}, avatar_url={avatarURL}
+        |WHERE id = {id}
+        |RETURNING *
+        """.stripMargin
+      ).on(
+          Symbol("id")          -> group.id,
+          Symbol("name")        -> group.name,
+          Symbol("description") -> group.description,
+          Symbol("avatarURL")   -> group.avatarURL
+        )
+        .as(GroupRepository.parser.*)
+        .headOption
+    }
+  }
+
+  /**
+    * Deletes a Group from the database
+    *
+    * @param group The group to delete
+    * @param c    Implicit provided optional connection
+    */
+  def delete(group: Group)(
+      implicit c: Option[Connection] = None
+  ): Boolean = {
+    withMRConnection { implicit c =>
+      Query
+        .simple(List(BaseParameter(Group.FIELD_ID, group.id)))
+        .build("DELETE FROM groups")
+        .execute()
+    }
+  }
+}
+
+object GroupRepository {
+  // The anorm row parser mapping database records to Group objects
+  val parser: RowParser[Group] = Macro.parser[Group](
+    "groups.id",
+    "groups.name",
+    "groups.description",
+    "groups.avatar_url",
+    "groups.group_type",
+    "groups.created",
+    "groups.modified"
+  )
+}

--- a/app/org/maproulette/framework/service/ChallengeService.scala
+++ b/app/org/maproulette/framework/service/ChallengeService.scala
@@ -57,21 +57,11 @@ class ChallengeService @Inject() (
           ),
           operator = Operator.CUSTOM
         ),
-        SubQueryFilter(
-          user.id.toString,
-          Query.simple(
-            List(
-              BaseParameter(Grant.FIELD_OBJECT_TYPE, ProjectType().typeId),
-              BaseParameter(
-                Grant.FIELD_OBJECT_ID,
-                s"${Project.TABLE}.${Project.FIELD_ID}",
-                useValueDirectly = true
-              ),
-              BaseParameter(Grant.FIELD_GRANTEE_TYPE, UserType().typeId)
-            ),
-            base = s"SELECT ${Grant.TABLE}.object_id FROM grants "
-          ),
-          table = Some("")
+        BaseParameter(
+          Challenge.FIELD_PARENT_ID,
+          user.managedProjectIds,
+          Operator.IN,
+          table = Some(Challenge.TABLE)
         )
       ),
       OR(),

--- a/app/org/maproulette/framework/service/GroupService.scala
+++ b/app/org/maproulette/framework/service/GroupService.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import java.net.URLDecoder
+
+import javax.inject.{Inject, Singleton}
+import org.apache.commons.lang3.StringUtils
+import org.maproulette.exception.{InvalidException, NotFoundException}
+import org.maproulette.framework.model.{Group, GroupMember, MemberObject}
+import org.maproulette.framework.psql._
+import org.maproulette.framework.psql.filter._
+import org.maproulette.framework.psql.{OR, Order, Paging, Query}
+import org.maproulette.framework.repository.{GroupRepository, GroupMemberRepository}
+import org.maproulette.permissions.Permission
+
+/**
+  * Service for handling Group requests
+  *
+  * @author nrotstan
+  */
+@Singleton
+class GroupService @Inject() (
+    repository: GroupRepository,
+    groupMemberRepository: GroupMemberRepository,
+    grantService: GrantService,
+    permission: Permission
+) extends ServiceMixin[Group] {
+
+  /**
+    * Finds 0 or more groups that match the filter criteria
+    *
+    * @param query The psql query object containing all the filtering, paging and ordering information
+    * @return The list of groups that match the filter criteria
+    */
+  override def query(query: Query): List[Group] = this.repository.query(query)
+
+  /**
+    * Retrieves a single group based on an id
+    *
+    * @param id The id of the group
+    */
+  def retrieve(id: Long): Option[Group] = this.repository.retrieve(id)
+
+  /**
+    * Retrieves all groups matching the ids
+    */
+  def list(ids: List[Long], paging: Paging = Paging()): List[Group] =
+    this.repository.list(ids, paging)
+
+  /**
+    * Retrieves a single group with an exact name
+    *
+    * @param name The name of the group
+    * @param query query object containing additional filtering, paging and ordering information
+    * @return The matching group or None if no exact match
+    */
+  def retrieveByName(name: String, query: Query = Query.empty): Option[Group] = {
+    this
+      .query(
+        query.addFilterGroup(
+          FilterGroup(
+            List(BaseParameter(Group.FIELD_NAME, name))
+          )
+        )
+      )
+      .headOption
+  }
+
+  /**
+    * Search for groups matching the given search criteria
+    *
+    * @param nameFragment Group name fragment to match
+    * @param query query object containing additional filtering, paging and ordering information
+    */
+  def search(nameFragment: String, query: Query = Query.empty): List[Group] = {
+    this.query(
+      query.addFilterGroup(
+        FilterGroup(
+          List(
+            BaseParameter(Group.FIELD_NAME, SQLUtils.search(nameFragment), Operator.ILIKE)
+          )
+        )
+      )
+    )
+  }
+
+  /**
+    * Create a new Group
+    *
+    * @param group The group to create
+    * @return The newly created group
+    */
+  def create(group: Group): Option[Group] = this.repository.create(group)
+
+  /**
+    * Retrieve group members with matching ids
+    *
+    * @param ids The ids of desired group members
+    */
+  def listGroupMembers(ids: List[Long]): List[GroupMember] =
+    this.groupMemberRepository.list(ids)
+
+  /**
+    * Retrieve members of the given group
+    *
+    * @param group The group for which members are desired
+    * @param query query object containing any additional filtering, paging and ordering information
+    */
+  def groupMembers(group: Group, query: Query = Query.empty): List[GroupMember] =
+    this.groupMemberRepository.getGroupMembers(group, query)
+
+  /**
+    * Retrieve members of the groups matching the given ids
+    *
+    * @param group The ids of groups for which members are desired
+    */
+  def groupMembersForGroupIds(ids: List[Long]): List[GroupMember] =
+    this.groupMemberRepository.getGroupMembersForGroupIds(ids)
+
+  /**
+    * Add a member to a group
+    *
+    * @param group  The group on which to add the new member
+    * @param member The member to add to the group
+    * @return       The new GroupMember or None on failure
+    */
+  def addGroupMember(
+      group: Group,
+      member: MemberObject,
+      status: Int = GroupMember.STATUS_MEMBER
+  ): Option[GroupMember] =
+    this.groupMemberRepository.addGroupMember(group, member, status)
+
+  /**
+    * Retrieve a GroupMember representing the member object
+    *
+    * @param group      The desired group
+    * @param member     The member to retrieve
+    */
+  def getGroupMember(group: Group, member: MemberObject): Option[GroupMember] =
+    this.groupMemberRepository.getGroupMember(group, member)
+
+  /**
+    * Update the status of a group member
+    *
+    * @param group  The group to which the member belongs
+    * @param member The member to update
+    * @param status The new status of the group member
+    */
+  def updateGroupMemberStatus(
+      group: Group,
+      member: MemberObject,
+      status: Int
+  ): Option[GroupMember] = {
+    this.getGroupMember(group, member) match {
+      case Some(groupMember) =>
+        this.groupMemberRepository.updateGroupMember(groupMember.copy(status = status))
+      case None => None
+    }
+  }
+
+  /**
+    * Remove a member from a group
+    *
+    * @param group      The group from which to remove the member
+    * @param member     The member to remove
+    */
+  def removeGroupMember(group: Group, member: MemberObject): Boolean =
+    this.groupMemberRepository.deleteGroupMember(group, member)
+
+  /**
+    * Retrieve a list of all the Groups of which the given member object has
+    * membership
+    *
+    * @param member The member object for which groups are desired
+    */
+  def memberGroups(member: MemberObject, query: Query = Query.empty): List[Group] =
+    this.groupMemberRepository.getMemberGroups(member, query)
+
+  /**
+    * Retrieve GroupMember objects representing the given member's membership in
+    * each of the groups in which they are members
+    */
+  def memberships(member: MemberObject): List[GroupMember] =
+    this.groupMemberRepository.getMemberships(member)
+
+  /**
+    * Retrieve GroupMember instances representing all group memberships for all
+    * the given member ids of the same member type
+    */
+  def getMembershipsForMembers(memberType: Int, memberIds: List[Long]): List[GroupMember] =
+    this.groupMemberRepository.getMembershipsForMembers(memberType, memberIds)
+
+  /**
+    * Determines if a member has membership in a group
+    *
+    * @param group  The group
+    * @param member The candidate member to test for membership
+    */
+  def isGroupMember(group: Group, member: MemberObject): Boolean =
+    this.groupMembers(group).exists { m =>
+      m.asMemberObject() == member
+    }
+
+  /**
+    * Update a group
+    *
+    * @param group The latest group data
+    */
+  def updateGroup(group: Group): Option[Group] = this.repository.update(group)
+
+  /**
+    * Delete a group from the database
+    *
+    * @param group The group to delete
+    * @return Boolean if delete was successful
+    */
+  def deleteGroup(group: Group): Boolean = this.repository.delete(group)
+}

--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -155,23 +155,13 @@ class ProjectService @Inject() (
       if (user.grants.isEmpty && !permission.isSuperUser(user)) {
         List.empty
       } else {
-        val managedProjectIds =
-          this.serviceManager.grant
-            .retrieveGrantsTo(Grantee.user(user.id), User.superUser)
-            .filter { g =>
-              g.target.objectType == ProjectType()
-            }
-            .map { g =>
-              g.target.objectId
-            }
-
         // TODO No sql should exist in the service layer
         val customQuery =
           s"""SELECT distinct projects.*, LOWER(projects.name), LOWER(projects.display_name)
               FROM projects"""
         val baseFilterGroup = FilterGroup(
           List(
-            BaseParameter(Project.FIELD_ID, managedProjectIds, Operator.IN),
+            BaseParameter(Project.FIELD_ID, user.managedProjectIds(), Operator.IN),
             BaseParameter(Project.FIELD_NAME, SQLUtils.search(searchString), Operator.LIKE),
             FilterParameter.conditional(
               Project.FIELD_ENABLED,

--- a/app/org/maproulette/framework/service/ServiceManager.scala
+++ b/app/org/maproulette/framework/service/ServiceManager.scala
@@ -19,6 +19,7 @@ class ServiceManager @Inject() (
     projectService: Provider[ProjectService],
     grantService: Provider[GrantService],
     userService: Provider[UserService],
+    groupService: Provider[GroupService],
     commentService: Provider[CommentService],
     tagService: Provider[TagService],
     challengeService: Provider[ChallengeService],
@@ -27,7 +28,8 @@ class ServiceManager @Inject() (
     userMetricService: Provider[UserMetricService],
     virtualProjectService: Provider[VirtualProjectService],
     taskReviewService: Provider[TaskReviewService],
-    taskService: Provider[TaskService]
+    taskService: Provider[TaskService],
+    teamService: Provider[TeamService]
 ) {
   def comment: CommentService = commentService.get()
 
@@ -40,6 +42,7 @@ class ServiceManager @Inject() (
   def getService(itemType: ItemType): ServiceMixin[_] = itemType match {
     case ProjectType()   => this.project
     case UserType()      => this.user
+    case GroupType()     => this.group
     case ChallengeType() => this.challenge
     case TagType()       => this.tag
     case GrantType()     => this.grant
@@ -52,6 +55,8 @@ class ServiceManager @Inject() (
 
   def user: UserService = userService.get()
 
+  def group: GroupService = groupService.get()
+
   def challenge: ChallengeService = challengeService.get()
 
   def challengeListing: ChallengeListingService = challengeListingService.get()
@@ -61,4 +66,6 @@ class ServiceManager @Inject() (
   def taskReview: TaskReviewService = taskReviewService.get()
 
   def task: TaskService = taskService.get()
+
+  def team: TeamService = teamService.get()
 }

--- a/app/org/maproulette/framework/service/TeamService.scala
+++ b/app/org/maproulette/framework/service/TeamService.scala
@@ -1,0 +1,854 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import java.net.URLDecoder
+
+import javax.inject.{Inject, Singleton}
+import org.apache.commons.lang3.StringUtils
+import org.maproulette.exception.{InvalidException, NotFoundException}
+import org.maproulette.framework.model._
+import org.maproulette.data.{Actions, UserType, GroupType, ProjectType}
+import org.maproulette.framework.psql._
+import org.maproulette.framework.psql.filter._
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
+import org.maproulette.permissions.Permission
+
+/**
+  * Service for handling teams, which are really just groups
+  *
+  * @author nrotstan
+  */
+@Singleton
+class TeamService @Inject() (
+    groupService: GroupService,
+    grantService: GrantService,
+    serviceManager: ServiceManager,
+    webSocketProvider: WebSocketProvider,
+    permission: Permission
+) extends ServiceMixin[Group] {
+
+  /**
+    * Query teams. Note that this version runs as the guest user
+    */
+  override def query(query: Query): List[Group] = this.query(query, User.guestUser)
+
+  /**
+    * Query teams
+    *
+    * @param user The user making the request
+    */
+  def query(query: Query, user: User): List[Group] = {
+    // Everyone has read access to teams, so no need to check permissions
+    this.groupService.query(
+      query.addFilterGroup(
+        FilterGroup(
+          List(BaseParameter(Group.FIELD_GROUP_TYPE, Group.GROUP_TYPE_TEAM))
+        )
+      )
+    )
+  }
+
+  /**
+    * Retrieves a single team based on an id. Note that this version runs as
+    * the guest user
+    *
+    * @param id The id of the team
+    */
+  def retrieve(id: Long): Option[Group] = this.retrieve(id, User.guestUser)
+
+  /**
+    * Retrieves a single team based on an id
+    *
+    * @param id   The id of the team
+    * @param user The user making the request
+    */
+  def retrieve(id: Long, user: User): Option[Group] = {
+    // Everyone has read access to teams, so no need to check permissions
+    this
+      .query(
+        Query.simple(List(BaseParameter(Group.FIELD_ID, id)))
+      )
+      .headOption
+  }
+
+  /**
+    * Retrieves all teams matching the ids
+    */
+  def list(ids: List[Long], user: User): List[Group] =
+    // Everyone has read access to teams, so no need to check permissions
+    this.groupService.list(ids)
+
+  /**
+    * Retrieves a single team based on a team name
+    *
+    * @param id   The name of the team
+    * @param user The user making the request
+    */
+  def retrieveByName(name: String, user: User): Option[Group] =
+    this.groupService.retrieveByName(
+      name,
+      Query.simple(List(BaseParameter(Group.FIELD_GROUP_TYPE, Group.GROUP_TYPE_TEAM)))
+    )
+
+  /**
+    * Search for teams matching the given search criteria
+    *
+    * @param nameFragment team name fragment to match
+    * @param user         The user making the request
+    */
+  def search(nameFragment: String, paging: Paging, user: User): List[Group] = {
+    // Everyone has read access to teams, so no need to check permissions
+    this.groupService.search(
+      nameFragment,
+      Query.simple(
+        List(
+          BaseParameter(Group.FIELD_GROUP_TYPE, Group.GROUP_TYPE_TEAM)
+        ),
+        paging = paging
+      )
+    )
+  }
+
+  /**
+    * Create a new team
+    *
+    * @param team  The team to create
+    * @param admin The initial administrator of the team
+    * @param user  The user creating team
+    * @return The newly created team
+    */
+  def create(team: Group, admin: MemberObject, user: User): Option[Group] = {
+    // Anyone can create a team
+    this.groupService.create(team.copy(groupType = Group.GROUP_TYPE_TEAM)) match {
+      case Some(createdTeam) =>
+        this.addTeamMember(
+          createdTeam,
+          admin,
+          Grant.ROLE_ADMIN,
+          TeamMember.STATUS_MEMBER,
+          User.superUser
+        )
+        Some(createdTeam)
+      case None => None
+    }
+  }
+
+  /**
+    * Retrieve all members of a team regardless of status
+    *
+    * @param team The team for which members are desired
+    * @param user The user making the request
+    */
+  def teamMembers(team: Group, user: User): List[GroupMember] = {
+    // Everyone has read access to teams, so no need to check permissions
+    this.ensureTeam(team)
+    this.groupService.groupMembersForGroupIds(List(team.id))
+  }
+
+  /**
+    * Retrieve memberships in all teams for given user member ids
+    *
+    * @param memberIds The ids of the member objects (NOT users!) representing the team users
+    * @param user The user making the request
+    * @return TeamUser representations of the memberships
+    */
+  def listTeamUsers(memberIds: List[Long], user: User): List[TeamUser] = {
+    // Everyone has read access to teams, so no need to check permissions
+    if (memberIds.isEmpty) {
+      return List()
+    }
+
+    val members = this.groupService.listGroupMembers(memberIds)
+    this.memberUsers(members, user)
+  }
+
+  /**
+    * Retrieve TeamUser representation of all member users on a team
+    *
+    * @param teamIds ids of teams for which members are desired
+    * @param user    The user making the request
+    */
+  def teamUsersByTeamIds(teamIds: List[Long], user: User): List[TeamUser] = {
+    // Everyone has read access to teams, so no need to check permissions
+    if (teamIds.isEmpty) {
+      return List()
+    }
+
+    val members = this.groupService.groupMembersForGroupIds(teamIds)
+    this.memberUsers(members, user)
+  }
+
+  /**
+    * Retrieve active members of a team granted admin role on the team
+    *
+    * @param team The team for which admins are desired
+    * @param user The user making the request
+    */
+  def teamAdmins(team: Group, user: User): List[GroupMember] = {
+    // Everyone has read access to teams, so no need to check permissions
+    this.ensureTeam(team)
+    val adminMemberIds = this.grantService
+      .retrieveMatchingGrants(
+        role = Some(Grant.ROLE_ADMIN),
+        target = Some(GrantTarget.group(team.id)),
+        user = User.superUser
+      )
+      .map(grant => grant.grantee.granteeId)
+
+    this.groupService.groupMembers(
+      team,
+      Query.simple(
+        List(
+          BaseParameter(GroupMember.FIELD_MEMBER_ID, adminMemberIds, Operator.IN),
+          BaseParameter(GroupMember.FIELD_STATUS, TeamMember.STATUS_INVITED, Operator.NE)
+        )
+      )
+    )
+  }
+
+  /**
+    * Retrieve TeamUser representations of the given user members
+    *
+    * @param members  List of GroupMembers for which User objects are desired
+    * @param user     The user making the request
+    */
+  def memberUsers(
+      members: List[GroupMember],
+      user: User
+  ): List[TeamUser] = {
+    if (members.isEmpty) {
+      return List()
+    }
+
+    val userType    = UserType().typeId
+    val userMembers = members.filter(member => member.memberType == userType)
+    val userIds     = userMembers.map(member => member.memberId)
+    val users = this.serviceManager.user.query(
+      Query.simple(
+        List(BaseParameter(User.FIELD_ID, userIds, Operator.IN))
+      ),
+      user
+    )
+
+    userMembers
+      .map(member => {
+        users.find(u => u.id == member.memberId) match {
+          case Some(user) => Some(TeamUser.fromUser(member.groupId, member, user))
+          case None       => None
+        }
+      })
+      .flatten
+  }
+
+  /**
+    * Retrieve TeamUser representations of all user members on a team
+    *
+    * @param teamId The id of the team for which members are desired
+    * @param user   The user making the request
+    */
+  def teamUsers(teamId: Long, user: User): List[TeamUser] = {
+    this.retrieve(teamId, user) match {
+      case Some(team) =>
+        this.memberUsers(this.teamMembers(team, user), user)
+      case None =>
+        throw new NotFoundException(s"No team with id ${teamId} found")
+    }
+  }
+
+  /**
+    * Add a member to a team with a specific role
+    *
+    * @param team   The team on which to add the member
+    * @param member The member to be added to the team
+    * @param role   The member's role
+    * @param status The member's status on the team, defaults to INVITED
+    * @param user   The user making the request
+    * @return       The new GroupMember
+    */
+  def addTeamMember(
+      team: Group,
+      member: MemberObject,
+      role: Int,
+      status: Int = TeamMember.STATUS_INVITED,
+      user: User
+  ): Option[GroupMember] = {
+    // Only team admin can add members to a team
+    this.ensureTeam(team)
+    this.permission.hasObjectAdminAccess(team, user)
+
+    val addedMember = this.groupService.addGroupMember(team, member, status)
+    this.grantTeamRole(team, role, member)
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.teamUpdate(
+        WebSocketMessages.TeamUpdateData(team.id, Some(member.objectId))
+      )
+    )
+    this.serviceManager.user.clearCache(member.objectId)
+    addedMember
+  }
+
+  /**
+    * Invite a user to join a team
+    *
+    * @param teamId The id of the team to which the member should be invited
+    * @param userId The member to be invited to the team
+    * @param role   The member's role should they accept the invitation
+    * @param user   The user making the request
+    * @return       The new TeamUser
+    */
+  def inviteTeamUser(teamId: Long, userId: Long, role: Int, user: User): Option[TeamUser] = {
+    val team = this.retrieve(teamId, user) match {
+      case Some(t) => t
+      case None =>
+        throw new NotFoundException(s"No team with id $teamId found")
+    }
+
+    val invitee = this.serviceManager.user.retrieve(userId) match {
+      case Some(u) => u
+      case None =>
+        throw new NotFoundException(s"No user with id $userId found")
+    }
+
+    this.addTeamMember(team, MemberObject.user(userId), role, TeamMember.STATUS_INVITED, user) match {
+      case Some(member) => Some(TeamUser.fromUser(team.id, member, invitee))
+      case None         => None
+    }
+  }
+
+  /**
+    * Accept an invitation to join a team
+    *
+    * @param teamId The id of the team the member is joining
+    * @param member The member accepting the invitation
+    * @param user   The user making the request
+    * @return       The updated GroupMember
+    */
+  def acceptInvitation(teamId: Long, member: MemberObject, user: User): Option[GroupMember] = {
+    this.retrieve(teamId, user) match {
+      case Some(team) =>
+        this.getTeamMember(team, member, user) match {
+          case Some(teamMember) =>
+            if (teamMember.status != TeamMember.STATUS_INVITED) {
+              throw new InvalidException("Invitation has already been accepted")
+            }
+            this.updateMemberStatus(team, member, TeamMember.STATUS_MEMBER, User.superUser)
+          case None =>
+            throw new NotFoundException("No open invitation found")
+        }
+      case None =>
+        throw new NotFoundException(s"No team with id $teamId found")
+    }
+  }
+
+  /**
+    * Accept an invitation made to user to join a team
+    *
+    * @param teamId The id of the team the member is joining
+    * @param userId The id of the user member accepting the invitation
+    * @param user   The user making the request
+    * @return       The updated TeamUser
+    */
+  def acceptUserInvitation(teamId: Long, userId: Long, user: User): Option[TeamUser] = {
+    val invitee = this.serviceManager.user.retrieve(userId) match {
+      case Some(u) => u
+      case None =>
+        throw new NotFoundException(s"No user with id $userId found")
+    }
+
+    this.acceptInvitation(teamId, MemberObject.user(userId), user) match {
+      case Some(member) => Some(TeamUser.fromUser(teamId, member, invitee))
+      case None         => None
+    }
+  }
+
+  /**
+    * Decline an invitation to join a team
+    *
+    * @param teamId The id of the team the member was invited to join
+    * @param member The member declining the invitation
+    * @param user   The user making the request
+    */
+  def declineInvitation(teamId: Long, member: MemberObject, user: User): Boolean = {
+    this.retrieve(teamId, user) match {
+      case Some(team) =>
+        this.getTeamMember(team, member, user) match {
+          case Some(teamMember) if (teamMember.status == TeamMember.STATUS_INVITED) =>
+            this.removeTeamMember(team, member, User.superUser)
+          case _ =>
+            throw new NotFoundException("No open invitation found")
+        }
+      case None =>
+        throw new NotFoundException(s"No team with id $teamId found")
+    }
+  }
+
+  /**
+    * Retrieve a GroupMember object representing the given team member
+    *
+    * @param team   The desired team
+    * @param member The member to retrieve
+    * @param user   The user making the request
+    */
+  def getTeamMember(team: Group, member: MemberObject, user: User): Option[GroupMember] = {
+    // Everyone has read access to teams, so no need to check permissions
+    this.ensureTeam(team)
+    this.groupService.getGroupMember(team, member)
+  }
+
+  /**
+    * Remove a member from a team
+    *
+    * @param team   The team from which to remove the member
+    * @param member The member to be removed from the team
+    * @param user   The user performing the removal
+    */
+  def removeTeamMember(team: Group, member: MemberObject, user: User): Boolean = {
+    this.ensureTeam(team)
+    // Only team admin (or the member itself) can remove a member from a team
+    if (MemberObject.user(user.id) != member) {
+      this.permission.hasObjectAdminAccess(team, user)
+    }
+
+    // Don't let the last admin get removed from the team
+    this.ensureNotLastAdmin(team, member)
+
+    this.groupService.removeGroupMember(team, member)
+    this.clearTeamRoles(team, member)
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.teamUpdate(
+        WebSocketMessages.TeamUpdateData(team.id, Some(member.objectId))
+      )
+    )
+    this.serviceManager.user.clearCache(member.objectId)
+    true
+  }
+
+  /**
+    * Update the role granted to a team member on a team
+    *
+    * @param team   The team to which the member belongs
+    * @param member The member whose role is to be updated
+    * @param role   The new role
+    * @param user   The user making the request
+    * @return       The new TeamMember
+    */
+  def updateMemberRole(team: Group, member: MemberObject, role: Int, user: User): Boolean = {
+    // Only a team admin can update the role of a member
+    this.ensureTeam(team)
+    this.permission.hasObjectAdminAccess(team, user)
+
+    // Make sure the member is actually on the team before we update their role
+    if (this.getTeamMember(team, member, user) == None) {
+      throw new InvalidException(s"Cannot update role on team for non-member")
+    }
+
+    // Don't let the last admin get demoted
+    if (Grant.hasLesserPrivilege(role, Grant.ROLE_ADMIN)) {
+      this.ensureNotLastAdmin(team, member)
+    }
+    this.setTeamRole(team, role, member)
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.teamUpdate(
+        WebSocketMessages.TeamUpdateData(team.id, Some(member.objectId))
+      )
+    )
+    true
+  }
+
+  /**
+    * Update the role granted to a user member on a team
+    *
+    * @param teamId The id of the team to which the member belongs
+    * @param userId The id of the user member whose role is to be updated
+    * @param role   The new role
+    * @param user   The user making the request
+    * @return       The updated TeamUser
+    */
+  def updateUserRole(teamId: Long, userId: Long, role: Int, user: User): TeamUser = {
+    val team = this.retrieve(teamId, user) match {
+      case Some(t) => t
+      case None    => throw new NotFoundException(s"No team with id $teamId found")
+    }
+
+    this.updateMemberRole(team, MemberObject.user(userId), role, user)
+
+    // Fetch the updated member and user data
+    val member = getTeamMember(team, MemberObject.user(userId), user) match {
+      case Some(m) => m
+      case None =>
+        throw new NotFoundException(s"No membership on team $teamId for user $userId found")
+    }
+
+    this.serviceManager.user.retrieve(userId) match {
+      case Some(u) => TeamUser.fromUser(teamId, member, u)
+      case None =>
+        throw new NotFoundException(s"No user with id $userId found")
+    }
+  }
+
+  /**
+    * Update the status of a team member
+    *
+    * @param team   The team to which the member belongs
+    * @param member The member whose role is to be updated
+    * @param status The new status
+    * @param user   The user making the request
+    * @return       The updated GroupMember
+    */
+  def updateMemberStatus(
+      team: Group,
+      member: MemberObject,
+      status: Int,
+      user: User
+  ): Option[GroupMember] = {
+    // Only a team admin can update the status of a member
+    this.ensureTeam(team)
+    this.permission.hasObjectAdminAccess(team, user)
+    val updatedMember = this.groupService.updateGroupMemberStatus(team, member, status)
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.teamUpdate(
+        WebSocketMessages.TeamUpdateData(team.id, Some(member.objectId))
+      )
+    )
+    updatedMember
+  }
+
+  /**
+    * Retrieve a list of TeamUser instances representing all of the team
+    * memberships for each given user
+    *
+    * @param userIds The ids of the users for which team memberships are desired
+    * @param user    The user making the request
+    */
+  def teamUsersByUserIds(userIds: List[Long], user: User): List[TeamUser] = {
+    if (userIds.isEmpty) {
+      return List()
+    }
+
+    val users = this.serviceManager.user.retrieveListById(userIds)
+    val userMembers =
+      this.groupService.getMembershipsForMembers(UserType().typeId, userIds)
+
+    userMembers
+      .map(member => {
+        users.find(u => u.id == member.memberId) match {
+          case Some(user) => Some(TeamUser.fromUser(member.groupId, member, user))
+          case None       => None
+        }
+      })
+      .flatten
+  }
+
+  /**
+    * Retrieves list of team ids to which a user has membership
+    *
+    * @param userId The user for which member teams are desired
+    * @param user The user making the request
+    */
+  def teamIdsByUser(userId: Long, user: User): List[Long] =
+    this.grantService
+      .retrieveGrantsTo(Grantee.user(userId), User.superUser)
+      .filter(_.target.objectType == GroupType())
+      .map(_.target.objectId)
+
+  /**
+    * Retrieves a list of grants on projects assigned to the given teams
+    *
+    * @param teamIds The ids of the teams for which managed project ids are desired
+    * @param user The user making the request
+    */
+  def projectGrantsForTeams(teamIds: List[Long], user: User): List[Grant] = {
+    if (teamIds.isEmpty) {
+      return List.empty
+    }
+
+    this.grantService
+      .retrieveMatchingGrants(
+        grantee = Some(teamIds.map(id => Grantee.group(id))),
+        user = User.superUser
+      )
+      .filter(_.target.objectType == ProjectType())
+  }
+
+  /**
+    * Retrieves list of project ids managed by the given user id through
+    * their team getMemberships
+    * @param userId The user for which managed project ids are desired
+    * @param user The user making the request
+    */
+  def projectGrantsForUser(userId: Long, user: User): List[Grant] =
+    this.projectGrantsForTeams(this.teamIdsByUser(userId, user), user)
+
+  /**
+    * Retrieves list of project ids managed by the given user id through
+    * their team getMemberships
+    * @param userId The user for which managed project ids are desired
+    * @param user The user making the request
+    */
+  def managedProjectIdsForUser(userId: Long, user: User): List[Long] =
+    this.projectGrantsForUser(userId, user).map(_.target.objectId)
+
+  /**
+    * Determines if a member has membership in the given team and an active
+    * status (i.e. has not merely been invited to join)
+    *
+    * @param team   The team
+    * @param member The member to test for membership
+    * @param user   The user making the request
+    */
+  def isActiveTeamMember(team: Group, member: MemberObject, user: User): Boolean =
+    this
+      .teamMembers(team, user)
+      .exists(m => m.status != TeamMember.STATUS_INVITED && m.asMemberObject() == member)
+
+  /**
+    * Determines if a member has been granted a role on the team
+    *
+    * @param team   The team
+    * @param role   The role to test for
+    * @param member The member to test for a role
+    * @param user   The user making the request
+    */
+  def hasTeamRole(team: Group, role: Int, member: MemberObject, user: User) = {
+    val grants = this.grantService.retrieveMatchingGrants(
+      grantee = Some(List(Grantee(Actions.getItemType(member.objectType).get, member.objectId))),
+      role = Some(role),
+      target = Some(GrantTarget.group(team.id)),
+      user = User.superUser
+    )
+    this.isActiveTeamMember(team, member, user) && !grants.isEmpty
+  }
+
+  /**
+    * Determines if a member has been granted the admin role on a team
+    *
+    * @param team   The team
+    * @param member The member to test for admin role on team
+    * @param user   The user making the request
+    */
+  def isTeamAdmin(team: Group, member: MemberObject, user: User): Boolean = {
+    this.hasTeamRole(team, Grant.ROLE_ADMIN, member, user)
+  }
+
+  /**
+    * Determines if a user member has been granted the admin role on a team
+    *
+    * @param team       The team
+    * @param memberUser The user member to test for admin role on team
+    * @param user       The user making the request
+    */
+  def isUserTeamAdmin(team: Group, memberUser: User, user: User): Boolean =
+    this.isTeamAdmin(team, MemberObject.user(memberUser.id), user)
+
+  /**
+    * Update a team
+    *
+    * @param team The latest team data
+    * @param user The user updating the team
+    */
+  def updateTeam(team: Group, user: User): Option[Group] = {
+    // Only a team admin can update a team
+    this.ensureTeam(team)
+    this.permission.hasObjectAdminAccess(team, user)
+    val updatedGroup = this.groupService.updateGroup(team)
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.teamUpdate(
+        WebSocketMessages.TeamUpdateData(team.id, None)
+      )
+    )
+    updatedGroup
+  }
+
+  /**
+    * Deletes a team from the database
+    *
+    * @param team The team to delete
+    * @param user The user deleting the team
+    * @return Boolean if delete was successful
+    */
+  def deleteTeam(team: Group, user: User): Boolean = {
+    // Only a team admin can delete a team
+    this.permission.hasObjectAdminAccess(team, user)
+    this.groupService.deleteGroup(team)
+    this.grantService.deleteMatchingGrants(
+      target = Some(GrantTarget.group(team.id)),
+      user = User.superUser
+    )
+    webSocketProvider.sendMessage(
+      WebSocketMessages.teamUpdate(
+        WebSocketMessages.TeamUpdateData(team.id, None)
+      )
+    )
+    true
+  }
+
+  /**
+    * Adds a team to a project. All members of the team will be indirectly
+    * granted the given role on the project
+    *
+    * @param id        The ID of the team to add to the project
+    * @param projectId The project that user is being added too
+    * @param role      The type of role to add 1 - Admin, 2 - Write, 3 - Read
+    * @param user      The user that is adding the user to the project
+    */
+  def addTeamToProject(
+      id: Long,
+      projectId: Long,
+      role: Int,
+      user: User,
+      clear: Boolean = false
+  ): Boolean = {
+    if (!this.retrieve(id, user).isDefined) {
+      throw new NotFoundException(s"No team with id ${id} found")
+    }
+    this.permission.hasProjectAccess(this.serviceManager.project.retrieve(projectId), user)
+
+    if (clear) {
+      this.grantService.deleteMatchingGrants(
+        grantee = Some(Grantee.group(id)),
+        target = Some(GrantTarget.project(projectId)),
+        user = User.superUser
+      )
+    }
+
+    val grant = this.grantService.createGrant(
+      Grant(-1, "", Grantee.group(id), role, GrantTarget.project(projectId)),
+      User.superUser
+    )
+
+    this.serviceManager.project.clearCache(projectId)
+    this.serviceManager.user.clearCache()
+    true
+  }
+
+  /**
+    * Removes a team from a project
+    *
+    * @param id        The ID of the team to remove from the project
+    * @param projectId The project from which the team is being removed
+    * @param user      The user making the request
+    */
+  def removeTeamFromProject(id: Long, projectId: Long, user: User): Boolean = {
+    if (!this.retrieve(id, user).isDefined) {
+      throw new NotFoundException(s"No team with id ${id} found")
+    }
+    this.permission.hasProjectAccess(this.serviceManager.project.retrieve(projectId), user)
+
+    this.grantService.deleteMatchingGrants(
+      grantee = Some(Grantee.group(id)),
+      target = Some(GrantTarget.project(projectId)),
+      user = User.superUser
+    )
+
+    this.serviceManager.project.clearCache(projectId)
+    this.serviceManager.user.clearCache()
+    true
+  }
+
+  /**
+    * Retrieve any teams granted a role on a project
+    *
+    * @param projectId The project for which teams are desired
+    * @param user      The user making the request
+    */
+  def getTeamsManagingProject(projectId: Long, user: User): List[ManagingTeam] = {
+    this.permission.hasObjectReadAccess(this.serviceManager.project.retrieve(projectId), user)
+
+    val teamGrants = this.grantService
+      .retrieveGrantsOn(
+        GrantTarget.project(projectId),
+        User.superUser
+      )
+      .filter(_.grantee.granteeType == GroupType())
+
+    this
+      .list(teamGrants.map(_.grantee.granteeId).distinct, user)
+      .map(team =>
+        ManagingTeam(
+          team,
+          teamGrants.filter(_.grantee.granteeId == team.id)
+        )
+      )
+  }
+
+  /**
+    * Remove all granted roles to member on team
+    */
+  private def clearTeamRoles(team: Group, member: MemberObject) = {
+    this.grantService.deleteMatchingGrants(
+      grantee = Some(Grantee(Actions.getItemType(member.objectType).get, member.objectId)),
+      target = Some(GrantTarget.group(team.id)),
+      user = User.superUser
+    )
+    this.clearCachedMember(member)
+  }
+
+  /**
+    * Grant role to member on team
+    */
+  private def grantTeamRole(team: Group, role: Int, member: MemberObject) = {
+    this.grantService.createGrant(
+      Grant(
+        -1L,
+        "",
+        Grantee(Actions.getItemType(member.objectType).get, member.objectId),
+        role,
+        GrantTarget.group(team.id)
+      ),
+      User.superUser
+    )
+    this.clearCachedMember(member)
+  }
+
+  /**
+    * Set member's role on team, clearing any prior roles
+    */
+  private def setTeamRole(team: Group, role: Int, member: MemberObject) = {
+    this.clearTeamRoles(team, member)
+    this.grantTeamRole(team, role, member)
+  }
+
+  /**
+    * Clear member object from its cache so it gets refreshed from the database
+    */
+  private def clearCachedMember(member: MemberObject) = {
+    member.objectType match {
+      case Actions.ITEM_TYPE_USER =>
+        this.serviceManager.user.clearCache(member.objectId)
+      case _ => // Nothing to do
+    }
+  }
+
+  /**
+    * Ensure the given group actually represents a team, throwing an exception
+    * if not
+    */
+  private def ensureTeam(team: Group) = {
+    if (team.groupType != Group.GROUP_TYPE_TEAM) {
+      throw new InvalidException(s"Group ${team.id} is not a team")
+    }
+  }
+
+  /**
+    * Ensure the current member is not the last administrator of the team,
+    * throwing an exception if so. Useful for operations that would remove or
+    * alter the role of an existing administrator
+    */
+  private def ensureNotLastAdmin(team: Group, member: MemberObject) = {
+    val admins = this.teamAdmins(team, User.superUser)
+    if (admins.size == 1 && admins.head.asMemberObject() == member) {
+      throw new InvalidException(
+        "Teams must have at least one administrator"
+      )
+    }
+  }
+}

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -1182,10 +1182,5 @@ class TaskReviewDAL @Inject() (
   }
 
   private def userHasProjectGrantSQL(user: User): String =
-    s"""${user.id} IN (
-        SELECT g.grantee_id from grants g
-        WHERE g.object_type = ${ProjectType().typeId} AND
-              g.object_id = p.id AND
-              g.grantee_type = ${UserType().typeId}
-    )"""
+    s"""p.id IN (${user.managedProjectIds().mkString(",")})"""
 }

--- a/app/org/maproulette/provider/websockets/WebSocketActor.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketActor.scala
@@ -50,6 +50,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
   implicit val taskReviewWrites                   = TaskReview.writes
   implicit val taskWrites: Writes[Task]           = Task.TaskFormat
   implicit val challengeWrites: Writes[Challenge] = Challenge.writes.challengeWrites
+  implicit val teamUpdateDataWrites               = WebSocketMessages.teamUpdateDataWrites
+  implicit val teamMessageWrites                  = WebSocketMessages.teamMessageWrites
 
   def receive = {
     case serverMessage: WebSocketMessages.NotificationMessage =>
@@ -57,6 +59,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
     case serverMessage: WebSocketMessages.ReviewMessage =>
       out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.TaskMessage =>
+      out ! Json.toJson(serverMessage)
+    case serverMessage: WebSocketMessages.TeamMessage =>
       out ! Json.toJson(serverMessage)
     case clientMessage: WebSocketMessages.ClientMessage =>
       clientMessage.messageType match {

--- a/app/org/maproulette/provider/websockets/WebSocketMessages.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketMessages.scala
@@ -58,6 +58,11 @@ object WebSocketMessages {
   case class TaskMessage(messageType: String, data: TaskAction, meta: ServerMeta)
       extends ServerMessage
 
+  case class TeamUpdateData(teamId: Long, userId: Option[Long])
+
+  case class TeamMessage(messageType: String, data: TeamUpdateData, meta: ServerMeta)
+      extends ServerMessage
+
   // Public helper methods for creation of individual messages and data objects
   def pong(): PongMessage = PongMessage("pong", ServerMeta(None))
 
@@ -78,6 +83,8 @@ object WebSocketMessages {
 
   def taskUpdate(taskData: Task, userData: Option[UserSummary]): List[ServerMessage] =
     createTaskMessage("task-update", taskData, userData)
+
+  def teamUpdate(data: TeamUpdateData): TeamMessage = createTeamMessage("team-update", data)
 
   def userSummary(user: User): UserSummary =
     UserSummary(user.id, user.osmProfile.displayName, user.osmProfile.avatarURL)
@@ -125,6 +132,10 @@ object WebSocketMessages {
     )
   }
 
+  private def createTeamMessage(messageType: String, data: TeamUpdateData): TeamMessage = {
+    TeamMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_TEAMS)))
+  }
+
   // Reads for client messages
   implicit val clientMessageReads: Reads[ClientMessage]       = Json.reads[ClientMessage]
   implicit val subscriptionDataReads: Reads[SubscriptionData] = Json.reads[SubscriptionData]
@@ -137,10 +148,12 @@ object WebSocketMessages {
   implicit val notificationDataWrites: Writes[NotificationData] = Json.writes[NotificationData]
   implicit val notificationMessageWrites: Writes[NotificationMessage] =
     Json.writes[NotificationMessage]
-  implicit val reviewDataWrites: Writes[ReviewData]       = Json.writes[ReviewData]
-  implicit val reviewMessageWrites: Writes[ReviewMessage] = Json.writes[ReviewMessage]
-  implicit val taskActionWrites: Writes[TaskAction]       = Json.writes[TaskAction]
-  implicit val taskMessageWrites: Writes[TaskMessage]     = Json.writes[TaskMessage]
+  implicit val reviewDataWrites: Writes[ReviewData]         = Json.writes[ReviewData]
+  implicit val reviewMessageWrites: Writes[ReviewMessage]   = Json.writes[ReviewMessage]
+  implicit val taskActionWrites: Writes[TaskAction]         = Json.writes[TaskAction]
+  implicit val taskMessageWrites: Writes[TaskMessage]       = Json.writes[TaskMessage]
+  implicit val teamUpdateDataWrites: Writes[TeamUpdateData] = Json.writes[TeamUpdateData]
+  implicit val teamMessageWrites: Writes[TeamMessage]       = Json.writes[TeamMessage]
 
   // Available subscription types
   val SUBSCRIPTION_USER            = "user" // expected to be accompanied by user id
@@ -148,4 +161,5 @@ object WebSocketMessages {
   val SUBSCRIPTION_REVIEWS         = "reviews"
   val SUBSCRIPTION_TASKS           = "tasks"
   val SUBSCRIPTION_CHALLENGE_TASKS = "challengeTasks" // expected to be accompanied by challenge id
+  val SUBSCRIPTION_TEAMS           = "teams"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -107,6 +107,7 @@ generateRoutesFile := {
       "virtualchallenge.api",
       "virtualproject.api",
       "bundle.api",
+      "team.api",
       "v2.api"
     )
     println(s"Generating Routes File from ${routeFiles.mkString(",")}")

--- a/conf/evolutions/default/63.sql
+++ b/conf/evolutions/default/63.sql
@@ -1,0 +1,38 @@
+# --- MapRoulette Scheme
+
+# --- !Ups
+CREATE TABLE IF NOT EXISTS groups
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  name character varying NOT NULL,
+  description character varying,
+  avatar_url character varying,
+  group_type integer DEFAULT 0,
+  created timestamp without time zone DEFAULT NOW(),
+  modified timestamp without time zone DEFAULT NOW()
+);;
+
+SELECT create_index_if_not_exists('groups', 'name', '(lower(name))', true);;
+SELECT create_index_if_not_exists('groups', 'group_type', '(group_type)');;
+
+CREATE TABLE IF NOT EXISTS group_members
+(
+  id SERIAL NOT NULL PRIMARY KEY,
+  group_id integer NOT NULL,
+  member_type integer NOT NULL,
+  member_id integer NOT NULL,
+  status integer DEFAULT 0,
+  created timestamp without time zone DEFAULT NOW(),
+  modified timestamp without time zone DEFAULT NOW(),
+  CONSTRAINT group_members_group_id FOREIGN KEY (group_id)
+    REFERENCES groups(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE
+);;
+
+SELECT create_index_if_not_exists('group_members', 'group_id', '(group_id)');;
+SELECT create_index_if_not_exists('group_members', 'member_type_member_id', '(member_type, member_id)');;
+SELECT create_index_if_not_exists('group_members', 'group_member_type_member_id', '(group_id, member_type, member_id)', true);;
+
+# --- !Downs
+DROP TABLE IF EXISTS group_members;;
+DROP TABLE IF EXISTS groups;;

--- a/conf/v2_route/team.api
+++ b/conf/v2_route/team.api
@@ -1,0 +1,315 @@
+###
+# tags: [ Team ]
+# summary: Create a new team
+# description: Creates a new team
+# responses:
+#   '201':
+#     description: The new team with unique id
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.Group'
+# parameters:
+#   - name: body
+#     in: body
+#     description: The JSON structure for the team (a group) body
+#     required: true
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.Group'
+###
+POST    /team                                       @org.maproulette.framework.controller.TeamController.createTeam()
+###
+# tags: [ Team ]
+# summary: Update a team
+# description: Updates the team info (name, description, avatar URL)
+# responses:
+#   '200':
+#     description: The updated team
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.Group'
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+#   - name: body
+#     in: body
+#     description: The JSON structure for the team (a group) body
+#     required: true
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.Group'
+###
+PUT    /team/:id                                    @org.maproulette.framework.controller.TeamController.updateTeam(id: Long)
+###
+# tags: [ Team ]
+# summary: Retrieves a team
+# produces: [ application/json ]
+# description: Retrieves a team based on a specific ID.
+# responses:
+#   '200':
+#     description: The team
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.Group'
+#   '404':
+#     description: If the team is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+###
+GET     /team/:id                                   @org.maproulette.framework.controller.TeamController.retrieve(id:Long)
+###
+# tags: [ Team ]
+# summary: Find teams by name
+# produces: [ application/json ]
+# description: Search for teams by name
+# responses:
+#   '200':
+#     description: a list of matching teams
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.framework.model.Group'
+#   '404':
+#     description: If the team is not found
+# parameters:
+#   - name: name
+#     in: query
+#     description: Name fragment to match
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default is 10 results
+#   - name: page
+#     in: query
+#     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.
+###
+GET     /teams/find                                 @org.maproulette.framework.controller.TeamController.find(name:String, limit:Int ?= 10, page:Int ?= 0)
+###
+# tags: [ Team ]
+# summary: Retrieves users who are members of a team
+# produces: [ application/json ]
+# description: Retrieves all the user members of a team
+# responses:
+#   '200':
+#     description: The users
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.framework.model.TeamUser'
+#   '404':
+#     description: If the team is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+###
+GET     /team/:id/userMembers                       @org.maproulette.framework.controller.TeamController.teamUsers(id:Long)
+###
+# tags: [ Team ]
+# summary: Retrieves all team memberships for a user
+# produces: [ application/json ]
+# description: Retrieves all the given user's team memberships
+# responses:
+#   '200':
+#     description: The memberships
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.framework.model.TeamUser'
+#   '404':
+#     description: If the team is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+###
+GET     /team/all/user/:userId/memberships          @org.maproulette.framework.controller.TeamController.userTeamMemberships(userId:Long)
+###
+# tags: [ Team ]
+# summary: Invites a user to join a team
+# description: Invites a user to join a team with the given role
+# responses:
+#   '200':
+#     description: team user
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.TeamUser'
+#   '404':
+#     description: If the team or user is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+#   - name: userId
+#     in: path
+#     description: The ID for the user to invite
+#   - name: role
+#     in: path
+#     description: Either 1 - Admin, 2 - Write, 3 - Read
+###
+POST    /team/:id/user/:userId/invite/:role         @org.maproulette.framework.controller.TeamController.inviteUser(id:Long, userId:Long, role:Int)
+###
+# tags: [ Team ]
+# summary: Accept an invitation to join a team
+# description: Accepts the logged-in user's invitation to join a team
+# responses:
+#   '200':
+#     description: Updated team user
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.TeamUser'
+#   '404':
+#     description: If the team is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+###
+PUT    /team/:id/invite/accept                      @org.maproulette.framework.controller.TeamController.acceptInvite(id:Long)
+###
+# tags: [ Team ]
+# summary: Decline an invitation to join a team
+# description: Decline the logged-in user's invitation to join a team
+# responses:
+#   '200':
+#     description: A simple OK status message
+#   '404':
+#     description: If the team is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+###
+DELETE /team/:id/invite                             @org.maproulette.framework.controller.TeamController.declineInvite(id:Long)
+###
+# tags: [ Team ]
+# summary: Update a team member's role
+# description: Update a team member's granted role on the team
+# responses:
+#   '200':
+#     description: Updated team user
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.TeamUser'
+#   '404':
+#     description: If the team or user is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+#   - name: userId
+#     in: path
+#     description: The ID for the user to invite
+#   - name: role
+#     in: path
+#     description: Either 1 - Admin, 2 - Write, 3 - Read
+###
+PUT    /team/:id/user/:userId/role/:role            @org.maproulette.framework.controller.TeamController.updateMemberRole(id:Long, userId:Long, role:Int)
+###
+# tags: [ Team ]
+# summary: Remove a member from a team
+# description: Remove a team member from a team
+# responses:
+#   '200':
+#     description: A simple OK status message
+#   '404':
+#     description: If the team or user is not found
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+#   - name: userId
+#     in: path
+#     description: The ID for the user to remove
+###
+DELETE /team/:id/user/:userId/                      @org.maproulette.framework.controller.TeamController.removeTeamMember(id:Long, userId:Long)
+###
+# tags: [ Team ]
+# summary: Grant role to team on project
+# description: Grant a team an Admin, Write or Read role on the project
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: teamId
+#     in: path
+#     description: The id of the team to be granted the role
+#   - name: projectId
+#     in: path
+#     description: The id of the project on which the role is to be granted
+#   - name: role
+#     in: path
+#     description: Either 1 - Admin, 2 - Write, 3 - Read
+###
+POST     /team/:teamId/project/:projectId/:role  @org.maproulette.framework.controller.TeamController.addTeamToProject(teamId:Long, projectId:Long, role:Int)
+###
+# tags: [ Team ]
+# summary: Set granted role of team on project
+# description: Grant a team an Admin, Write or Read role on the project, clearing any prior roles
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: teamId
+#     in: path
+#     description: The id of the team to be granted the role
+#   - name: projectId
+#     in: path
+#     description: The id of the project on which the role is to be granted
+#   - name: role
+#     in: path
+#     description: Either 1 - Admin, 2 - Write, 3 - Read
+###
+PUT      /team/:teamId/project/:projectId/:role  @org.maproulette.framework.controller.TeamController.setTeamProjectRole(teamId:Long, projectId:Long, role:Int)
+###
+# tags: [ Team ]
+# summary: Remove granted roles on project from team
+# description: Remove roles on a project from a team
+# responses:
+#   '200':
+#     description: Ok with a standard message
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: teamId
+#     in: path
+#     description: The id of the team to be granted the role
+#   - name: projectId
+#     in: path
+#     description: The id of the project on which the role is to be granted
+###
+DELETE   /team/:teamId/project/:projectId        @org.maproulette.framework.controller.TeamController.removeTeamFromProject(teamId:Long, projectId:Long)
+###
+# tags: [ Team ]
+# summary: Get teams granted a role on a project
+# description: Get teams granted an Admin, Write or Read role on a project
+# responses:
+#   '200':
+#     description: a list of teams
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.framework.model.Group'
+#   '401':
+#     description: The user is not authorized to make this request
+# parameters:
+#   - name: projectId
+#     in: path
+#     description: The id of the project for which teams are desired
+###
+GET      /teams/projectManagers/:projectId        @org.maproulette.framework.controller.TeamController.getTeamsManagingProject(projectId:Long)
+###
+# tags: [ Team ]
+# summary: Delete a team
+# description: Deletes a team with ID
+# responses:
+#   '200':
+#     description: A simple OK status message
+# parameters:
+#   - name: id
+#     in: path
+#     description: The ID for the team
+###
+DELETE /team/:id                                    @org.maproulette.framework.controller.TeamController.deleteTeam(id: Long)

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -460,13 +460,17 @@ PUT     /user/:userId/refresh                        @org.maproulette.framework.
 #   - name: osmIds
 #     in: query
 #     description: A list of comma separated OSM id's to filter the request by
+#   - name: includeTeams
+#     in: query
+#     description: If true, indirect managers via teams will also be included
+#     default: false
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
 #     required: true
 #     type: string
 ###
-GET     /user/project/:projectId                     @org.maproulette.framework.controller.UserController.getUsersManagingProject(projectId:Long, osmIds:String ?= "")
+GET     /user/project/:projectId                     @org.maproulette.framework.controller.UserController.getUsersManagingProject(projectId:Long, osmIds:String ?= "", includeTeams:Boolean ?= false)
 ###
 # tags: [ User ]
 # summary: Grant role to user on project

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -7386,7 +7386,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"Postman Team A\",\n  \"description\": \"A test team from Postman\"\n}",
+							"raw": "{\n  \"id\": -1,\n  \"name\": \"Postman Team A\",\n  \"description\": \"A test team from Postman\",\n  \"groupType\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -7425,6 +7425,16 @@
 								],
 								"type": "text/javascript"
 							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "8d31a476-f2b7-4de2-9229-e2876b3e555a",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
 					"request": {
@@ -7443,7 +7453,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"Team A\",\n  \"description\": \"A test team\"\n}",
+							"raw": "{\n  \"id\": {{TestTeam}},\n  \"name\": \"Team A\",\n  \"description\": \"A test team\",\n  \"groupType\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -7554,7 +7564,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"name\": \"Team B\",\n  \"description\": \"A second test team\"\n}",
+							"raw": "{\n  \"id\": -1,\n  \"name\": \"Team B\",\n  \"description\": \"A second test team\",\n  \"groupType\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b5a1f054-d2cb-4c96-9c99-666f6e50a055",
+		"_postman_id": "ad4df37d-381a-427f-ac9b-e4c78c6df93d",
 		"name": "maproulette2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -21,7 +21,8 @@
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
-								]
+								],
+								"id": "91402bfb-90a3-4ce8-89c2-1bceb796414f"
 							}
 						}
 					],
@@ -64,7 +65,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0a7e23c4-b5e4-4b5a-b23e-e96e3e28dfd4",
+								"id": "63b080cc-15cd-4173-a981-b9ef62a040db",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -115,7 +116,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a3b2cfd4-5af0-4476-bc4a-39824a0d29cd",
+								"id": "ee589d2c-dbdf-4805-abee-8205b48f6ebf",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID\", jsonData.id);",
@@ -167,7 +168,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "72e60338-d2f3-4730-bb66-6fe7f513d03d",
+								"id": "a2a47c4c-7a24-49c5-acaa-bed09e68ab26",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -220,7 +221,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "fd6c141f-63cd-4f25-9977-2fafd83463e0"
 							}
 						}
 					],
@@ -264,7 +266,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d62e91a2-16b7-4de4-958b-0b9d45522434",
+								"id": "36bab08d-d3f5-4b87-9421-6957596684e3",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -316,7 +318,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "48b4ba7a-b0a5-4cd0-9652-5ae00e0f48e5"
 							}
 						}
 					],
@@ -366,7 +369,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "03b0a82e-5f26-46f5-a28a-e3b1a7df8870",
+								"id": "25c86ebc-c966-4a1c-9581-752c713cb3ec",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TagsChallengeID\", jsonData.id);",
@@ -418,7 +421,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ca8ec3a0-289f-4357-bb08-fef178724e0c",
+								"id": "9e6c8905-7bc9-4663-9305-ec3930c64fb7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -466,7 +469,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "166ebb2c-eda3-4c07-9e30-71e275566ff5",
+								"id": "a87a47fa-fb03-4f73-b370-6511f9f81cc5",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -516,7 +519,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b4c85630-833a-4df4-b2d8-ad83f3ecb26e",
+								"id": "ee531176-37f1-4070-8f99-f51887ec5813",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -569,7 +572,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"id": "f792381c-6249-4021-ad96-1b89c2726f1a",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -617,7 +620,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5d92aa7b-b9d9-420a-a54b-789a87c04175",
+								"id": "9a4d12ca-5550-40ba-962b-f70932c87194",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -665,7 +668,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b35c2674-41a0-4dea-b9e5-a46478edd678",
+								"id": "d1297631-00af-441f-870a-39f717aa4300",
 								"exec": [
 									"tests[\"response code is 201\"] = responseCode.code === 201;"
 								],
@@ -722,7 +725,8 @@
 									"tests[\"Task2\"] = jsonData[1].name === \"Task 2\";",
 									"tests[\"Task3\"] = jsonData[2].name === \"Task 3\";",
 									"tests[\"Task4\"] = jsonData[3].name === \"Task 4\";"
-								]
+								],
+								"id": "d37c5e20-d514-4833-a156-4e3757605eac"
 							}
 						}
 					],
@@ -763,7 +767,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"id": "6413f12a-8428-456d-85cb-c4101a1fc4d7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -821,7 +825,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "14d21a79-8d51-42ce-bfe5-db9291011373",
+								"id": "16176eb7-6bc8-4ab1-8fb0-0e5983d93d20",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -872,7 +876,8 @@
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 204\"] = responseCode.code === 204;"
-								]
+								],
+								"id": "e1961b01-b33c-47ac-a0e5-26a450b9cecd"
 							}
 						}
 					],
@@ -928,7 +933,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"tag1\"] = jsonData[0].name === \"tag2\""
-								]
+								],
+								"id": "a486d5d4-312c-44ce-9d8d-3d7760e16df6"
 							}
 						}
 					],
@@ -969,7 +975,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2f25f505-b0af-458e-aab2-9e1a6715f8a6",
+								"id": "38e7ecc7-bba5-4cbb-8179-f06b2b24082d",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1026,7 +1032,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "f8d31ec9-9162-48ae-940c-6a3624854414"
 							}
 						}
 					],
@@ -1076,7 +1083,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e3afdd8b-3294-4a9a-ad99-11f3aac23b43",
+								"id": "a368c67f-35b3-4c20-a212-351d15e8879f",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TagsTaskChallengeID\", jsonData.id);",
@@ -1127,7 +1134,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4a0d54a1-ab03-4b28-b86d-1f914e34f9d9",
+								"id": "3de93d4c-42db-4022-8c3d-e5c9082b273e",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1186,7 +1193,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fd8068af-6b11-4765-9798-9ca0e0e8acfa",
+								"id": "d8888348-ced8-420a-b5ea-252a615e2af6",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1247,7 +1254,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "aa3691b5-126a-4b98-a2af-c9666813a275"
 							}
 						}
 					],
@@ -1302,7 +1310,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "2f27030d-f8ef-477b-a238-8e688c82dc92"
 							}
 						}
 					],
@@ -1365,7 +1374,8 @@
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"TestProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project.\";"
-								]
+								],
+								"id": "a935e575-4ec1-4f14-a721-eb1bab08a5c0"
 							}
 						}
 					],
@@ -1408,7 +1418,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "efbb42af-bda5-4229-bf7d-49e8e5d44038",
+								"id": "e33ececa-35da-4c12-bbb1-c4ac94474b04",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestChallenge\", jsonData.id);",
@@ -1460,7 +1470,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"id": "4407d6e1-a000-4f1f-94af-f9f749a4f36d",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1526,7 +1536,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"id": "aa1b149a-4037-4785-bf37-fb52ed9710f5",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1596,7 +1606,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ccbb60bf-2a2d-45b7-8ee1-e472b52afce2",
+								"id": "83c2db92-adc2-4c7e-8a1c-575ec74bb8b9",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
@@ -1645,7 +1655,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "34086a73-0c30-41d9-9f3c-308e35e15579",
+								"id": "d58f571a-1306-47bf-8a94-0d27a9b2681a",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
@@ -1698,7 +1708,8 @@
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"NewTask\";",
 									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction\";"
-								]
+								],
+								"id": "940404d8-bc0c-4aed-902b-269c163b7a2f"
 							}
 						}
 					],
@@ -1747,7 +1758,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"name\"] = jsonData.name === \"NewTask\";",
 									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction\";"
-								]
+								],
+								"id": "6ac6e999-3eeb-40db-8e44-a13c5bd7226f"
 							}
 						}
 					],
@@ -1787,7 +1799,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "642f4f2a-e761-49f0-afa7-1c7121667ac8",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1838,7 +1850,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "7801f920-9616-4b17-a1b4-faf4ddcd91be",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1889,7 +1901,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "4396ea78-ffad-48a2-999e-c9f380d9409e",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1940,7 +1952,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "9937f629-a306-4ff6-b2f2-8664a3fa8de0",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1990,7 +2002,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "695dbdc2-abd1-4ca1-ba4d-11d81fdc7fe0",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2042,7 +2054,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e7c6af8f-c978-41d6-adb2-6853cfcbb476",
+								"id": "7238c80b-a144-432e-ae0f-71bf9ac6a1f4",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2090,7 +2102,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "4ae78bb2-f989-4f67-8603-23322dda5711",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2142,7 +2154,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e7c6af8f-c978-41d6-adb2-6853cfcbb476",
+								"id": "565cafa2-4e66-41da-8ccd-8d492a330082",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2196,7 +2208,8 @@
 									"postman.setGlobalVariable(\"NewComment\", jsonData.id);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"comment\"] = jsonData.comment === \"This is a comment\";"
-								]
+								],
+								"id": "b6e65307-a396-4728-a5b2-1244426ec787"
 							}
 						}
 					],
@@ -2248,7 +2261,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"comment\"] = jsonData.comment === \"This is an updated comment\";"
-								]
+								],
+								"id": "a667d612-f78d-4203-979b-63b80e2c0ef7"
 							}
 						}
 					],
@@ -2299,7 +2313,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"comment\"] = jsonData.comment === \"This is a comment Number2\";"
-								]
+								],
+								"id": "f3ce376b-4f56-471b-b722-1da38c87ffe4"
 							}
 						}
 					],
@@ -2351,7 +2366,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"comment\"] = jsonData.comment === \"This is an updated comment\";"
-								]
+								],
+								"id": "952405d9-1b6a-4c3e-9d99-c63b4f857723"
 							}
 						}
 					],
@@ -2392,7 +2408,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"Comment1\"] = jsonData.length == 2;"
-								]
+								],
+								"id": "a0ffd490-d867-47b9-abdc-7af041d3f482"
 							}
 						}
 					],
@@ -2432,7 +2449,8 @@
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
-								]
+								],
+								"id": "5a2cc98a-3ff0-4a79-a491-fbbe1e8ea97f"
 							}
 						}
 					],
@@ -2474,7 +2492,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "691bf11c-998d-49fb-98a4-e66bcbefc1d2",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2525,7 +2543,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "705b2416-7628-4ad0-acbf-81bf9c0c477b",
+								"id": "83fc9796-a7c3-445b-9381-31818c630f33",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewTask1\", jsonData.id);",
@@ -2576,7 +2594,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "accfcc10-4c9d-432b-9798-e893f2cfd930",
+								"id": "f2a940c4-4744-41ac-870d-5a7ef5460d10",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -2635,7 +2653,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "accfcc10-4c9d-432b-9798-e893f2cfd930",
+								"id": "f3cfee53-e6a1-4bb0-94b8-73ef00046e8d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -2692,7 +2710,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "accfcc10-4c9d-432b-9798-e893f2cfd930",
+								"id": "bb6cd25e-11e6-4c0a-9c53-10d19aa24a93",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -2747,7 +2765,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "808e381a-4d4d-4359-8267-5ed1c117697c"
 							}
 						}
 					],
@@ -2803,7 +2822,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "061180ba-93d9-4165-8ea2-d5b5ce27f475",
+								"id": "1e34051e-e435-4532-8003-ee6e695c2c33",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -2854,7 +2873,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "31fa6818-074e-4220-b1fa-819310da0d7d",
+								"id": "6e96efe2-e230-487b-b836-22592c8e976a",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"pm.globals.set(\"TagsChallengeID\", jsonData.id);",
@@ -2906,7 +2925,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8cbfa022-0bb4-482a-a390-99a4adabdf44",
+								"id": "18bbdcb1-7a9a-4412-b197-af40c4584623",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2960,7 +2979,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"Task1\"] = jsonData[0].name === \"Task 1\";",
 									"tests[\"Task2\"] = jsonData[1].name === \"Task 2\";"
-								]
+								],
+								"id": "641cc801-a21f-4528-9e9a-97e49bcea06a"
 							}
 						}
 					],
@@ -3001,7 +3021,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "debcb03c-61d4-41ac-b44c-c4c004a4ef17",
+								"id": "4154cd21-071d-427d-9c47-8979123b2bac",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3050,7 +3070,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5e033501-5ba7-41b4-be01-a381af19764a",
+								"id": "7421fb08-b05d-48a9-bdc9-d29fbb001082",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3091,7 +3111,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5e033501-5ba7-41b4-be01-a381af19764a",
+								"id": "c24ad7b0-02d9-44a1-85b6-b14324685c85",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3132,7 +3152,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "15d75894-c8c7-4b94-aa40-df2dc493dee9",
+								"id": "6d968fe4-0ac1-42f4-b600-4b2762d0ef77",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3181,7 +3201,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1a6e7819-860d-4a17-b2b8-6362f5ccda8f",
+								"id": "6d574247-d164-4cc1-9032-e9833c229693",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3221,7 +3241,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "905e5406-7776-4bcf-a8cb-27617a05c142",
+								"id": "b1660d5c-3f3f-42dd-87f0-fb9a0bd9b98d",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3265,7 +3285,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "252d9d44-2975-4a1f-9d54-bc8a57e7b769",
+								"id": "db4166ec-36ae-428e-93f9-4fe0b6bd123a",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3306,7 +3326,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ba4b7365-f1e5-4e96-805c-469fc29537eb",
+								"id": "5307142c-c1d7-4dce-8481-6c572f9de83a",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3354,7 +3374,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8741daf9-46d3-4e42-aa20-f29ed39caa34",
+								"id": "03ab8700-0034-4090-af1c-a76a2dc37e6e",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3402,7 +3422,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "040adc26-6e95-4944-b364-3aab59535897",
+								"id": "49ea50d8-87a3-40b9-9495-5418d3eee16b",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3457,7 +3477,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9d2536b9-3357-4448-b6d6-cf827a945ba6",
+								"id": "1e6dc696-ffe9-4e48-8f8b-53a2e9a76cfe",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3498,7 +3518,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "edf43e3b-fae6-4701-a734-f1e516779056",
+								"id": "b5107b45-62c5-4a3d-9af2-2bd7b1047559",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3539,7 +3559,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a423abbb-b93e-478a-80d4-e0d2b09d5875",
+								"id": "070538a3-905b-4a0a-b81d-7b04b2aaaed8",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3580,7 +3600,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "266672e7-9dab-437f-a9c8-96131099737d",
+								"id": "6a764726-7d03-4fda-a22d-123978f2daef",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3629,7 +3649,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "608ddc0f-ebb0-436f-940e-4165b0c6061a",
+								"id": "d9831868-619a-4e8e-8b09-147fa278f0c9",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3671,7 +3691,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a423abbb-b93e-478a-80d4-e0d2b09d5875",
+								"id": "d8b39d4c-f7f3-40c3-a4b0-62dabd921da8",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3712,7 +3732,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "66484512-de78-42a6-9a03-ab5d7049c9d7",
+								"id": "6da65ec0-e442-435d-af54-d4132581c4b8",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"pm.globals.set(\"VirtualChallengeID\", jsonData.id);",
@@ -3761,7 +3781,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9e2d657d-efa4-4dfc-800b-d094be10e9d6",
+								"id": "50254e1a-4b78-4d30-895b-a26412a47a23",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 404\"] = responseCode.code === 404;"
@@ -3800,7 +3820,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "debcb03c-61d4-41ac-b44c-c4c004a4ef17",
+								"id": "e1c8fa95-ba3c-4180-83de-d8d1965f2477",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"pm.globals.set(\"VirtualChallengeID\", jsonData.id);",
@@ -3854,7 +3874,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "2a63565a-d377-47ab-b7f4-44b3746beab0"
 							}
 						}
 					],
@@ -3950,7 +3971,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8b33660-98cc-40fd-88a5-6a51bf8e541d",
+								"id": "97877fd4-aeb4-4184-9f29-4e1b374293ca",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleProjectID\", jsonData.id);",
@@ -4002,7 +4023,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "11236b80-b37f-4355-b115-93751d636d58",
+								"id": "451db45c-11d7-40a3-853d-3472e01eb242",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"ProjectWithChildren\", jsonData.id);",
@@ -4053,7 +4074,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b5f3e831-15b3-4f7a-9567-681f1b3c9d14",
+								"id": "0a61715b-3b02-4a58-a555-f2f4db3c1880",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
@@ -4100,7 +4121,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "816f826b-eb7c-4507-a2f6-31d4f28754f5",
+								"id": "36ad61b5-7272-48c2-95a5-ab5d6c4f7a62",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4147,7 +4168,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0d97b997-2614-4dfe-82f6-c3c2a4250543",
+								"id": "f8ea328a-ae06-4122-9043-4aed8edc0d72",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4197,7 +4218,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e3d0d192-40e6-4ad5-a503-6ef0e9b6de99",
+								"id": "32b25a57-9685-4c5c-b44a-7840dc8d51b6",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4254,7 +4275,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e43e965b-1635-47c2-a3f6-a2026cbb04a6",
+								"id": "0db2ed1c-2af4-414f-a459-59e9e8e7309c",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);"
@@ -4315,7 +4336,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "effdc13e-b508-416b-bb50-51b0d418ac57"
 							}
 						}
 					],
@@ -4371,7 +4393,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing. (Update)\";"
-								]
+								],
+								"id": "aca650b3-5361-4bbe-929d-371b1ce36471"
 							}
 						}
 					],
@@ -4421,7 +4444,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing. (Update)\";"
-								]
+								],
+								"id": "aaf99918-57d2-4791-9244-90abf3727010"
 							}
 						}
 					],
@@ -4461,7 +4485,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a7fc6ab9-3263-4b97-b4f4-d74a108fcbf8",
+								"id": "73ce2528-d794-48e8-8fcc-1429455ef8d8",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4518,7 +4542,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Body matches name\"] = responseBody.has(\"SimpleProject\");",
 									"tests[\"Body matches description\"] = responseBody.has(\"Test project containing all children used for api testing. (Update)\");"
-								]
+								],
+								"id": "36598199-817d-4c1e-ba91-7c6ab85ae513"
 							}
 						}
 					],
@@ -4570,7 +4595,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing. (Update)\";"
-								]
+								],
+								"id": "c455f75e-d189-43b1-9df7-fd005815f633"
 							}
 						}
 					],
@@ -4615,7 +4641,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "26884f54-9cfc-48b7-9a40-a77bdac74249"
 							}
 						}
 					],
@@ -4671,7 +4698,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8b33660-98cc-40fd-88a5-6a51bf8e541d",
+								"id": "5427b51b-4a65-45bc-a24f-6374cd1a0b11",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"VPProjectID\", jsonData.id);",
@@ -4723,7 +4750,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e2e239b5-f0bb-4db2-9ff5-c35dcad3ac9a",
+								"id": "1930a215-f4a6-4c16-86e6-b083401f3348",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleProjectID1\", jsonData.id);",
@@ -4774,7 +4801,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8c9d2e3d-d15e-404e-b481-401d3784fa86",
+								"id": "4de88fdc-dcab-4e94-8887-2fd2b0d48ecf",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID1\", jsonData.id);",
@@ -4826,7 +4853,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6b0b445c-c19d-4118-be3c-df9246996105",
+								"id": "bc33979e-545d-4c7d-b038-526e0365a5de",
 								"exec": [
 									"tests[\"response code is 201\"] = responseCode.code === 200;",
 									""
@@ -4878,7 +4905,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b990bc5d-5b6a-4f0b-ab1f-73ed847db742",
+								"id": "f30cdc6a-69ba-46fe-afe5-e3719f5b94d6",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"Body matches name\"] = responseBody.has(\"VPProject\");",
@@ -4929,7 +4956,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"id": "e3f3de11-93f2-4a5e-bfbd-6ae5da05a3b6",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4976,7 +5003,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6bc048ac-0af1-4d72-9b76-18cb706e8cda",
+								"id": "d4d0730d-d7a3-49df-956a-3c30713f2fb5",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5023,7 +5050,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"id": "934f3572-47f3-4388-ab89-573ced1e8560",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
@@ -5139,7 +5166,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"id": "b03fec4b-1be8-4cfd-9d38-522981fb648d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5191,7 +5218,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"id": "0482c1f8-233b-44fb-8b13-94a4c7ac8336",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5243,7 +5270,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"id": "149000e3-5b58-422a-87bf-b8f3f3d6781d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5295,7 +5322,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5764c1b4-b2f2-410b-9bf1-fca395d7b00a",
+								"id": "54080ce4-c6d5-43d7-91c9-9129635bb24f",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"pm.test(\"Body is correct\", function () {",
@@ -5349,7 +5376,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bb86b48d-e330-49e5-a4da-d098b2136260",
+								"id": "46ba3c45-96c6-4613-9d2f-56609e695c24",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5401,7 +5428,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ded06c13-b45a-4536-9b8c-08232a15a1ca",
+								"id": "16d94f61-78a9-483b-9cb5-cc766aa9331d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5448,7 +5475,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1257b0e9-25a3-4843-a7c2-1e366be2cf94",
+								"id": "9dcfe978-1c04-47ac-b3b6-69f4400e3c42",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5504,7 +5531,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9dd6dd4b-9180-42aa-9d47-50b8eccc0771",
+								"id": "7b38bd9b-2813-42c8-a0af-e98fa37931c4",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5566,7 +5593,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1d386575-6c95-4065-a746-3f39e5a793d0",
+								"id": "47494748-dd3a-4862-822b-921bb5d70b17",
 								"exec": [
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5623,7 +5650,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"name\"] = jsonData.name === \"testtag1\";",
 									"tests[\"description\"] = jsonData.description === \"TestTag1 description\";"
-								]
+								],
+								"id": "17f215c4-e727-46f3-9d8a-d29f4b626671"
 							}
 						}
 					],
@@ -5669,7 +5697,8 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"name\"] = jsonData.name === \"updatedtesttag1\";",
 									"tests[\"description\"] = jsonData.description === \"Updated Tag description\";"
-								]
+								],
+								"id": "f5947def-bfb1-4508-a83c-c7532bf18e1d"
 							}
 						}
 					],
@@ -5718,7 +5747,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "90ce181b-c571-484a-ad57-0627655f90df"
 							}
 						}
 					],
@@ -5768,7 +5798,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2740d979-7705-40db-a5af-a07618e427c0",
+								"id": "7cfc2eb4-0600-49b5-ad93-1f8edb5cdf2c",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -5821,7 +5851,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a015f41e-3b14-4edf-a905-1af643a30a9e",
+								"id": "470aaca6-13ae-4cdb-9ff0-1148557d13e7",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -5873,7 +5903,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e2a68b5c-c408-4710-b9a8-ced1dfcf0396",
+								"id": "c2a8a4d6-c117-4b65-bff1-386cffe90f1a",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {",
 									"    pm.expect(pm.response.code).to.be.oneOf([200]);",
@@ -5952,7 +5982,8 @@
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
-								]
+								],
+								"id": "3d0b076c-12ef-422f-b161-7d335096e56f"
 							}
 						}
 					],
@@ -5995,7 +6026,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "04cdcb8b-ce2e-4a7c-80e6-a1b63c00fb38",
+								"id": "f2d969fb-dcb1-4c15-8489-0087278bd0e8",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID\", jsonData.id);",
@@ -6046,7 +6077,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "04cdcb8b-ce2e-4a7c-80e6-a1b63c00fb38",
+								"id": "9e115ac1-2e4b-4c64-b688-5463c11353c3",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID1\", jsonData.id);",
@@ -6097,7 +6128,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "166ebb2c-eda3-4c07-9e30-71e275566ff5",
+								"id": "3f649f1f-1c21-4ccf-b388-ffd2e962e160",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SFTagID\", jsonData[0].id);",
@@ -6146,7 +6177,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e2a68b5c-c408-4710-b9a8-ced1dfcf0396",
+								"id": "af83fab6-02e9-4222-b2bc-193db517fd26",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {",
 									"    pm.expect(pm.response.code).to.be.oneOf([200]);",
@@ -6222,7 +6253,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "166ebb2c-eda3-4c07-9e30-71e275566ff5",
+								"id": "7c9a2b40-b77b-4b92-a966-3954c6bc4780",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6269,7 +6300,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "166ebb2c-eda3-4c07-9e30-71e275566ff5",
+								"id": "121cf944-e776-481d-bdff-42802e0554d0",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6322,7 +6353,8 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
-								]
+								],
+								"id": "70d7616e-50a1-42b5-9531-bb1d8fda9299"
 							}
 						}
 					],
@@ -6378,7 +6410,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b66704e2-4a0d-469b-b3ea-b8178853b754",
+								"id": "47f5f5ff-3b26-4ebd-8a14-241535cca70e",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestBundleProject\", jsonData.id);",
@@ -6428,7 +6460,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c38e2230-0f76-4588-80f6-6cc7772d1ff4",
+								"id": "9d3fc629-230f-40b5-9dfb-ddb033ae75c3",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestBundleChallenge\", jsonData.id);",
@@ -6479,7 +6511,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "95f07c63-a41d-410d-ad61-2617d001c8fb",
+								"id": "f9017f03-b2aa-4092-b691-6739d03be089",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewTask1\", jsonData.id);",
@@ -6529,7 +6561,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ecdd7063-cdcc-4607-bcae-a32874ce4b04",
+								"id": "dd28ce19-5e0a-465c-ae28-fb14ba0c5da2",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewTask2\", jsonData.id);",
@@ -6579,7 +6611,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "705b2416-7628-4ad0-acbf-81bf9c0c477b",
+								"id": "c503971b-d5c0-495a-a7e7-4ce5772aee14",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewBundle\", jsonData.bundleId);",
@@ -6628,7 +6660,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d0bacf4b-7616-4d8a-ae40-205f8ee5d7c1",
+								"id": "b4bc006a-9be9-42d7-9ab4-83912157daa6",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewComment\", jsonData.id);",
@@ -6680,7 +6712,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "ec9f2350-a9a4-4dc9-8062-16a6f5afa919",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6744,7 +6776,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"id": "b4c7c947-8c15-4204-9c0f-fffa2b8ab5d7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6791,7 +6823,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "705b2416-7628-4ad0-acbf-81bf9c0c477b",
+								"id": "4f05a514-b16d-45fa-822b-c55829e9920c",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 400\"] = responseCode.code === 400;",
@@ -6839,7 +6871,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "07168541-6076-47fc-811d-9371cc053198",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 400\"] = responseCode.code === 400;",
@@ -6899,7 +6931,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"id": "e6fe15b3-2500-4e23-9ae4-b8554bbd9faa",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6948,7 +6980,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"id": "798e6be4-10ca-44ea-9c78-e4d3f6b3881f",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6996,7 +7028,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "ab515355-a44e-4635-a207-e0a4bb2a8c0b",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7057,7 +7089,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f34aeb15-22d1-4a6c-a562-0e816d81de82",
+								"id": "8d39c503-392f-48ff-bda0-6d237c2024e8",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7105,7 +7137,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3bb07589-1294-4a38-8299-caa0e8cfa152",
+								"id": "521f11bf-d30a-4c72-b6e0-5dd92248773d",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7151,7 +7183,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f56731b-4f82-4f20-acc5-6d0878a787ee",
+								"id": "4dea42dc-cbe3-460f-8326-e7aae331cece",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7211,7 +7243,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5b81c410-0935-4d7b-89fc-f6bba888a7e4",
+								"id": "1b614931-79ef-42af-83f4-0fb91da0f94a",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -7265,7 +7297,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5b81c410-0935-4d7b-89fc-f6bba888a7e4",
+								"id": "f4bdd240-f9d3-43c4-941e-7b842bdbde07",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -7311,6 +7343,840 @@
 								}
 							]
 						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "teams",
+			"item": [
+				{
+					"name": "Create Team A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e4e643e4-2258-4084-8bf6-813971a49ea1",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"TestTeam\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"tests[\"name\"] = jsonData.name === \"Postman Team A\";",
+									"tests[\"description\"] = jsonData.description === \"A test team from Postman\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test",
+								"type": "text"
+							},
+							{
+								"key": "contentType",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Postman Team A\",\n  \"description\": \"A test team from Postman\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team"
+							]
+						},
+						"description": "Creates a new Team"
+					},
+					"response": []
+				},
+				{
+					"name": "Update Team A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4ee288e1-bd50-4c96-a158-6f99275261ff",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"name\"] = jsonData.name === \"Team A\";",
+									"tests[\"description\"] = jsonData.description === \"A test team\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Team A\",\n  \"description\": \"A test team\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeam}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeam}}"
+							]
+						},
+						"description": "Updates team fields"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Team Members",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "943315ba-2520-477c-acaa-075edd3d06ac",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"one result\"] = jsonData.length === 1",
+									"tests[\"result should be SuperUser\"] = jsonData[0].name === \"SuperUser\"",
+									"tests[\"result should be on team\"] = jsonData[0].teamId === parseInt(pm.variables.get(\"TestTeam\"))",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeam}}/userMembers",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeam}}",
+								"userMembers"
+							]
+						},
+						"description": "Get members of team"
+					},
+					"response": []
+				},
+				{
+					"name": "Create Team B",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2089f4fc-1adb-437d-b149-a30501b03955",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									"postman.setGlobalVariable(\"TestTeamB\", jsonData.id);",
+									"tests[\"name\"] = jsonData.name === \"Team B\";",
+									"tests[\"description\"] = jsonData.description === \"A second test team\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"Team B\",\n  \"description\": \"A second test team\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team"
+							]
+						},
+						"description": "Creates another new team"
+					},
+					"response": []
+				},
+				{
+					"name": "Search Teams",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "1f80f7ec-08a5-42e7-98c8-fdb6b2573164",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"one result\"] = jsonData.length === 1",
+									"tests[\"result should be Team A\"] = jsonData[0].name === \"Team A\"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/teams/find?name=Team A",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"teams",
+								"find"
+							],
+							"query": [
+								{
+									"key": "name",
+									"value": "Team A"
+								}
+							]
+						},
+						"description": "Search teams"
+					},
+					"response": []
+				},
+				{
+					"name": "Create Test Project for Teams",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "3fbd4c7a-5441-42e7-b414-9b8081b5c145",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setGlobalVariable(\"TeamProject\", jsonData.id);",
+									"tests[\"response code is 201\"] = responseCode.code === 201;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"TeamProject\",\n    \"description\":\"Test project for team testing\",\n    \"enabled\":true\n}"
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project"
+							]
+						},
+						"description": "Creates a test project for team testing"
+					},
+					"response": []
+				},
+				{
+					"name": "Add Team A to Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "dd2870bf-d1c5-4d98-ba30-e03c6c93ae61",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeam}}/project/{{TeamProject}}/1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeam}}",
+								"project",
+								"{{TeamProject}}",
+								"1"
+							]
+						},
+						"description": "Add team A to Teams project"
+					},
+					"response": []
+				},
+				{
+					"name": "Verify Team Grant on Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "fc10db08-9dd7-4e8c-b280-ed9f9be6c0d1",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"project has team grant\"] = !!_.find(",
+									"    jsonData.grants,",
+									"    g => g.role === 1 && g.grantee.granteeType === 6 && g.grantee.granteeId === parseInt(pm.variables.get(\"TestTeam\"))",
+									")"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{TeamProject}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{TeamProject}}"
+							]
+						},
+						"description": "Get the Teams project and check the grants"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Teams Managing Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ed5bb7d4-b60d-42c3-9d6c-13fd0d678f7a",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"tests[\"one result\"] = jsonData.length === 1",
+									"tests[\"is Team A\"] = jsonData[0].team.name === \"Team A\"",
+									"tests[\"has grant on project\"] = jsonData[0].grants[0].target.objectId === parseInt(pm.variables.get(\"TeamProject\"))",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/teams/projectManagers/{{TeamProject}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"teams",
+								"projectManagers",
+								"{{TeamProject}}"
+							]
+						},
+						"description": "Get teams managing project"
+					},
+					"response": []
+				},
+				{
+					"name": "Set Team A role on Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "568a5345-2d51-437d-8592-a8c44de8274c",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeam}}/project/{{TeamProject}}/2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeam}}",
+								"project",
+								"{{TeamProject}}",
+								"2"
+							]
+						},
+						"description": "Set role of Team A on project"
+					},
+					"response": []
+				},
+				{
+					"name": "Verify updated Team Grant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ec041704-b87e-4c0a-8bc0-f3d4ea99661e",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"project has team grant\"] = !!_.find(",
+									"    jsonData.grants,",
+									"    g => g.role === 2 && g.grantee.granteeType === 6 && g.grantee.granteeId === parseInt(pm.variables.get(\"TestTeam\"))",
+									")"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{TeamProject}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{TeamProject}}"
+							]
+						},
+						"description": "Get the Teams project and check the grants for updated role"
+					},
+					"response": []
+				},
+				{
+					"name": "Remove Team A from Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a31fcbf1-ecc7-4d1b-87fb-52b068e17f44",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeam}}/project/{{TeamProject}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeam}}",
+								"project",
+								"{{TeamProject}}"
+							]
+						},
+						"description": "Remove team A from Teams project"
+					},
+					"response": []
+				},
+				{
+					"name": "Verify team grant removed",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "94be57f6-9558-4702-a4e0-5a4d4a8dbd1b",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"project has no team grants\"] = !_.find(",
+									"    jsonData.grants,",
+									"    g => g.grantee.granteeType === 6 && g.grantee.granteeId === parseInt(pm.variables.get(\"TestTeam\"))",
+									")"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{TeamProject}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{TeamProject}}"
+							]
+						},
+						"description": "Get the Teams project and verify that grants to team A no longer exist"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Team A",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "89992f3b-a679-4c06-a9f2-c21653efcbf3",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeam}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeam}}"
+							]
+						},
+						"description": "Deletes team A"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Team B",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7f87a38d-d07c-47fa-9db4-37d961a23acb",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"type": "text",
+								"value": "test"
+							},
+							{
+								"key": "contentType",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:9000/api/v2/team/{{TestTeamB}}",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"team",
+								"{{TestTeamB}}"
+							]
+						},
+						"description": "Deletes team B"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Teams Project",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "0a4aa237-d17a-4924-a22f-c760ce75af88",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"Status\"] = jsonData.status === \"OK\";"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/project/{{TeamProject}}?immediate=true",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"project",
+								"{{TeamProject}}"
+							],
+							"query": [
+								{
+									"key": "immediate",
+									"value": "true"
+								}
+							]
+						},
+						"description": "Deletes the project for teams testing"
 					},
 					"response": []
 				}

--- a/test/org/maproulette/framework/FrameworkMasterSuite.scala
+++ b/test/org/maproulette/framework/FrameworkMasterSuite.scala
@@ -15,6 +15,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite, Suites, Tag}
   */
 class FrameworkMasterSuite extends Suites with BeforeAndAfterAll with TestDatabase {
   private val suites = IndexedSeq(
+    new TeamServiceSpec,
     new ChallengeServiceSpec,
     new ChallengeRepositorySpec,
     new ChallengeListingServiceSpec,
@@ -35,6 +36,9 @@ class FrameworkMasterSuite extends Suites with BeforeAndAfterAll with TestDataba
     new UserSavedObjectsRepositorySpec,
     new UserServiceSpec,
     new UserRepositorySpec,
+    new GroupServiceSpec,
+    new GroupRepositorySpec,
+    new GroupMemberRepositorySpec,
     new VirtualProjectServiceSpec,
     new VirtualProjectRepositorySpec
   )

--- a/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
@@ -25,6 +25,14 @@ class FilterOperatorSpec extends PlaySpec {
       Operator.format(KEY, parameterKey, Operator.EQ, true) mustEqual s"NOT $KEY = {$parameterKey}"
     }
 
+    "format NE operator correctly" in {
+      Operator.format(KEY, parameterKey, Operator.NE) mustEqual s"$KEY <> {$parameterKey}"
+    }
+
+    "format NOT NE operator correctly" in {
+      Operator.format(KEY, parameterKey, Operator.NE, true) mustEqual s"NOT $KEY <> {$parameterKey}"
+    }
+
     "format GT operator correctly" in {
       Operator.format(KEY, parameterKey, Operator.GT) mustEqual s"$KEY > {$parameterKey}"
     }

--- a/test/org/maproulette/framework/psql/QuerySpec.scala
+++ b/test/org/maproulette/framework/psql/QuerySpec.scala
@@ -160,4 +160,24 @@ class QuerySpec extends PlaySpec {
       .simple(List(parameter), "SELECT * FROM projects")
       .sqlWithBaseQuery("SELECT * FROM challenges") mustEqual s"SELECT * FROM projects WHERE $KEY = {$setKey}"
   }
+
+  "allows filter groups to be added" in {
+    val parameter2     = BaseParameter("key2", "value2")
+    val query          = Query.simple(List(parameter))
+    val augmentedQuery = query.addFilterGroup(FilterGroup(List(parameter2)))
+
+    // Original query remains untouched
+    query.parameters().size mustEqual 1
+
+    // Augmented query gets additional parameters
+    val params = augmentedQuery.parameters()
+    params.size mustEqual 2
+    params.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, "value2")
+    params(1) mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
+  }
+
+  "supports creation of empty query" in {
+    val query = Query.empty
+    query.parameters().size mustEqual 0
+  }
 }

--- a/test/org/maproulette/framework/repository/GroupMemberRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/GroupMemberRepositorySpec.scala
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework
+
+import org.maproulette.framework.model.{Group, GroupMember, MemberObject, User}
+import org.maproulette.data.{UserType, GroupType}
+import org.maproulette.framework.psql.Query
+import org.maproulette.framework.psql.filter.BaseParameter
+import org.maproulette.framework.repository.{GroupRepository, GroupMemberRepository}
+import org.maproulette.framework.service.GroupService
+import org.maproulette.framework.util.{FrameworkHelper, GroupTag}
+import play.api.Application
+
+/**
+  * @author nrotstan
+  */
+class GroupMemberRepositorySpec(implicit val application: Application) extends FrameworkHelper {
+  val repository: GroupMemberRepository =
+    this.application.injector.instanceOf(classOf[GroupMemberRepository])
+  val groupService: GroupService = this.serviceManager.group
+
+  var defaultGroup: Group = null
+  var randomUser: User    = null
+
+  "GroupMemberRepository" should {
+    "perform a basic query" taggedAs (GroupTag) in {
+      val groupMembers =
+        this.repository
+          .query(
+            Query.simple(List(BaseParameter(GroupMember.FIELD_GROUP_ID, this.defaultGroup.id)))
+          )
+
+      groupMembers.size mustEqual 1
+      groupMembers.head.groupId mustEqual this.defaultGroup.id
+      groupMembers.head.memberType mustEqual UserType().typeId
+      groupMembers.head.memberId mustEqual this.defaultUser.id
+    }
+
+    "add a group member" taggedAs GroupTag in {
+      val anotherGroup =
+        this.groupService
+          .create(this.getTestGroup("GroupMemberRepositorySpec_AddGroupMemberTest Group"))
+          .get
+
+      val createdGroupMember = this.repository
+        .addGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+
+      createdGroupMember.get.groupId mustEqual anotherGroup.id
+      createdGroupMember.get.memberType mustEqual UserType().typeId
+      createdGroupMember.get.memberId mustEqual this.randomUser.id
+      createdGroupMember.get.status mustEqual GroupMember.STATUS_MEMBER
+
+      val retrievedGroupMember = this.repository
+        .query(
+          Query.simple(
+            List(
+              BaseParameter(GroupMember.FIELD_GROUP_ID, anotherGroup.id),
+              BaseParameter(GroupMember.FIELD_MEMBER_TYPE, UserType().typeId),
+              BaseParameter(GroupMember.FIELD_MEMBER_ID, this.randomUser.id)
+            )
+          )
+        )
+        .head
+
+      retrievedGroupMember.groupId mustEqual anotherGroup.id
+      retrievedGroupMember.memberType mustEqual UserType().typeId
+      retrievedGroupMember.memberId mustEqual this.randomUser.id
+    }
+
+    "update only status on a group member" taggedAs GroupTag in {
+      val anotherGroup =
+        this.groupService
+          .create(this.getTestGroup("GroupMemberRepositorySpec_UpdateGroupMemberTest Group"))
+          .get
+
+      val createdGroupMember = this.repository
+        .addGroupMember(anotherGroup, MemberObject.user(this.randomUser.id), 1)
+
+      createdGroupMember.get.status mustEqual 1
+      val updatedGroupMember = this.repository
+        .updateGroupMember(createdGroupMember.get.copy(status = 2, memberType = GroupType().typeId))
+
+      // Only status should have changed
+      updatedGroupMember.get.status mustEqual 2
+      updatedGroupMember.get.memberType mustEqual UserType().typeId
+      updatedGroupMember.get.memberId mustEqual this.randomUser.id
+      updatedGroupMember.get.groupId mustEqual anotherGroup.id
+    }
+
+    "retrieve members on a group" taggedAs GroupTag in {
+      val createdGroupMember = this.repository
+        .addGroupMember(this.defaultGroup, MemberObject.user(this.randomUser.id))
+
+      val members = this.repository.getGroupMembers(this.defaultGroup)
+      members.size mustEqual 2
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(members.head.memberId)
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(members(1).memberId)
+    }
+
+    "retrieve all group memberships for a member" taggedAs GroupTag in {
+      val anotherUser = this.serviceManager.user.create(
+        this.getTestUser(99913597, "RetrieveMembershipsOUser"),
+        User.superUser
+      )
+      val anotherGroup =
+        this.serviceManager.group
+          .create(this.getTestGroup("GroupMemberRepositorySpec_RetrieveMembershipsTest Group"))
+          .get
+
+      this.repository.addGroupMember(this.defaultGroup, MemberObject.user(anotherUser.id))
+      this.repository.addGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+
+      val memberships = this.repository.getMemberships(MemberObject.user(anotherUser.id))
+      memberships.size mustEqual 2
+
+      memberships.head.memberType mustEqual UserType().typeId
+      memberships.head.memberId mustEqual anotherUser.id
+      Seq(this.defaultGroup.id, anotherGroup.id) must contain(memberships.head.groupId)
+
+      memberships(1).memberType mustEqual UserType().typeId
+      memberships(1).memberId mustEqual anotherUser.id
+      Seq(this.defaultGroup.id, anotherGroup.id) must contain(memberships(1).groupId)
+    }
+
+    "retrieve groups a member belongs to" taggedAs GroupTag in {
+      val anotherUser = this.serviceManager.user.create(
+        this.getTestUser(99912345, "RetrieveMemberGroupsOUser"),
+        User.superUser
+      )
+      val anotherGroup =
+        this.serviceManager.group
+          .create(this.getTestGroup("GroupMemberRepositorySpec_RetrieveMemberGroupsTest Group"))
+          .get
+
+      this.repository.addGroupMember(this.defaultGroup, MemberObject.user(anotherUser.id))
+      this.repository.addGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+
+      val userGroups = this.repository.getMemberGroups(MemberObject.user(anotherUser.id))
+      userGroups.size mustEqual 2
+      Seq(this.defaultGroup.id, anotherGroup.id) must contain(userGroups.head.id)
+      Seq(this.defaultGroup.id, anotherGroup.id) must contain(userGroups(1).id)
+    }
+
+    "delete a group member" taggedAs GroupTag in {
+      val anotherUser = this.serviceManager.user.create(
+        this.getTestUser(99924680, "DeleteGroupMemberOUser"),
+        User.superUser
+      )
+      val anotherGroup =
+        this.serviceManager.group
+          .create(this.getTestGroup("GroupMemberRepositorySpec_DeleteGroupMemberTest Group"))
+          .get
+      val newGroupMember = this.repository
+        .addGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+        .get
+
+      this.repository.deleteGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+
+      val retrievedGroupMember = this.repository
+        .getGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+      retrievedGroupMember mustEqual None
+    }
+
+    "delete group members with query" taggedAs GroupTag in {
+      val anotherUser = this.serviceManager.user.create(
+        this.getTestUser(99935791, "DeleteGroupMemberQueryOUser"),
+        User.superUser
+      )
+      val anotherGroup =
+        this.serviceManager.group
+          .create(this.getTestGroup("GroupMemberRepositorySpec_DeleteGroupMemberQueryTest Group"))
+          .get
+      val newGroupMember = this.repository
+        .addGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+        .get
+
+      this.repository.delete(
+        Query.simple(
+          List(
+            BaseParameter(GroupMember.FIELD_GROUP_ID, newGroupMember.groupId),
+            BaseParameter(GroupMember.FIELD_MEMBER_ID, newGroupMember.memberId)
+          )
+        )
+      )
+
+      val retrievedGroupMember = this.repository
+        .getGroupMember(anotherGroup, MemberObject.user(anotherUser.id))
+      retrievedGroupMember mustEqual None
+    }
+  }
+
+  override implicit val projectTestName: String = "GroupMemberRepositorySpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    randomUser = this.serviceManager.user.create(
+      this.getTestUser(12345, "RandomOUser"),
+      User.superUser
+    )
+
+    defaultGroup = this.serviceManager.group
+      .create(this.getTestGroup("GroupMemberRepositorySpec_Test Group"))
+      .get
+
+    this.serviceManager.group.addGroupMember(
+      defaultGroup,
+      MemberObject.user(this.defaultUser.id)
+    )
+  }
+
+  protected def getTestGroup(name: String): Group = {
+    Group(
+      -1,
+      name,
+      Some("A test group"),
+      Some("http://www.gravatar.com/avatar/?d=identicon")
+    )
+  }
+}

--- a/test/org/maproulette/framework/repository/GroupRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/GroupRepositorySpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework
+
+import org.maproulette.framework.model.{Group, Project, User}
+import org.maproulette.framework.psql.Query
+import org.maproulette.framework.psql.filter.BaseParameter
+import org.maproulette.framework.repository.{GroupRepository}
+import org.maproulette.framework.service.GroupService
+import org.maproulette.framework.util.{FrameworkHelper, GroupTag}
+import play.api.Application
+
+/**
+  * @author nrotstan
+  */
+class GroupRepositorySpec(implicit val application: Application) extends FrameworkHelper {
+  val repository: GroupRepository = this.application.injector.instanceOf(classOf[GroupRepository])
+  val service: GroupService       = this.serviceManager.group
+
+  var defaultGroup: Group = null
+  var randomUser: User    = null
+
+  "GroupRepository" should {
+    "perform a basic query" taggedAs (GroupTag) in {
+      val groups =
+        this.repository
+          .query(Query.simple(List(BaseParameter(Group.FIELD_ID, this.defaultGroup.id))))
+      groups.size mustEqual 1
+      groups.head.id mustEqual this.defaultGroup.id
+    }
+
+    "create a group" taggedAs GroupTag in {
+      val createdGroup   = this.repository.create(Group(-1, "RandomCreateGroup")).get
+      val retrievedGroup = this.repository.retrieve(createdGroup.id)
+      retrievedGroup.get mustEqual createdGroup
+    }
+
+    "update a group" taggedAs GroupTag in {
+      val randomGroup = this.repository.create(Group(-1, "RandomGroup")).get
+      this.repository.update(
+        Group(randomGroup.id, "UpdatedName", Some("Updated description"), Some("new_avatar_url"))
+      )
+      val group = this.service.retrieve(randomGroup.id)
+      group.get.name mustEqual "UpdatedName"
+      group.get.description.get mustEqual "Updated description"
+      group.get.avatarURL.get mustEqual "new_avatar_url"
+    }
+
+    "delete a group" taggedAs GroupTag in {
+      val group = this.repository.create(Group(-1, "RandomDeleteGroup")).get
+      this.repository.delete(group)
+      this.service.retrieve(group.id) mustEqual None
+    }
+  }
+
+  override implicit val projectTestName: String = "GroupRepositorySpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    randomUser = this.serviceManager.user.create(
+      this.getTestUser(12345, "RandomOUser"),
+      User.superUser
+    )
+    defaultGroup =
+      this.serviceManager.group.create(this.getTestGroup("GroupRepositorySpec_Test Group")).get
+  }
+
+  protected def getTestGroup(name: String): Group = {
+    Group(
+      -1,
+      name,
+      Some("A test group"),
+      Some("http://www.gravatar.com/avatar/?d=identicon")
+    )
+  }
+}

--- a/test/org/maproulette/framework/repository/UserRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/UserRepositorySpec.scala
@@ -105,23 +105,6 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
         )
       )
     }
-
-    "get users managing projects" taggedAs UserRepoTag in {
-      val managers = this.userRepository.getUsersManagingProject(this.defaultProject.id)
-      managers.size mustEqual 1
-      managers.head.osmId mustEqual this.defaultUser.osmProfile.id
-      val managers2 =
-        this.userRepository.getUsersManagingProject(this.defaultProject.id, Some(List.empty))
-      managers2.size mustEqual 1
-      managers2.head.osmId mustEqual this.defaultUser.osmProfile.id
-      val managers3 = this.userRepository
-        .getUsersManagingProject(this.defaultProject.id, Some(List(this.defaultUser.id)))
-      managers3.size mustEqual 0
-      val managers4 = this.userRepository
-        .getUsersManagingProject(this.defaultProject.id, Some(List(this.defaultUser.osmProfile.id)))
-      managers4.size mustEqual 1
-      managers4.head.osmId mustEqual this.defaultUser.osmProfile.id
-    }
   }
 
   override implicit val projectTestName: String = "UserRepositorySpecProject"

--- a/test/org/maproulette/framework/service/GroupServiceSpec.scala
+++ b/test/org/maproulette/framework/service/GroupServiceSpec.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import org.maproulette.framework.model.{Group, GroupMember, MemberObject, User}
+import org.maproulette.data.{UserType}
+import org.maproulette.framework.util.{FrameworkHelper, GroupTag}
+import play.api.Application
+
+/**
+  * @author nrotstan
+  */
+class GroupServiceSpec(implicit val application: Application) extends FrameworkHelper {
+  val service: GroupService = this.serviceManager.group
+
+  var defaultGroup: Group = null
+  var randomUser: User    = null
+  var anotherUser: User   = null
+
+  "GroupService" should {
+    "create a new group" taggedAs GroupTag in {
+      val group = this.service.create(this.getTestGroup("GroupServiceSpec_Group B")).get
+      group.name mustEqual "GroupServiceSpec_Group B"
+    }
+
+    "add a member to a group" taggedAs GroupTag in {
+      this.service.addGroupMember(this.defaultGroup, MemberObject.user(this.defaultUser.id))
+      this.service.addGroupMember(this.defaultGroup, MemberObject.user(this.randomUser.id))
+
+      val allMembers = this.service.groupMembers(this.defaultGroup)
+      allMembers.size mustEqual 2
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(allMembers.head.memberId)
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(allMembers(1).memberId)
+    }
+
+    "retrieve a group by id" taggedAs GroupTag in {
+      val group = this.service.retrieve(this.defaultGroup.id)
+      group.get.id mustEqual this.defaultGroup.id
+    }
+
+    "retrieve a group by exact name" taggedAs GroupTag in {
+      val group = this.service.retrieveByName("GroupServiceSpec_Group A")
+      group.get.id mustEqual this.defaultGroup.id
+    }
+
+    "perform a basic search for groups" taggedAs GroupTag in {
+      val groupsWithA = this.service.search("Group A")
+      val groupsWithB = this.service.search("Group B")
+      val matchNone   = this.service.search("Nothing")
+      val matchAll    = this.service.search("GroupServiceSpec")
+
+      groupsWithA.size mustEqual 1
+      groupsWithA.head.id mustEqual this.defaultGroup.id
+
+      groupsWithB.size mustEqual 1
+      val groupB = groupsWithB.head
+      groupB.name mustEqual "GroupServiceSpec_Group B"
+
+      matchNone.size mustEqual 0
+
+      matchAll.size mustEqual 2
+      Seq(this.defaultGroup.id, groupB.id) must contain(matchAll.head.id)
+      Seq(this.defaultGroup.id, groupB.id) must contain(matchAll(1).id)
+    }
+
+    "retrieve all members of a group" taggedAs GroupTag in {
+      val anotherGroup =
+        this.service.create(this.getTestGroup("GroupServiceSpec_RetrieveAllMembersTest Group")).get
+
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.anotherUser.id))
+
+      val allMembers = this.service.groupMembers(anotherGroup)
+      allMembers.size mustEqual 2
+      Seq(this.randomUser.id, this.anotherUser.id) must contain(allMembers.head.memberId)
+      Seq(this.randomUser.id, this.anotherUser.id) must contain(allMembers(1).memberId)
+    }
+
+    "determine if a user is a member of a group" taggedAs GroupTag in {
+      val anotherGroup =
+        this.service.create(this.getTestGroup("GroupServiceSpec_IsGroupMemberTest Group")).get
+
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.anotherUser.id))
+
+      this.service.isGroupMember(anotherGroup, MemberObject.user(this.randomUser.id)) mustEqual true
+      this.service
+        .isGroupMember(anotherGroup, MemberObject.user(this.anotherUser.id)) mustEqual true
+      this.service
+        .isGroupMember(anotherGroup, MemberObject.user(this.defaultUser.id)) mustEqual false
+    }
+
+    "retrieve an individual member of a group" taggedAs GroupTag in {
+      val anotherGroup =
+        this.service.create(this.getTestGroup("GroupServiceSpec_RetrieveGroupMemberTest Group")).get
+
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.anotherUser.id))
+
+      val member =
+        this.service.getGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+
+      member.get.groupId mustEqual anotherGroup.id
+      member.get.memberType mustEqual UserType().typeId
+      member.get.memberId mustEqual randomUser.id
+    }
+
+    "remove a member from a group" taggedAs GroupTag in {
+      val anotherGroup =
+        this.service.create(this.getTestGroup("GroupServiceSpec_RemoveGroupMemberTest Group")).get
+
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+      this.service.addGroupMember(anotherGroup, MemberObject.user(this.anotherUser.id))
+
+      this.service.removeGroupMember(anotherGroup, MemberObject.user(this.randomUser.id))
+      val remainingMembers = this.service.groupMembers(anotherGroup)
+
+      remainingMembers.size mustEqual 1
+      remainingMembers.head.memberId mustEqual this.anotherUser.id
+    }
+
+    "retrieve all groups to which a member belongs" taggedAs GroupTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(24680, "RetrieveAllMemberGroupsOUser"),
+        User.superUser
+      )
+      val anotherGroup =
+        this.service
+          .create(this.getTestGroup("GroupServiceSpec_RetrieveMemberGroupsTest Group"))
+          .get
+
+      this.service.addGroupMember(anotherGroup, MemberObject.user(freshUser.id))
+      this.service.addGroupMember(this.defaultGroup, MemberObject.user(freshUser.id))
+
+      val allGroups = this.service.memberGroups(MemberObject.user(freshUser.id))
+      allGroups.size mustEqual 2
+      Seq(this.defaultGroup.id, anotherGroup.id) must contain(allGroups.head.id)
+      Seq(this.defaultGroup.id, anotherGroup.id) must contain(allGroups(1).id)
+    }
+  }
+
+  override implicit val projectTestName: String = "GroupServiceSpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    randomUser = this.serviceManager.user.create(
+      this.getTestUser(12345, "RandomOUser"),
+      User.superUser
+    )
+    anotherUser = this.serviceManager.user.create(
+      this.getTestUser(98765, "AnotherUser"),
+      User.superUser
+    )
+    defaultGroup =
+      this.serviceManager.group.create(this.getTestGroup("GroupServiceSpec_Group A")).get
+  }
+
+  protected def getTestGroup(name: String): Group = {
+    Group(
+      -1,
+      name,
+      Some("A test group"),
+      Some("http://www.gravatar.com/avatar/?d=identicon")
+    )
+  }
+}

--- a/test/org/maproulette/framework/service/TeamServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TeamServiceSpec.scala
@@ -1,0 +1,478 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import org.maproulette.framework.model.{
+  TeamMember,
+  Group,
+  GroupMember,
+  MemberObject,
+  User,
+  Grant,
+  Grantee,
+  GrantTarget
+}
+import org.maproulette.data.{UserType, ProjectType}
+import org.maproulette.framework.util.{FrameworkHelper, TeamTag}
+import org.maproulette.framework.psql.{Paging}
+import play.api.Application
+
+/**
+  * @author mcuthbert
+  */
+class TeamServiceSpec(implicit val application: Application) extends FrameworkHelper {
+  val service: TeamService = this.serviceManager.team
+
+  var defaultTeam: Group = null
+  var randomUser: User   = null
+  var anotherUser: User  = null
+
+  "TeamService" should {
+    "create a new team with an initial admin member" taggedAs TeamTag in {
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_createTeamTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+      team.name mustEqual "TeamService_createTeamTest Team"
+      team.groupType mustEqual Group.GROUP_TYPE_TEAM
+
+      val members = this.service.teamMembers(team, this.defaultUser)
+      members.size mustEqual 1
+      members.head.memberType mustEqual UserType().typeId
+      members.head.memberId mustEqual this.defaultUser.id
+      this.service.isTeamAdmin(
+        this.defaultTeam,
+        MemberObject.user(this.defaultUser.id),
+        this.defaultUser
+      ) mustEqual true
+    }
+
+    "add a member to a team" taggedAs TeamTag in {
+      val addedMember = this.service.addTeamMember(
+        this.defaultTeam,
+        MemberObject.user(this.randomUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+
+      val allMembers = this.service.teamMembers(this.defaultTeam, this.defaultUser)
+      allMembers.size mustEqual 2
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(allMembers.head.memberId)
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(allMembers(1).memberId)
+    }
+
+    "add a member to a team with a specific status" taggedAs TeamTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(22213597, "AddTeamMemberStatusOUser"),
+        User.superUser
+      )
+
+      val addedMember = this.service.addTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_INVITED,
+        this.defaultUser
+      )
+
+      addedMember.get.status mustEqual TeamMember.STATUS_INVITED
+      addedMember.get.memberType mustEqual UserType().typeId
+      addedMember.get.memberId mustEqual freshUser.id
+
+      val retrievedMember =
+        this.service
+          .getTeamMember(this.defaultTeam, MemberObject.user(freshUser.id), this.defaultUser)
+
+      retrievedMember.get.memberId mustEqual freshUser.id
+      retrievedMember.get.memberType mustEqual UserType().typeId
+      retrievedMember.get.status mustEqual TeamMember.STATUS_INVITED
+    }
+
+    "not allow a non-admin member to add members to the team" taggedAs TeamTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(22224680, "AddTeamMemberOUser"),
+        User.superUser
+      )
+
+      an[IllegalAccessException] should be thrownBy this.service.addTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_INVITED,
+        freshUser
+      )
+    }
+
+    "retrieve a team by id" taggedAs TeamTag in {
+      val team = this.service.retrieve(this.defaultTeam.id, User.superUser)
+      team.get.id mustEqual this.defaultTeam.id
+    }
+
+    "retrieve a team by name" taggedAs TeamTag in {
+      val team = this.service.retrieveByName("TeamServiceSpec_Team A", User.superUser)
+      team.get.id mustEqual this.defaultTeam.id
+    }
+
+    "do a basic search for teams" taggedAs TeamTag in {
+      val teamB = this.service
+        .create(
+          this.getTestTeam("TeamServiceSpec_searchTeams Team B"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+      val teamC = this.service
+        .create(
+          this.getTestTeam("TeamServiceSpec_searchTeams Team C"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+
+      val teamsWithA    = this.service.search("Team A", Paging(), this.defaultUser)
+      val teamsWithB    = this.service.search("Team B", Paging(), this.defaultUser)
+      val matchNone     = this.service.search("Nothing", Paging(), this.defaultUser)
+      val matchMultiple = this.service.search("searchTeams Team", Paging(), this.defaultUser)
+
+      teamsWithA.size mustEqual 1
+      teamsWithA.head.id mustEqual this.defaultTeam.id
+
+      teamsWithB.size mustEqual 1
+      teamsWithB.head.id mustEqual teamB.id
+
+      matchNone.size mustEqual 0
+
+      matchMultiple.size mustEqual 2
+      Seq(teamB.id, teamC.id) must contain(matchMultiple.head.id)
+      Seq(teamB.id, teamC.id) must contain(matchMultiple(1).id)
+    }
+
+    "retrieve all members of a team" taggedAs TeamTag in {
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_retrieveAllMembersTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+      this.service.addTeamMember(
+        team,
+        MemberObject.user(this.randomUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+      val allMembers = this.service.teamMembers(team, this.defaultUser)
+
+      allMembers.size mustEqual 2
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(allMembers.head.memberId)
+      Seq(this.defaultUser.id, this.randomUser.id) must contain(allMembers(1).memberId)
+    }
+
+    "retrieve user representation of team members" taggedAs TeamTag in {
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_retrieveUserMembersTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+      this.service.addTeamMember(
+        team,
+        MemberObject.user(this.randomUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+      this.service.addTeamMember(
+        team,
+        MemberObject.user(this.anotherUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+      val allMembers  = this.service.teamMembers(team, this.defaultUser)
+      val userMembers = this.service.memberUsers(allMembers, this.defaultUser)
+
+      userMembers.size mustEqual 3
+      Seq(this.defaultUser.id, this.randomUser.id, this.anotherUser.id) must contain(
+        userMembers.head.userId
+      )
+      Seq(this.defaultUser.id, this.randomUser.id, this.anotherUser.id) must contain(
+        userMembers(1).userId
+      )
+      Seq(this.defaultUser.id, this.randomUser.id, this.anotherUser.id) must contain(
+        userMembers(2).userId
+      )
+    }
+
+    "check if a member is on a team" taggedAs TeamTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(22297531, "AddIsTeamMemberOUser"),
+        User.superUser
+      )
+      this.service.isActiveTeamMember(
+        this.defaultTeam,
+        MemberObject.user(this.defaultUser.id),
+        this.defaultUser
+      ) mustEqual true
+      this.service.isActiveTeamMember(
+        this.defaultTeam,
+        MemberObject.user(this.randomUser.id),
+        this.defaultUser
+      ) mustEqual true
+      this.service.isActiveTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        this.defaultUser
+      ) mustEqual false
+    }
+
+    "check if a user is an admin of a team" taggedAs TeamTag in {
+      this.service.isTeamAdmin(
+        this.defaultTeam,
+        MemberObject.user(this.defaultUser.id),
+        this.defaultUser
+      ) mustEqual true
+      this.service.isTeamAdmin(
+        this.defaultTeam,
+        MemberObject.user(this.randomUser.id),
+        this.defaultUser
+      ) mustEqual false
+      this.service.isTeamAdmin(
+        this.defaultTeam,
+        MemberObject.user(this.anotherUser.id),
+        this.defaultUser
+      ) mustEqual false
+    }
+
+    "not consider an invited member to be active on the team" taggedAs TeamTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(22212985, "InviteesNotActiveOUser"),
+        User.superUser
+      )
+      this.service.addTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_INVITED,
+        this.defaultUser
+      )
+      this.service.isActiveTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        this.defaultUser
+      ) mustEqual false
+    }
+
+    "update the status of a team member" taggedAs TeamTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(22298912, "InviteesNotActiveOUser"),
+        User.superUser
+      )
+      val addedMember = this.service.addTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_INVITED,
+        this.defaultUser
+      )
+
+      addedMember.get.status mustEqual TeamMember.STATUS_INVITED
+      addedMember.get.memberType mustEqual UserType().typeId
+      addedMember.get.memberId mustEqual freshUser.id
+
+      val updatedMember = this.service.updateMemberStatus(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+
+      updatedMember.get.status mustEqual TeamMember.STATUS_MEMBER
+      updatedMember.get.memberType mustEqual UserType().typeId
+      updatedMember.get.memberId mustEqual freshUser.id
+
+      val retrievedMember =
+        this.service
+          .getTeamMember(this.defaultTeam, MemberObject.user(freshUser.id), this.defaultUser)
+
+      retrievedMember.get.status mustEqual TeamMember.STATUS_MEMBER
+      retrievedMember.get.memberType mustEqual UserType().typeId
+      retrievedMember.get.memberId mustEqual freshUser.id
+
+      this.service.isActiveTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        this.defaultUser
+      ) mustEqual true
+    }
+
+    "retrieve an individual member of a team" taggedAs TeamTag in {
+      val member =
+        this.service
+          .getTeamMember(this.defaultTeam, MemberObject.user(this.randomUser.id), this.defaultUser)
+
+      member.get.groupId mustEqual defaultTeam.id
+      member.get.memberType mustEqual UserType().typeId
+      member.get.memberId mustEqual randomUser.id
+      member.get.status mustEqual TeamMember.STATUS_MEMBER
+    }
+
+    "remove a member from a team" taggedAs TeamTag in {
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_removeMemberTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+      this.service.addTeamMember(
+        team,
+        MemberObject.user(this.randomUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+      this.service.teamMembers(team, this.defaultUser).size mustEqual 2
+
+      this.service.removeTeamMember(team, MemberObject.user(this.randomUser.id), this.defaultUser)
+      val remainingMembers = this.service.teamMembers(team, this.defaultUser)
+      remainingMembers.size mustEqual 1
+      remainingMembers.head.memberId mustEqual this.defaultUser.id
+    }
+
+    "not allow a normal member to remove members from a team" taggedAs TeamTag in {
+      an[IllegalAccessException] should be thrownBy this.service.removeTeamMember(
+        this.defaultTeam,
+        MemberObject.user(this.defaultUser.id),
+        this.randomUser
+      )
+    }
+
+    "assign a new role to a team member" taggedAs TeamTag in {
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_updateMemberRoleTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+
+      this.service.addTeamMember(
+        team,
+        MemberObject.user(this.randomUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+      this.service.updateMemberRole(
+        team,
+        MemberObject.user(this.randomUser.id),
+        Grant.ROLE_WRITE_ACCESS,
+        this.defaultUser
+      )
+
+      this.serviceManager.grant
+        .retrieveMatchingGrants(
+          grantee = Some(List(Grantee.user(this.randomUser.id))),
+          role = Some(Grant.ROLE_WRITE_ACCESS),
+          target = Some(GrantTarget.group(team.id)),
+          user = User.superUser
+        )
+        .size mustEqual 1
+    }
+
+    "not allow normal members to assign new roles to team members" taggedAs TeamTag in {
+      an[IllegalAccessException] should be thrownBy this.service.updateMemberRole(
+        this.defaultTeam,
+        MemberObject.user(this.defaultUser.id),
+        Grant.ROLE_READ_ONLY,
+        this.randomUser
+      )
+    }
+
+    "update a team" taggedAs TeamTag in {
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_updateTeamTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+      this.service.updateTeam(
+        team.copy(name = "TeamService_updateTeamTest New Team Name"),
+        this.defaultUser
+      )
+
+      val retrievedTeam = this.service.retrieve(team.id, this.defaultUser)
+      retrievedTeam.get.id mustEqual team.id
+      retrievedTeam.get.name mustEqual "TeamService_updateTeamTest New Team Name"
+    }
+
+    "not allow normal members to update a team" taggedAs TeamTag in {
+      an[IllegalAccessException] should be thrownBy this.service.updateTeam(
+        defaultTeam.copy(name = "New Team Name"),
+        this.randomUser
+      )
+    }
+
+    "retrieve all team memberships possessed by a user" taggedAs TeamTag in {
+      val freshUser = this.serviceManager.user.create(
+        this.getTestUser(22235791, "RetrieveMemberTeamsOUser"),
+        User.superUser
+      )
+
+      val team = this.service
+        .create(
+          this.getTestTeam("TeamService_retrieveMemberTeamsTest Team"),
+          MemberObject.user(freshUser.id),
+          freshUser
+        )
+        .get
+
+      this.service.addTeamMember(
+        this.defaultTeam,
+        MemberObject.user(freshUser.id),
+        Grant.ROLE_READ_ONLY,
+        TeamMember.STATUS_MEMBER,
+        this.defaultUser
+      )
+
+      val allMemberships =
+        this.service.teamUsersByUserIds(List(freshUser.id), freshUser)
+
+      allMemberships.size mustEqual 2
+      Seq(this.defaultTeam.id, team.id) must contain(allMemberships.head.teamId)
+      Seq(this.defaultTeam.id, team.id) must contain(allMemberships(1).teamId)
+    }
+  }
+
+  override implicit val projectTestName: String = "TeamServiceSpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    randomUser = this.serviceManager.user.create(
+      this.getTestUser(22212345, "RandomOUser"),
+      User.superUser
+    )
+    anotherUser = this.serviceManager.user.create(
+      this.getTestUser(22298765, "AnotherUser"),
+      User.superUser
+    )
+    defaultTeam = this.serviceManager.team
+      .create(
+        this.getTestTeam("TeamServiceSpec_Team A"),
+        MemberObject.user(defaultUser.id),
+        defaultUser
+      )
+      .get
+  }
+}

--- a/test/org/maproulette/framework/service/UserServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserServiceSpec.scala
@@ -11,6 +11,7 @@ import org.maproulette.framework.psql.{OR, Paging, Query}
 import org.maproulette.framework.util.{FrameworkHelper, UserTag}
 import org.maproulette.exception.{InvalidException}
 import org.maproulette.models.Task
+import org.maproulette.data.{ProjectType}
 import org.scalatest.Matchers._
 import play.api.Application
 
@@ -75,6 +76,56 @@ class UserServiceSpec(implicit val application: Application) extends FrameworkHe
       }
     }
 
+    "retrieve includes grants conferred by teams" taggedAs UserTag in {
+      val insertedUser =
+        this.userService
+          .create(this.getTestUser(21, "retrieveConferredGrantsUser1"), User.superUser)
+
+      val team = this.serviceManager.team
+        .create(
+          this.getTestTeam("UserRepository_conferredGrantsTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+
+      val project = this.serviceManager.project
+        .create(
+          Project(-1, this.defaultUser.osmProfile.id, "retrieveConferredGrantsProject"),
+          this.defaultUser
+        )
+
+      this.serviceManager.team
+        .addTeamMember(
+          team,
+          MemberObject.user(insertedUser.id),
+          Grant.ROLE_ADMIN,
+          TeamMember.STATUS_MEMBER,
+          User.superUser
+        )
+
+      this.serviceManager.team
+        .addTeamToProject(
+          team.id,
+          project.id,
+          Grant.ROLE_WRITE_ACCESS,
+          User.superUser
+        )
+
+      // Work off a fresh copy of the user
+      val user = this.userService.retrieve(insertedUser.id).get
+      user.grants
+        .filter(g =>
+          g.target.objectType == ProjectType() &&
+            g.target.objectId == project.id &&
+            g.role == Grant.ROLE_WRITE_ACCESS
+        )
+        .size mustEqual 1
+
+      user.managedProjectIds().contains(project.id) mustEqual true
+      user.grantsForProject(project.id).size mustEqual 1
+    }
+
     "generate new API key" taggedAs UserTag in {
       val insertedUser =
         this.userService.create(this.getTestUser(11, "APIGenerationTestUser"), User.superUser)
@@ -116,16 +167,19 @@ class UserServiceSpec(implicit val application: Application) extends FrameworkHe
         this.userService.create(this.getTestUser(18, "OSMUsernameNotRelated"), User.superUser)
 
       val searchResultUser1 = UserSearchResult(
+        user1.id,
         user1.osmProfile.id,
         user1.osmProfile.displayName,
         user1.osmProfile.avatarURL
       )
       val searchResultUser2 = UserSearchResult(
+        user2.id,
         user2.osmProfile.id,
         user2.osmProfile.displayName,
         user2.osmProfile.avatarURL
       )
       val searchResultUser3 = UserSearchResult(
+        user3.id,
         user3.osmProfile.id,
         user3.osmProfile.displayName,
         user3.osmProfile.avatarURL
@@ -187,6 +241,69 @@ class UserServiceSpec(implicit val application: Application) extends FrameworkHe
         )
       managers4.size mustEqual 1
       managers4.head.osmId mustEqual this.defaultUser.osmProfile.id
+    }
+
+    "get project managers indirectly through teams" taggedAs UserTag in {
+      val freshUser = this.userService.create(
+        this.getTestUser(44412345, "GetIndirectProjectManagersOUser"),
+        User.superUser
+      )
+
+      val team = this.serviceManager.team
+        .create(
+          this.getTestTeam("UserService_getProjectManagersTest Team"),
+          MemberObject.user(this.defaultUser.id),
+          this.defaultUser
+        )
+        .get
+
+      val project = this.serviceManager.project
+        .create(
+          Project(-1, this.defaultUser.osmProfile.id, "getAllProjectManagersProject"),
+          this.defaultUser
+        )
+
+      this.serviceManager.team
+        .addTeamMember(
+          team,
+          MemberObject.user(freshUser.id),
+          Grant.ROLE_ADMIN,
+          TeamMember.STATUS_MEMBER,
+          User.superUser
+        )
+
+      this.serviceManager.team
+        .addTeamToProject(
+          team.id,
+          project.id,
+          Grant.ROLE_WRITE_ACCESS,
+          User.superUser
+        )
+
+      this.permission.hasObjectWriteAccess(project, freshUser)
+      val managers =
+        this.userService.getUsersManagingProject(project.id, user = User.superUser)
+
+      managers.map(_.userId).contains(this.defaultUser.id) mustEqual true
+      managers.map(_.userId).contains(freshUser.id) mustEqual true
+      managers.size mustEqual 2
+
+      this.serviceManager.team
+        .removeTeamFromProject(
+          team.id,
+          project.id,
+          User.superUser
+        )
+
+      an[IllegalAccessException] should be thrownBy this.permission.hasObjectWriteAccess(
+        project,
+        freshUser
+      )
+      val managersAfterRemoval =
+        this.userService.getUsersManagingProject(project.id, user = User.superUser)
+
+      managersAfterRemoval.size mustEqual 1
+      managersAfterRemoval.head.userId mustEqual this.defaultUser.id
     }
 
     "add a user to a project" taggedAs UserTag in {

--- a/test/org/maproulette/framework/util/FrameworkHelper.scala
+++ b/test/org/maproulette/framework/util/FrameworkHelper.scala
@@ -12,6 +12,7 @@ import org.maproulette.framework.model._
 import org.maproulette.framework.service.ServiceManager
 import org.maproulette.models.Task
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL, TaskReviewDAL}
+import org.maproulette.permissions.Permission
 import org.scalatest.{BeforeAndAfterAll, Tag}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -29,6 +30,7 @@ trait FrameworkHelper extends PlaySpec with BeforeAndAfterAll with MockitoSugar 
   val challengeDAL: ChallengeDAL     = application.injector.instanceOf(classOf[ChallengeDAL])
   val taskDAL: TaskDAL               = application.injector.instanceOf(classOf[TaskDAL])
   val taskReviewDAL: TaskReviewDAL   = application.injector.instanceOf(classOf[TaskReviewDAL])
+  val permission: Permission         = application.injector.instanceOf(classOf[Permission])
 
   // To be removed when all of SnapshotManager has been converted
   val snapshotManager: SnapshotManager = application.injector.instanceOf(classOf[SnapshotManager])
@@ -141,6 +143,15 @@ trait FrameworkHelper extends PlaySpec with BeforeAndAfterAll with MockitoSugar 
     )
   }
 
+  protected def getTestTeam(name: String): Group = {
+    Group(
+      -1,
+      name,
+      Some("A test team"),
+      Some("http://www.gravatar.com/avatar/?d=identicon")
+    )
+  }
+
   override protected def afterAll(): Unit = {
     val testProject = this.serviceManager.project.retrieveByName(projectTestName)
     this.serviceManager.project.delete(testProject.get.id, User.superUser, true)
@@ -162,6 +173,7 @@ object UserMetricsTag          extends Tag("usermetrics")
 object UserSavedObjectsTag     extends Tag("usersavedobjects")
 object UserSavedObjectsRepoTag extends Tag("usersavedobjectsrepo")
 object UserTag                 extends Tag("user")
+object GroupTag                extends Tag("group")
 object UserRepoTag             extends Tag("userRepo")
 object VirtualProjectTag       extends Tag("virtualproject")
 object VirtualProjectRepoTag   extends Tag("virtualprojectrepo")
@@ -169,3 +181,4 @@ object KeywordTag              extends Tag("keyword")
 object KeywordRepoTag          extends Tag("keywordrepo")
 object TaskReviewTag           extends Tag("taskreviewtag")
 object TaskTag                 extends Tag("tasktag")
+object TeamTag                 extends Tag("teamtag")

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -140,10 +140,13 @@ trait TestSpec extends PlaySpec with MockitoSugar {
   val tagService               = mock[TagService]
   val taskReviewService        = mock[TaskReviewService]
   val taskService              = mock[TaskService]
+  val groupService             = mock[GroupService]
+  val teamService              = mock[TeamService]
   val serviceManager = new ServiceManager(
     Providers.of[ProjectService](projectService),
     Providers.of[GrantService](grantService),
     Providers.of[UserService](userService),
+    Providers.of[GroupService](groupService),
     Providers.of[CommentService](commentService),
     Providers.of[TagService](tagService),
     Providers.of[ChallengeService](challengeService),
@@ -152,7 +155,8 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     Providers.of[UserMetricService](userMetricService),
     Providers.of[VirtualProjectService](virtualProjectService),
     Providers.of[TaskReviewService](taskReviewService),
-    Providers.of[TaskService](taskService)
+    Providers.of[TaskService](taskService),
+    Providers.of[TeamService](teamService)
   )
   val permission =
     new Permission(Providers.of[DALManager](dalManager), serviceManager, new Config())


### PR DESCRIPTION
* Add back a restructured Groups mechanism (unrelated to the old
security groups) which serve as a generic means of collecting together
typed objects into referenceable groups

* Add support for Teams, which use Groups

* As with users, teams can be added to projects and granted roles on them

* Teams confer their grants to their user members, potentially giving
those users additional permissions on projects via their teams

* Modify various queries that were manually querying a user's grants to
determine project access to instead ask the user for their managed
projects (as they can now include projects managed via their teams)

* Augment the Sangria graphQL integration to support Relations, which
require the use of Sangria Fetcher objects for deferred query
resolution

* Add a ServiceManager instance to the UserContext used by graphQL
resolvers, giving Fetchers easy access to services