### PR TITLE
Fix permission check when applying priority rules

### DIFF
--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -610,7 +610,7 @@ class ChallengeDAL @Inject() (
     * @param c    The connection for the request
     */
   def updateTaskPriorities(user: User)(implicit id: Long, c: Option[Connection] = None): Unit = {
-    this.permission.hasWriteAccess(TaskType(), user)
+    this.permission.hasWriteAccess(ChallengeType(), user)
     this.withMRConnection { implicit c =>
       val challenge = this.retrieveById(id) match {
         case Some(c) => c


### PR DESCRIPTION
* Change item type used in permission check performed prior to applying
updated priority rules from TaskType to ChallengeType, as the implicit
id passed down is a challenge id and not a task id. The old check would
end up load a task matching the challenge id and ultimately check
permissions against that task's parent project, leading to arbitrary
outcomes for non-superusers that could prevent updated priority rules
from being applied

* Fixes osmlab/maproulette3#1110