### PR TITLE
Support following of users

### DIFF
--- a/app/org/maproulette/data/ActionManager.scala
+++ b/app/org/maproulette/data/ActionManager.scala
@@ -195,13 +195,13 @@ class ActionManager @Inject() (config: Config, db: Database)(implicit applicatio
     * Helper function for getActivity list that gets the recent activity for a specific user, and
     * will only retrieve activity where status was set for tasks.
     *
-    * @param user   The user to get the activity for
+    * @param osmUserIds The OSM ids of users to get activity for
     * @param limit  limit the number of returned items
     * @param offset paging, starting at 0
     * @return
     */
   def getRecentActivity(
-      user: User,
+      osmUserIds: List[Long],
       limit: Int = Config.DEFAULT_LIST_SIZE,
       offset: Int = 0
   ): List[ActionItem] =
@@ -209,7 +209,7 @@ class ActionManager @Inject() (config: Config, db: Database)(implicit applicatio
       limit,
       offset,
       ActionLimits(
-        osmUserLimit = List(user.osmProfile.id),
+        osmUserLimit = osmUserIds,
         actionLimit =
           List(Actions.ACTION_TYPE_TASK_STATUS_SET, Actions.ACTION_TYPE_QUESTION_ANSWERED)
       )

--- a/app/org/maproulette/framework/controller/FollowController.scala
+++ b/app/org/maproulette/framework/controller/FollowController.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.controller
+
+import java.net.URLDecoder
+
+import javax.inject.Inject
+import org.maproulette.data.ActionManager
+import org.maproulette.exception.NotFoundException
+import org.maproulette.framework.service.{ServiceManager, FollowService}
+import org.maproulette.framework.model.User
+import org.maproulette.session.SessionManager
+import play.api.libs.json._
+import play.api.mvc._
+
+/**
+  * @author nrotstan
+  */
+class FollowController @Inject() (
+    override val sessionManager: SessionManager,
+    override val actionManager: ActionManager,
+    override val bodyParsers: PlayBodyParsers,
+    service: FollowService,
+    serviceManager: ServiceManager,
+    components: ControllerComponents
+) extends AbstractController(components)
+    with MapRouletteController {
+
+  /**
+    * Retrieve users followed by a user
+    *
+    * @param userId The id of the user who is following other users
+    * @return The followed users
+    */
+  def followedBy(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(
+        Json.toJson(
+          this.service.getUsersFollowedBy(userId, user.getOrElse(User.guestUser))
+        )
+      )
+    }
+  }
+
+  /**
+    * Retrieve users following a user
+    *
+    * @param userId The id of the user who being followed
+    * @return The users who are following
+    */
+  def followersOf(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      Ok(
+        Json.toJson(
+          this.service.getUserFollowers(userId, user.getOrElse(User.guestUser))
+        )
+      )
+    }
+  }
+
+  /**
+    * Start following a user
+    *
+    * @param userId The id of the user to follow
+    */
+  def follow(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val followed = this.serviceManager.user.retrieve(userId) match {
+        case Some(u) => u
+        case None =>
+          throw new NotFoundException(s"No user with id $userId found")
+      }
+      this.service.follow(user, followed, user)
+      Ok(Json.toJson(this.service.getUsersFollowedBy(user.id, user)))
+    }
+  }
+
+  /**
+    * Stop following a user
+    *
+    * @param userId The id of the user to stop following
+    */
+  def unfollow(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      val followed = this.serviceManager.user.retrieve(userId) match {
+        case Some(u) => u
+        case None =>
+          throw new NotFoundException(s"No user with id $userId found")
+      }
+      this.service.stopFollowing(user, followed, user)
+      Ok(Json.toJson(this.service.getUsersFollowedBy(user.id, user)))
+    }
+  }
+
+  /**
+    * Block a follower
+    *
+    * @param userId The id of the user to block
+    */
+  def block(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.service.blockFollower(userId, user, user)
+      Ok(Json.toJson(this.service.getUserFollowers(user.id, user)))
+    }
+  }
+
+  /**
+    * Unblock a blocked follower
+    *
+    * @param userId The id of the user to unblock
+    */
+  def unblock(userId: Long): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.authenticatedRequest { implicit user =>
+      this.service.unblockFollower(userId, user, user)
+      Ok(Json.toJson(this.service.getUserFollowers(user.id, user)))
+    }
+  }
+}

--- a/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
@@ -267,6 +267,64 @@ class UserSchema @Inject() (override val service: UserService)
         )
         true
       }
+    ),
+    Field(
+      name = "follow",
+      description = Some("Follow a user"),
+      fieldType = UserType,
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user       = context.ctx.user
+        val followedId = context.arg(MRSchema.idArg)
+        val followed = this.service.retrieve(followedId) match {
+          case Some(u) => u
+          case None =>
+            throw new NotFoundException(s"No user with id $followedId found")
+        }
+        context.ctx.services.follow.follow(user, followed, user)
+        user
+      }
+    ),
+    Field(
+      name = "stopFollowing",
+      description = Some("Stop following a user"),
+      fieldType = UserType,
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user       = context.ctx.user
+        val followedId = context.arg(MRSchema.idArg)
+        val followed = this.service.retrieve(followedId) match {
+          case Some(u) => u
+          case None =>
+            throw new NotFoundException(s"No user with id $followedId found")
+        }
+        context.ctx.services.follow.stopFollowing(user, followed, user)
+        user
+      }
+    ),
+    Field(
+      name = "blockFollower",
+      description = Some("Block a follower from following a user"),
+      fieldType = UserType,
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user       = context.ctx.user
+        val followerId = context.arg(MRSchema.idArg)
+        context.ctx.services.follow.blockFollower(followerId, user, user)
+        user
+      }
+    ),
+    Field(
+      name = "unblockFollower",
+      description = Some("Unblock a blocked follower"),
+      fieldType = UserType,
+      arguments = MRSchema.idArg :: Nil,
+      resolve = context => {
+        val user       = context.ctx.user
+        val followerId = context.arg(MRSchema.idArg)
+        context.ctx.services.follow.unblockFollower(followerId, user, user)
+        user
+      }
     )
   )
 }

--- a/app/org/maproulette/framework/model/Group.scala
+++ b/app/org/maproulette/framework/model/Group.scala
@@ -44,8 +44,10 @@ object Group extends CommonField {
   val FIELD_GROUP_TYPE = "group_type"
 
   // Types of groups
-  val GROUP_TYPE_STANDARD = 0
-  val GROUP_TYPE_TEAM     = 1
+  val GROUP_TYPE_STANDARD  = 0
+  val GROUP_TYPE_TEAM      = 1
+  val GROUP_TYPE_FOLLOWING = 2
+  val GROUP_TYPE_FOLLOWERS = 3
 }
 
 /**

--- a/app/org/maproulette/framework/repository/GroupMemberRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupMemberRepository.scala
@@ -259,6 +259,28 @@ class GroupMemberRepository @Inject() (
       query.build(s"DELETE FROM group_members").execute()
     }
   }
+
+  /**
+    * Delete a member from multiple groups that all share the same group type
+    *
+    * @param member    The member to delete
+    * @param groupType The type of group from which member is to be deleted
+    */
+  def deleteGroupMemberAcrossGroupType(member: MemberObject, groupType: Int): Boolean = {
+    withMRConnection { implicit c =>
+      Query
+        .simple(
+          List(
+            BaseParameter(GroupMember.FIELD_GROUP_ID, "groups.id", useValueDirectly = true),
+            BaseParameter(Group.FIELD_GROUP_TYPE, groupType, table = Some(Group.TABLE)),
+            BaseParameter(GroupMember.FIELD_MEMBER_TYPE, member.objectType),
+            BaseParameter(GroupMember.FIELD_MEMBER_ID, member.objectId)
+          )
+        )
+        .build("DELETE FROM group_members USING groups")
+        .execute()
+    }
+  }
 }
 
 object GroupMemberRepository {

--- a/app/org/maproulette/framework/repository/GroupRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupRepository.scala
@@ -14,7 +14,7 @@ import org.joda.time.DateTime
 import org.maproulette.framework.model.{Group, GroupMember}
 import org.maproulette.framework.repository.{GroupMemberRepository}
 import org.maproulette.framework.psql.{Query, Paging}
-import org.maproulette.framework.psql.filter.{BaseParameter, Operator}
+import org.maproulette.framework.psql.filter.{BaseParameter, Operator, FilterGroup}
 import play.api.db.Database
 
 /**
@@ -61,19 +61,19 @@ class GroupRepository @Inject() (
   /**
     * Retrieve all groups matching the ids
     */
-  def list(ids: List[Long], paging: Paging = Paging()): List[Group] = {
+  def list(ids: List[Long], query: Query = Query.empty): List[Group] = {
     if (ids.isEmpty) {
       return List()
     }
 
-    this.query(
-      Query.simple(
-        List(
-          BaseParameter(Group.FIELD_ID, ids, Operator.IN)
-        ),
-        paging = paging
+    this
+      .query(
+        query.addFilterGroup(
+          FilterGroup(
+            List(BaseParameter(Group.FIELD_ID, ids, Operator.IN))
+          )
+        )
       )
-    )
   }
 
   /**

--- a/app/org/maproulette/framework/service/FollowService.scala
+++ b/app/org/maproulette/framework/service/FollowService.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import javax.inject.{Inject, Singleton}
+import org.maproulette.data.{UserType}
+import org.maproulette.exception.{NotFoundException, InvalidException}
+import org.maproulette.framework.model.{User, Follower, Group, MemberObject}
+import org.maproulette.permissions.Permission
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
+
+/**
+  * Service for handling following and followers for users
+  *
+  * @author nrotstan
+  */
+@Singleton
+class FollowService @Inject() (
+    serviceManager: ServiceManager,
+    webSocketProvider: WebSocketProvider,
+    permission: Permission
+) {
+
+  /**
+    * Follow a user, updating the follower's "following" group and the
+    * followed user's "followers" group
+    *
+    * @param follower The user who is to be the follower
+    * @param followed The user to be followed
+    * @param user     The user making the request
+    */
+  def follow(follower: User, followed: User, user: User): Unit = {
+    this.permission.hasWriteAccess(UserType(), user)(follower.id)
+    if (!followed.settings.allowFollowing.getOrElse(true)) {
+      throw new InvalidException("User cannot be followed")
+    }
+
+    this.serviceManager.group.addGroupMember(
+      this.getFollowingGroup(follower, user),
+      MemberObject.user(followed.id)
+    )
+
+    this.serviceManager.group.addGroupMember(
+      this.getFollowersGroup(followed, user),
+      MemberObject.user(follower.id)
+    )
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.followUpdate(
+        WebSocketMessages.FollowUpdateData(Some(follower.id), Some(followed.id))
+      )
+    )
+  }
+
+  /**
+    * Stop following a user, updating the follower's "following" group and the
+    * followed user's "followers" group
+    *
+    * @param follower The user who is following
+    * @param followed The user being followed
+    * @param user     The user making the request
+    */
+  def stopFollowing(follower: User, followed: User, user: User): Unit = {
+    this.permission.hasWriteAccess(UserType(), user)(followed.id)
+
+    this.serviceManager.group.removeGroupMember(
+      this.getFollowingGroup(follower, user),
+      MemberObject.user(followed.id)
+    )
+
+    this.serviceManager.group.removeGroupMember(
+      this.getFollowersGroup(followed, user),
+      MemberObject.user(follower.id)
+    )
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.followUpdate(
+        WebSocketMessages.FollowUpdateData(Some(follower.id), Some(followed.id))
+      )
+    )
+  }
+
+  /**
+    * Clear all of a user's followers
+    *
+    * @param followed The user for which followers are to be cleared
+    * @param user     The user making the request
+    */
+  def clearFollowers(followed: User, user: User): Unit = {
+    this.permission.hasWriteAccess(UserType(), user)(followed.id)
+    this.serviceManager.group.clearGroupMembers(this.getFollowersGroup(followed, user))
+    this.serviceManager.group.removeGroupMemberAcrossGroupType(
+      MemberObject.user(followed.id),
+      Group.GROUP_TYPE_FOLLOWING
+    )
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.followUpdate(
+        WebSocketMessages.FollowUpdateData(None, Some(followed.id))
+      )
+    )
+  }
+
+  /**
+    * Block a follower from following a user, updating their status in the "followers"
+    * group to BLOCKED
+    *
+    * @param follower The user to be blocked
+    * @param followed The user being followed
+    * @param user     The user making the request
+    */
+  def blockFollower(followerId: Long, followed: User, user: User): Unit = {
+    this.permission.hasWriteAccess(UserType(), user)(followed.id)
+
+    this.serviceManager.group.updateGroupMemberStatus(
+      this.getFollowersGroup(followed, user),
+      MemberObject.user(followerId),
+      Follower.STATUS_BLOCKED
+    )
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.followUpdate(
+        WebSocketMessages.FollowUpdateData(Some(followerId), Some(followed.id))
+      )
+    )
+  }
+
+  /**
+    * Unblock a follower, allowing them to follow a user again
+    *
+    * @param follower The user to be unblocked
+    * @param followed The user being followed
+    * @param user     The user making the request
+    */
+  def unblockFollower(followerId: Long, followed: User, user: User): Unit = {
+    this.permission.hasWriteAccess(UserType(), user)(followed.id)
+
+    this.serviceManager.group.updateGroupMemberStatus(
+      this.getFollowersGroup(followed, user),
+      MemberObject.user(followerId),
+      Follower.STATUS_FOLLOWING
+    )
+
+    webSocketProvider.sendMessage(
+      WebSocketMessages.followUpdate(
+        WebSocketMessages.FollowUpdateData(Some(followerId), Some(followed.id))
+      )
+    )
+  }
+
+  /**
+    * Retrieve list of Users being followed by a user
+    *
+    * @param follower The user following the desired users
+    * @param user     The user making the request
+    */
+  def getUsersFollowedBy(followerId: Long, user: User): List[User] =
+    this.getGroupUsers(
+      this.getFollowingGroup(
+        retrieveUserOrError(followerId),
+        user
+      )
+    )
+
+  /**
+    * Retrieve list of Followers who are following a user
+    *
+    * @param followed The user being followed by the desired users
+    * @param user     The user making the request
+    */
+  def getUserFollowers(followedId: Long, user: User): List[Follower] = {
+    val userMembers = this.serviceManager.group.membersOfType(
+      this.getFollowersGroup(retrieveUserOrError(followedId), user),
+      UserType()
+    )
+    val users = this.serviceManager.user.retrieveListById(userMembers.map(_.memberId))
+
+    userMembers
+      .map(member => {
+        users.find(u => u.id == member.memberId) match {
+          case Some(user) => Some(Follower(member.id, user, member.status))
+          case None       => None
+        }
+      })
+      .flatten
+  }
+
+  /**
+    * Retrieves the Following group for a User, creating it first if it doesn't
+    * exist
+    *
+    * @param follower The user whose following group is desired
+    * @param user     The user making the request
+    */
+  def getFollowingGroup(follower: User, user: User): Group = {
+    this.serviceManager.group
+      .retrieve(
+        follower.followingGroupId match {
+          case Some(groupId) => groupId
+          case None =>
+            this.serviceManager.user.addFollowingGroup(follower, user).get
+        }
+      )
+      .get
+  }
+
+  /**
+    * Retrieves the Followers group for a User, creating it first if it doesn't
+    * exist
+    *
+    * @param followed The user whose followers group is desired
+    * @param user     The user making the request
+    */
+  def getFollowersGroup(followed: User, user: User): Group = {
+    this.serviceManager.group
+      .retrieve(
+        followed.followersGroupId match {
+          case Some(groupId) => groupId
+          case None =>
+            this.serviceManager.user.addFollowersGroup(followed, user).get
+        }
+      )
+      .get
+  }
+
+  /**
+    * Retrieves a User or throws a NotFoundException if the user doesn't exist
+    *
+    * @param id The identifier for the object
+    * @return An optional object, None if not found
+    */
+  private def retrieveUserOrError(userId: Long): User =
+    this.serviceManager.user.retrieve(userId) match {
+      case Some(u) => u
+      case None    => throw new NotFoundException(s"No user with id ${userId} found")
+    }
+
+  /**
+    * Retrieves User representations of user members of a group
+    */
+  private def getGroupUsers(group: Group): List[User] =
+    this.serviceManager.user.retrieveListById(
+      this.serviceManager.group.membersOfType(group, UserType()).map(_.memberId)
+    )
+}

--- a/app/org/maproulette/framework/service/ServiceManager.scala
+++ b/app/org/maproulette/framework/service/ServiceManager.scala
@@ -19,6 +19,7 @@ class ServiceManager @Inject() (
     projectService: Provider[ProjectService],
     grantService: Provider[GrantService],
     userService: Provider[UserService],
+    followService: Provider[FollowService],
     groupService: Provider[GroupService],
     commentService: Provider[CommentService],
     tagService: Provider[TagService],
@@ -54,6 +55,8 @@ class ServiceManager @Inject() (
   def grant: GrantService = grantService.get()
 
   def user: UserService = userService.get()
+
+  def follow: FollowService = followService.get()
 
   def group: GroupService = groupService.get()
 

--- a/app/org/maproulette/provider/websockets/WebSocketActor.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketActor.scala
@@ -52,6 +52,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
   implicit val challengeWrites: Writes[Challenge] = Challenge.writes.challengeWrites
   implicit val teamUpdateDataWrites               = WebSocketMessages.teamUpdateDataWrites
   implicit val teamMessageWrites                  = WebSocketMessages.teamMessageWrites
+  implicit val followUpdateDataWrites             = WebSocketMessages.followUpdateDataWrites
+  implicit val followMessageWrites                = WebSocketMessages.followMessageWrites
 
   def receive = {
     case serverMessage: WebSocketMessages.NotificationMessage =>
@@ -61,6 +63,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
     case serverMessage: WebSocketMessages.TaskMessage =>
       out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.TeamMessage =>
+      out ! Json.toJson(serverMessage)
+    case serverMessage: WebSocketMessages.FollowMessage =>
       out ! Json.toJson(serverMessage)
     case clientMessage: WebSocketMessages.ClientMessage =>
       clientMessage.messageType match {

--- a/app/org/maproulette/provider/websockets/WebSocketMessages.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketMessages.scala
@@ -63,6 +63,11 @@ object WebSocketMessages {
   case class TeamMessage(messageType: String, data: TeamUpdateData, meta: ServerMeta)
       extends ServerMessage
 
+  case class FollowUpdateData(followerId: Option[Long], followedId: Option[Long])
+
+  case class FollowMessage(messageType: String, data: FollowUpdateData, meta: ServerMeta)
+      extends ServerMessage
+
   // Public helper methods for creation of individual messages and data objects
   def pong(): PongMessage = PongMessage("pong", ServerMeta(None))
 
@@ -85,6 +90,9 @@ object WebSocketMessages {
     createTaskMessage("task-update", taskData, userData)
 
   def teamUpdate(data: TeamUpdateData): TeamMessage = createTeamMessage("team-update", data)
+
+  def followUpdate(data: FollowUpdateData): FollowMessage =
+    createFollowMessage("follow-update", data)
 
   def userSummary(user: User): UserSummary =
     UserSummary(user.id, user.osmProfile.displayName, user.osmProfile.avatarURL)
@@ -136,6 +144,10 @@ object WebSocketMessages {
     TeamMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_TEAMS)))
   }
 
+  private def createFollowMessage(messageType: String, data: FollowUpdateData): FollowMessage = {
+    FollowMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_FOLLOWING)))
+  }
+
   // Reads for client messages
   implicit val clientMessageReads: Reads[ClientMessage]       = Json.reads[ClientMessage]
   implicit val subscriptionDataReads: Reads[SubscriptionData] = Json.reads[SubscriptionData]
@@ -148,12 +160,14 @@ object WebSocketMessages {
   implicit val notificationDataWrites: Writes[NotificationData] = Json.writes[NotificationData]
   implicit val notificationMessageWrites: Writes[NotificationMessage] =
     Json.writes[NotificationMessage]
-  implicit val reviewDataWrites: Writes[ReviewData]         = Json.writes[ReviewData]
-  implicit val reviewMessageWrites: Writes[ReviewMessage]   = Json.writes[ReviewMessage]
-  implicit val taskActionWrites: Writes[TaskAction]         = Json.writes[TaskAction]
-  implicit val taskMessageWrites: Writes[TaskMessage]       = Json.writes[TaskMessage]
-  implicit val teamUpdateDataWrites: Writes[TeamUpdateData] = Json.writes[TeamUpdateData]
-  implicit val teamMessageWrites: Writes[TeamMessage]       = Json.writes[TeamMessage]
+  implicit val reviewDataWrites: Writes[ReviewData]             = Json.writes[ReviewData]
+  implicit val reviewMessageWrites: Writes[ReviewMessage]       = Json.writes[ReviewMessage]
+  implicit val taskActionWrites: Writes[TaskAction]             = Json.writes[TaskAction]
+  implicit val taskMessageWrites: Writes[TaskMessage]           = Json.writes[TaskMessage]
+  implicit val teamUpdateDataWrites: Writes[TeamUpdateData]     = Json.writes[TeamUpdateData]
+  implicit val teamMessageWrites: Writes[TeamMessage]           = Json.writes[TeamMessage]
+  implicit val followUpdateDataWrites: Writes[FollowUpdateData] = Json.writes[FollowUpdateData]
+  implicit val followMessageWrites: Writes[FollowMessage]       = Json.writes[FollowMessage]
 
   // Available subscription types
   val SUBSCRIPTION_USER            = "user" // expected to be accompanied by user id
@@ -162,4 +176,5 @@ object WebSocketMessages {
   val SUBSCRIPTION_TASKS           = "tasks"
   val SUBSCRIPTION_CHALLENGE_TASKS = "challengeTasks" // expected to be accompanied by challenge id
   val SUBSCRIPTION_TEAMS           = "teams"
+  val SUBSCRIPTION_FOLLOWING       = "following"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ generateRoutesFile := {
       "virtualproject.api",
       "bundle.api",
       "team.api",
+      "follow.api",
       "v2.api"
     )
     println(s"Generating Routes File from ${routeFiles.mkString(",")}")

--- a/conf/evolutions/default/64.sql
+++ b/conf/evolutions/default/64.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+-- Add references to Following and Followers groups to users, as well as
+-- user setting for allowing others to follow them (defaults to yes)
+ALTER TABLE IF EXISTS users ADD COLUMN following_group INTEGER, ADD COLUMN followers_group INTEGER, ADD COLUMN allow_following BOOLEAN DEFAULT TRUE;;
+
+# --- !Downs
+-- remove Following and Followers type groups
+DELETE FROM groups WHERE group_type IN (2, 3);;
+ALTER TABLE IF EXISTS users DROP COLUMN following_group, DROP COLUMN followers_group, DROP COLUMN allow_following;;

--- a/conf/v2_route/data.api
+++ b/conf/v2_route/data.api
@@ -3,7 +3,7 @@ GET     /data/challenge/:challengeId/users          @org.maproulette.controllers
 ### NoDocs ###
 POST    /data/challenge/summary                     @org.maproulette.controllers.api.DataController.getChallengeSummaries(projectList:String ?= "", priority:String ?= "", onlyEnabled:Boolean ?= true)
 ### NoDocs ###
-GET     /data/user/activity                         @org.maproulette.controllers.api.DataController.getRecentUserActivity(limit:Int ?= -1, offset:Int ?= 0)
+GET     /data/user/activity                         @org.maproulette.controllers.api.DataController.getRecentUserActivity(osmUserIds:String ?= "", limit:Int ?= -1, offset:Int ?= 0)
 ### NoDocs ###
 GET     /data/user/summary                          @org.maproulette.controllers.api.DataController.getUserSummary(projectList:String ?= "", start:String ?= "", end:String ?= "", priority:Int ?= -1)
 ### NoDocs ###

--- a/conf/v2_route/follow.api
+++ b/conf/v2_route/follow.api
@@ -1,0 +1,101 @@
+###
+# tags: [ Follow ]
+# summary: Get users being followed by a user
+# description: Get users being followed by a user
+# responses:
+#   '200':
+#     description: The users followed by the specified user
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.User'
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the follower
+#     required: true
+###
+GET    /user/:userId/following                      @org.maproulette.framework.controller.FollowController.followedBy(userId: Long)
+
+###
+# tags: [ Follow ]
+# summary: Get users following a user
+# description: Get users following a user
+# responses:
+#   '200':
+#     description: The users following the specified user
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.User'
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user being followed
+#     required: true
+###
+GET    /user/:userId/followers                      @org.maproulette.framework.controller.FollowController.followersOf(userId: Long)
+
+###
+# tags: [ Follow ]
+# summary: Follow a user
+# description: Begin following a user's MapRoulette activity
+# responses:
+#   '200':
+#     description: Updated list of followed users
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.User'
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user to follow
+#     required: true
+###
+POST    /user/:userId/follow                        @org.maproulette.framework.controller.FollowController.follow(userId: Long)
+
+###
+# tags: [ Follow ]
+# summary: Stop following a user
+# description: Stop following a user's MapRoulette activity
+# responses:
+#   '200':
+#     description: Updated list of followed users
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.User'
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user to stop following
+#     required: true
+###
+DELETE /user/:userId/follow                         @org.maproulette.framework.controller.FollowController.unfollow(userId: Long)
+
+###
+# tags: [ Follow ]
+# summary: Block a follower
+# description: Prevent a user from following this user
+# responses:
+#   '200':
+#     description: Updated list of followers
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.User'
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user to block
+#     required: true
+###
+POST    /user/:userId/block                         @org.maproulette.framework.controller.FollowController.block(userId: Long)
+
+###
+# tags: [ Follow ]
+# summary: Stop blocking a follower
+# description: Remove block preventing a user from following this user
+# responses:
+#   '200':
+#     description: Updated list of followers
+#     schema:
+#       $ref: '#/definitions/org.maproulette.framework.model.User'
+# parameters:
+#   - name: userId
+#     in: path
+#     description: The id of the user to stop blocking
+#     required: true
+###
+DELETE /user/:userId/block                          @org.maproulette.framework.controller.FollowController.unblock(userId: Long)

--- a/postman/maproulette2.postman_collection.json
+++ b/postman/maproulette2.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "fe39a97c-9c4d-484f-bc2d-12b22ab895ce",
+		"_postman_id": "3a3eb254-8b59-43f0-b21a-5b82eff18cf1",
 		"name": "maproulette2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -22,7 +22,7 @@
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
 								],
-								"id": "2a91661f-5842-4113-8de4-98a0889832d0"
+								"id": "fe324c8b-540d-44de-b6bc-8851774e853c"
 							}
 						}
 					],
@@ -65,7 +65,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7a9bc2f5-2b3d-47e8-a3d9-1416754fb66c",
+								"id": "b5c6074c-d9fb-4ebd-9a64-b7f3c26d1e68",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -116,7 +116,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7f38c5f2-838a-4d58-a9e4-f895de7df6e0",
+								"id": "c86bfac1-c22a-47c4-9cf8-045f19e409d4",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID\", jsonData.id);",
@@ -168,7 +168,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2fec6077-0237-44ee-a12b-75c8cd7c0d38",
+								"id": "b30ed015-3add-4b7d-bf8a-0bd2e8f0e5fd",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -222,7 +222,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "69e0b4b9-b79d-480a-b943-b25f9125f0fb"
+								"id": "a59fb6ad-082a-4a6b-8e03-3132634109a6"
 							}
 						}
 					],
@@ -266,7 +266,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "19e92d88-56f4-4a5e-8cf6-9c1be1c46a6e",
+								"id": "78d5af0f-a4e4-4004-8d48-6ba82f2df346",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -319,7 +319,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "bd04c3a7-ae86-4911-ad3c-46fb59961a66"
+								"id": "38f216f9-fe84-4d16-9893-c7242e0c6ae4"
 							}
 						}
 					],
@@ -369,7 +369,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8e37adc8-b3ac-4222-9675-89542ab20abc",
+								"id": "c6fd875a-d99b-4649-995d-9311cd7dd66e",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TagsChallengeID\", jsonData.id);",
@@ -421,7 +421,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8cf122e8-0853-41ba-aecd-d8b32b244789",
+								"id": "7b1cb346-71c5-48e7-81c4-90466d1b5451",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -469,7 +469,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "535b6149-f433-46d3-b54f-d3fceb951ad0",
+								"id": "e7b91282-728f-4bf8-bab0-4b0a816d3037",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -519,7 +519,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1de25ffd-011d-463a-9407-58ad51f30de5",
+								"id": "57083094-5a92-458e-921b-8c901c8623a1",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -572,7 +572,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a567cf41-624a-4b76-997e-07b473b7ec49",
+								"id": "e642de3c-aef3-44f0-b814-2b5fcdcd3bca",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -620,7 +620,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5b8ff3da-4d29-44a1-9b0d-9a22d58f9cf7",
+								"id": "7afaf5c8-6542-4444-adb9-0af3f8717eb1",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -668,7 +668,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d8e5d353-d829-4cff-8dc6-ec25c5423d4a",
+								"id": "956934c3-6879-4574-ace8-2a268c9b0cd7",
 								"exec": [
 									"tests[\"response code is 201\"] = responseCode.code === 201;"
 								],
@@ -726,7 +726,7 @@
 									"tests[\"Task3\"] = jsonData[2].name === \"Task 3\";",
 									"tests[\"Task4\"] = jsonData[3].name === \"Task 4\";"
 								],
-								"id": "794af69b-5829-4b6e-979d-53bb51f4fe0b"
+								"id": "36d98e5a-2f6e-48d2-8d27-f092c26a55df"
 							}
 						}
 					],
@@ -767,7 +767,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0f32ccd4-7763-4f08-9fb3-b773be551817",
+								"id": "3f94c082-91f8-4cdb-aac8-da6fa6eb5cd8",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -825,7 +825,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "70cdc22c-5742-470e-93c6-2828fe554ba0",
+								"id": "24d28709-d691-4c88-9a91-be2c7fc92c07",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -877,7 +877,7 @@
 								"exec": [
 									"tests[\"response code is 204\"] = responseCode.code === 204;"
 								],
-								"id": "dfc01b90-8f03-46a5-b3bb-e5f7b8dfa769"
+								"id": "fb4dbeaf-cf27-4e8b-b787-3b8ae2f66e91"
 							}
 						}
 					],
@@ -934,7 +934,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"tag1\"] = jsonData[0].name === \"tag2\""
 								],
-								"id": "803bbc9d-7cbb-4235-a2f3-41712b3abe0f"
+								"id": "8b150ba1-33a2-4c4f-9c84-168f93fc1cdf"
 							}
 						}
 					],
@@ -975,7 +975,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "03143b99-96c8-41fd-a718-aca0fc4dfa5f",
+								"id": "f833dfc4-9317-47d5-a1ca-25231524b1c5",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1033,7 +1033,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "1360341f-9f6e-4bfc-a5e3-986a4ef739a1"
+								"id": "7bfc0f85-8ba5-41e7-83c1-e3fc2d42a5dd"
 							}
 						}
 					],
@@ -1083,7 +1083,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8e2c54f7-f6a2-46b1-9324-18889a2dc3cf",
+								"id": "ae37f9a2-e1d3-4830-9b88-e1135efffec1",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TagsTaskChallengeID\", jsonData.id);",
@@ -1134,7 +1134,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f35cfee7-a355-413c-8e12-3673b9f2b16e",
+								"id": "df8cde83-ff73-4376-8948-7ae4a8e9e701",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1193,7 +1193,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1ca8a48f-cec4-4c5e-9cff-acf97337010c",
+								"id": "0b654b14-f564-43f3-9930-ef1355852b81",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1255,7 +1255,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "e58f923f-63f8-435f-842b-6e6ec5e3b6d4"
+								"id": "60f818a0-e9a3-4e31-8f31-59c3bc49e43c"
 							}
 						}
 					],
@@ -1311,7 +1311,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "d1f7ea65-3650-4b31-8ae8-12f2d4a5baee"
+								"id": "7ef2e53d-2f5d-4bd5-8090-ddd5ff989ff7"
 							}
 						}
 					],
@@ -1375,7 +1375,7 @@
 									"tests[\"name\"] = jsonData.name === \"TestProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project.\";"
 								],
-								"id": "a33b1971-9efd-45b2-a4ed-0f51b2ae91bc"
+								"id": "d238187c-bd4a-4894-bec5-87ca4ec95a53"
 							}
 						}
 					],
@@ -1418,7 +1418,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "dca70b72-9536-4165-92a3-f9d050f79304",
+								"id": "ec7300c5-1d5c-4435-aeeb-0b8adcf4a9fa",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestChallenge\", jsonData.id);",
@@ -1470,7 +1470,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "29a35e8f-b055-4dc3-b6da-d8e38a784f39",
+								"id": "e178ba3b-1a2d-4a75-9335-b4917b3b8834",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1536,7 +1536,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a0a27f3a-4b45-41ee-b56c-96ea5ec11ed6",
+								"id": "76d42db5-e625-4d82-ade8-ef8a2f63359f",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1606,7 +1606,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "664bea2a-b7fe-436d-ad5c-234f3454c0ad",
+								"id": "25715c12-1e01-42c0-ad6a-55eb7cc0333c",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
@@ -1655,7 +1655,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fcb10290-bc01-4bb6-bb0e-cd8a28d109b0",
+								"id": "54dee9fc-cd3e-4a4c-ac64-48b172e021a7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
@@ -1709,7 +1709,7 @@
 									"tests[\"name\"] = jsonData.name === \"NewTask\";",
 									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction\";"
 								],
-								"id": "fb046b99-11c7-438d-ab3e-ab1468407493"
+								"id": "afcc3d5e-330a-43af-8396-9de2f7d4d50b"
 							}
 						}
 					],
@@ -1759,7 +1759,7 @@
 									"tests[\"name\"] = jsonData.name === \"NewTask\";",
 									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction\";"
 								],
-								"id": "89b4a5f9-f887-40ee-8bc6-0eddaea6432f"
+								"id": "5c1c62c0-045f-4ada-9b03-ae293c20ca43"
 							}
 						}
 					],
@@ -1799,7 +1799,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a08f1f74-a8ba-46db-9e18-40d84132730e",
+								"id": "0231f781-cf76-499d-b44f-6d07c3d9e566",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1850,7 +1850,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1792b3da-07c1-441c-bea7-3d0d7a25a264",
+								"id": "048ef65c-1bfd-429c-ae7e-ee6db43f1421",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1901,7 +1901,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2cad834e-1cba-4bdc-888a-b96398beee9d",
+								"id": "14b3bf11-ba10-4626-a0c0-ded5868087c8",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -1952,7 +1952,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "76eedb50-6c37-46dc-a43d-81d635603346",
+								"id": "7f0d0a42-1b08-4f81-a6a1-12823c411d37",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2002,7 +2002,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1ea37fe2-19db-424d-8b44-9b0514c33b84",
+								"id": "9185f21f-ae7b-4da5-8856-3afaa92befaf",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2054,7 +2054,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c9708400-c7c8-4261-9291-7939f4729b49",
+								"id": "c18773ba-b371-433c-abdc-4426a3e6982c",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2102,7 +2102,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8166ac82-a484-4c21-9973-e08012c5cc52",
+								"id": "6606bbee-477d-4dee-a1a2-e707f8daa2f6",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2154,7 +2154,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "345ecf17-bb23-4ead-a99a-5a1d1bcbca05",
+								"id": "23f30beb-91de-494d-8ddd-a3a9b4a2c386",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2209,7 +2209,7 @@
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"comment\"] = jsonData.comment === \"This is a comment\";"
 								],
-								"id": "3bef9dbb-bb10-47de-9b34-04f13778882c"
+								"id": "7fe29d51-f26d-4934-8002-03e8297febe8"
 							}
 						}
 					],
@@ -2262,7 +2262,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"comment\"] = jsonData.comment === \"This is an updated comment\";"
 								],
-								"id": "10cf9a24-c4ff-42d8-836c-faa6facc2f3b"
+								"id": "4378904e-1cf8-4ad5-a15e-ec2366850e47"
 							}
 						}
 					],
@@ -2314,7 +2314,7 @@
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"tests[\"comment\"] = jsonData.comment === \"This is a comment Number2\";"
 								],
-								"id": "9d2838f0-37ca-41cd-9fca-2b0ca1dfa5f6"
+								"id": "41b491ce-58ac-4dd4-853e-95fac22efaa9"
 							}
 						}
 					],
@@ -2367,7 +2367,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"comment\"] = jsonData.comment === \"This is an updated comment\";"
 								],
-								"id": "88295d97-f163-4513-8912-7cc104fb105f"
+								"id": "4a1330e4-7f6e-4c1f-99df-c556cad8c130"
 							}
 						}
 					],
@@ -2409,7 +2409,7 @@
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"Comment1\"] = jsonData.length == 2;"
 								],
-								"id": "911714f4-ae84-4032-9866-bad55c3302c7"
+								"id": "a25b737b-f8ef-440c-aa4f-6ab2b890982b"
 							}
 						}
 					],
@@ -2450,7 +2450,7 @@
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
-								"id": "093d8f02-22fb-4e5c-b7af-b8cca6f643be"
+								"id": "a36a7c1d-aeba-4bfc-a45b-07c926a3a4ec"
 							}
 						}
 					],
@@ -2492,7 +2492,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f0f05af3-2f1c-4ac2-a463-d951ea6fbe88",
+								"id": "ae5f7ce7-fb05-4de0-9a1f-eb48fdfff987",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -2543,7 +2543,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "08d76cb9-3d66-4653-af63-bb5c891400c0",
+								"id": "10ca121d-2b5f-471f-9dec-abd0c6002a43",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewTask1\", jsonData.id);",
@@ -2594,7 +2594,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "76f98fcf-04b5-4514-88e2-a94a07f0aba6",
+								"id": "002947fb-88d2-48e0-9a03-259644a1ee6e",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -2653,7 +2653,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "626394f8-4ac5-47ea-b4bb-ed9cbbda897e",
+								"id": "2d1a124f-b2f8-401d-a427-b42275743a6a",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -2710,7 +2710,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "94a7a309-e77f-447b-9121-6d0429e4b6a8",
+								"id": "89de62ef-b21d-44ac-b91e-08d0b58063d1",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -2766,7 +2766,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "8e1a40de-ae8c-41e1-91ff-01cae625028c"
+								"id": "e7e58683-aa44-4f36-bdf0-a54f5b5ffece"
 							}
 						}
 					],
@@ -2830,7 +2830,7 @@
 									"tests[\"name\"] = jsonData.name === \"TestProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project.\";"
 								],
-								"id": "151f7ab6-06e1-4fb2-a157-c485b24a8430"
+								"id": "eebbdfc3-203b-4920-b455-a72dd8a13454"
 							}
 						}
 					],
@@ -2873,7 +2873,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "beb3e4bc-0578-48ea-a9d4-6dd765ce63d3",
+								"id": "585b096d-b8e6-4318-a05f-4e9c30b0241b",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestChallenge\", jsonData.id);",
@@ -2933,7 +2933,7 @@
 									"tests[\"name\"] = jsonData.name === \"NewTask\";",
 									"tests[\"instruction\"] = jsonData.instruction === \"NewTask instruction\";"
 								],
-								"id": "9d78af29-d1d5-4711-bf18-b336c0bdbad6"
+								"id": "d7387ffe-b0d8-4868-a44d-8b61e2549c40"
 							}
 						}
 					],
@@ -2976,7 +2976,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1c23ad00-9152-4901-8baf-748898518097",
+								"id": "17e94870-eebd-4609-a740-b0576cac9b67",
 								"exec": [
 									""
 								],
@@ -3031,7 +3031,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "901ff811-f0c4-4206-a538-0ee6a08c8993",
+								"id": "1cda272e-2bbf-41b6-b9fe-6b66baa13d63",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3080,7 +3080,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "38959416-6269-4acc-808a-02423c3fb295",
+								"id": "5131ae29-4b45-4163-b9da-9576c9436b43",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3132,7 +3132,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "dbfc47ce-7d54-4bfa-ad61-f66c6cafbadc",
+								"id": "d6614ede-3216-4e99-95f6-f0d75de6926c",
 								"exec": [
 									""
 								],
@@ -3182,7 +3182,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e48fb1ba-dc4b-47a0-989a-64d6cdacfb98",
+								"id": "c6cc4c3b-53a9-48e3-a0cf-7083c017c44f",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3231,7 +3231,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bde9d121-e386-405b-9ab2-100879fd1c54",
+								"id": "0b9b70c1-2f57-446f-99e0-e0391b346275",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3283,7 +3283,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6fe84885-e0fe-4390-ad39-da77837f1baf",
+								"id": "c3931551-e14b-44d8-831d-e95a623deccb",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3345,7 +3345,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "00508854-8850-4667-b921-4b4c4f447164"
+								"id": "e386e2a2-c5ec-48ca-9249-8c8214be574c"
 							}
 						}
 					],
@@ -3401,7 +3401,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bcc397a4-7f01-4d02-bebc-d3b4cf373148",
+								"id": "02856af5-28e1-4485-9a41-4f76966d8d66",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3452,7 +3452,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1117fb10-95a1-4d11-ae42-b040e01612a2",
+								"id": "0ee4ddaf-152e-4cef-8d24-abd3ae8925db",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"pm.globals.set(\"TagsChallengeID\", jsonData.id);",
@@ -3504,7 +3504,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ad79b3b5-4180-4760-8193-e5c1d21c0532",
+								"id": "fea9385a-13e1-4f0a-8d67-ce6a205d4eb3",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -3559,7 +3559,7 @@
 									"tests[\"Task1\"] = jsonData[0].name === \"Task 1\";",
 									"tests[\"Task2\"] = jsonData[1].name === \"Task 2\";"
 								],
-								"id": "fc241772-8f20-425d-856d-cedb4557bd75"
+								"id": "a0153776-d35f-4954-86ac-86fcef6b0298"
 							}
 						}
 					],
@@ -3600,7 +3600,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f3080c2-aa33-49d1-b010-f55610634356",
+								"id": "5d9c502b-ade9-4b0d-8075-1727687f884d",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3649,7 +3649,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a6d37897-8179-46bb-b101-f63d4bc243fc",
+								"id": "2dd10d56-da72-46c4-9077-5a4dcb2c895d",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3690,7 +3690,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a2634624-0e08-4568-9163-b110f09776d7",
+								"id": "08d1c0a0-9b35-43a6-96fd-3535325dfcd1",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3731,7 +3731,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7aa8ee93-f2b4-4db1-9246-dba2956d3fcd",
+								"id": "5ce2baed-f910-4711-acb9-8c651ba0b2df",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3780,7 +3780,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0cef466c-7129-4d85-b67a-24cfbf891639",
+								"id": "9f894d29-09dc-4b79-bec7-6fb8efd2c841",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3820,7 +3820,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a2338543-10c6-46a6-b2c3-a9827e29ce71",
+								"id": "87e64f2b-8522-4d07-9933-88b1b08116d5",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3864,7 +3864,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bd24ded3-114f-43d6-b21e-f25131b71c6c",
+								"id": "d8ff007d-2380-4e72-97e7-fa505d8269d5",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3905,7 +3905,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0ebd16c5-2748-42b4-8282-11cf53680a9c",
+								"id": "c5ebb382-45f1-43eb-a6c7-831c88e9f0ad",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -3953,7 +3953,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "21e5e8cc-b6ca-4488-ad25-92447d63d3e9",
+								"id": "fd2a870c-f77a-4d89-901d-6e22d3f69c1d",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4001,7 +4001,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "23dd894c-c1c7-47d5-b67b-c744fa723c29",
+								"id": "10dae998-15dc-4bdd-816f-b6999ea44361",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -4056,7 +4056,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3e8bf3f2-4e2a-4411-8268-298d7ae08b35",
+								"id": "fc97d0dc-d141-415c-bd78-638a4d23444a",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4097,7 +4097,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0f8eb7e7-8390-4d0c-8d7d-68dc7dc44a74",
+								"id": "19348fea-f381-45f6-b0d8-9f219879968f",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4138,7 +4138,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "188702ce-f122-4f28-a996-235ce761b5c7",
+								"id": "b91327b8-9398-4340-99ef-bad5572e7df1",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4179,7 +4179,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "786cd864-3be0-4a9d-9e81-46a660dece51",
+								"id": "e39cda87-e184-4aea-8b07-f386aed0bd33",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4228,7 +4228,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "22ba221c-f09a-460f-89c1-15fd3ebb5172",
+								"id": "4039a91e-224d-4cc0-8390-4fc9bff6a960",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4270,7 +4270,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "81294983-4b39-4c0c-b7dd-d96beb611e82",
+								"id": "f41d8e03-dfc7-4aa3-9044-9d756f4dac2f",
 								"type": "text/javascript",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
@@ -4311,7 +4311,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6fdad0ca-8aec-4fc1-b9b0-0053297e96d2",
+								"id": "4c7d273b-ea78-4968-92c5-30551b9f77cc",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"pm.globals.set(\"VirtualChallengeID\", jsonData.id);",
@@ -4360,7 +4360,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a08c0fce-bd1b-4ad2-afe7-ee4b3717a346",
+								"id": "7c65793c-97f6-4ef9-ab96-513c7ad8a079",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 404\"] = responseCode.code === 404;"
@@ -4399,7 +4399,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9092c47c-06e2-4337-9577-c3bea3ba8390",
+								"id": "68ab666c-5b0e-4f99-a13a-58dc6089f706",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"pm.globals.set(\"VirtualChallengeID\", jsonData.id);",
@@ -4454,7 +4454,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "0433c75a-924b-47f9-b952-1355979b6794"
+								"id": "79e8ad70-cb2a-44bf-b65c-e2f1fba1334c"
 							}
 						}
 					],
@@ -4550,7 +4550,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c1dba463-5293-45f0-95a5-822055c2f749",
+								"id": "46075d9a-e77b-4fdf-8100-98c35d18ac2b",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleProjectID\", jsonData.id);",
@@ -4602,7 +4602,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a81d4983-72f7-45e6-830a-b516ebcbb5b9",
+								"id": "83697fd8-7afc-45bf-8dc2-bc36322896fb",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"ProjectWithChildren\", jsonData.id);",
@@ -4653,7 +4653,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "59fd33db-bf32-470a-8544-a7e98a3ad190",
+								"id": "97d38f49-051e-461f-99a4-d8e69ec918cf",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
@@ -4700,7 +4700,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "76b6ebaa-121a-4cf1-84f2-413d84f0ae24",
+								"id": "df8bf6bf-6809-412d-aec5-5e3a62258865",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4747,7 +4747,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "49474cd8-605e-4eb2-96ef-c036724e9e16",
+								"id": "b70c815c-cd62-427d-882f-e25a3d1ec983",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4797,7 +4797,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "45126818-4d94-43f6-8de4-62175d2761da",
+								"id": "984a1f92-c40f-4140-b972-c35a69d698a7",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -4854,7 +4854,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3a78c26b-e84f-4bca-a07c-bf864a629066",
+								"id": "ebe56beb-e81f-4bbf-9dcc-2e6b63edcc8f",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);"
@@ -4916,7 +4916,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "ab03c77c-50cc-43f9-9317-a6f2bcb11a05"
+								"id": "828e5280-acf5-462e-8149-64342f7ae08d"
 							}
 						}
 					],
@@ -4973,7 +4973,7 @@
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing. (Update)\";"
 								],
-								"id": "97808ea5-8a12-4bfa-80cd-eb122ecefb0c"
+								"id": "7a1de0a9-8437-4e6e-a297-9b6379df983b"
 							}
 						}
 					],
@@ -5024,7 +5024,7 @@
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing. (Update)\";"
 								],
-								"id": "4397b7f8-95e4-465d-b767-79fbf3ff7866"
+								"id": "35b96350-e9e1-4814-9045-6d309fbe8432"
 							}
 						}
 					],
@@ -5064,7 +5064,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9f543200-a0e7-4105-be87-e95ed903c500",
+								"id": "8d078d30-fe22-4b06-a1d9-260524b3e2b0",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5122,7 +5122,7 @@
 									"tests[\"Body matches name\"] = responseBody.has(\"SimpleProject\");",
 									"tests[\"Body matches description\"] = responseBody.has(\"Test project containing all children used for api testing. (Update)\");"
 								],
-								"id": "d3d4b156-004a-4d7b-aa58-24a63409d6e6"
+								"id": "849a106b-b9fc-4257-bc76-089b4cae1004"
 							}
 						}
 					],
@@ -5175,7 +5175,7 @@
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing. (Update)\";"
 								],
-								"id": "cca41c51-4731-4f3e-ad91-59c87f397a05"
+								"id": "e3c97d99-1325-49e9-a01c-c7679009b298"
 							}
 						}
 					],
@@ -5221,7 +5221,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "425c375f-d919-48ff-bd59-0d2335beb69b"
+								"id": "d99af622-1779-4bfb-b236-71899ef680d5"
 							}
 						}
 					],
@@ -5277,7 +5277,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "75f8b8cd-c986-48f1-8708-493d93608010",
+								"id": "b307d049-b109-4d7f-951d-759efcb78c05",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"VPProjectID\", jsonData.id);",
@@ -5329,7 +5329,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "88c3b11a-7075-4712-8e2a-f1a6bc118f5e",
+								"id": "d4a9b3c4-48b7-4dba-b610-0a6964ed478e",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleProjectID1\", jsonData.id);",
@@ -5380,7 +5380,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d3455a17-46ec-4184-92ad-c28c6c719d3c",
+								"id": "0421bbcb-f6e3-4f93-9e7f-ce8334413144",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID1\", jsonData.id);",
@@ -5432,7 +5432,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "ef863480-35e6-4925-98a7-fdd1b269eb2a",
+								"id": "1f210d7d-9a2f-41a3-b207-669661084666",
 								"exec": [
 									"tests[\"response code is 201\"] = responseCode.code === 200;",
 									""
@@ -5484,7 +5484,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "57034094-17bc-4fbb-883a-9de684ebc2c5",
+								"id": "a7ed228b-9acd-4661-95d4-4ca07fc03c8d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"tests[\"Body matches name\"] = responseBody.has(\"VPProject\");",
@@ -5535,7 +5535,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "80d5dbf9-7ac0-447c-bb05-f84de5e89e3a",
+								"id": "fce37bea-b698-4617-8f21-d92341939495",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5582,7 +5582,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "06a5ab2d-1119-4b99-b9a1-b89dc89ea167",
+								"id": "432cb8d9-bd76-4063-95ba-32ba520acec9",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -5629,7 +5629,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e8713d67-0177-484a-9adf-8385a802c541",
+								"id": "fa4fcf8c-016b-4ef6-ae2f-6da6d87397f4",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
@@ -5745,7 +5745,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2e89a173-287c-48a0-a6e0-d345d9dbc440",
+								"id": "4fa62eb6-0067-4dc6-b901-9269a41f6a5a",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5797,7 +5797,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "582d1e2c-0850-48f7-af83-7f9787ff171b",
+								"id": "4316d0b5-02fe-4880-a820-3ce252b5c76e",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5849,7 +5849,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "06810bc2-19c2-4376-8dba-dd577a2b1f92",
+								"id": "6f6e0f6b-befb-4280-ae31-7891ebd93803",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -5901,7 +5901,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fe5797f4-4feb-4af0-8837-03245bbde925",
+								"id": "3f69d33b-e675-4a4b-850d-9dfdb6af305f",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"pm.test(\"Body is correct\", function () {",
@@ -5955,7 +5955,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0b7e90c5-6041-477c-8152-602829d7905a",
+								"id": "41815074-9960-46c4-9c4f-cd48d027e5f0",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -6007,7 +6007,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "12be6990-6059-46bf-8662-3e02cb33a9c3",
+								"id": "646639fb-6937-4d6f-823e-d21bb5762c4c",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -6054,7 +6054,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "441188d1-65b5-4ffa-8ce7-ba69cfddf3d0",
+								"id": "05722fe1-7d42-4686-9d82-e01d4c701028",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -6110,7 +6110,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "43f4abc5-e5cd-440c-b69d-22cd7c8df61f",
+								"id": "a0f09b21-c238-401c-9a2a-1a8c8d88437f",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -6172,7 +6172,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a3b1c306-afc2-4d0e-9a2d-422e12d58246",
+								"id": "7a3ec0ae-d699-4823-9253-24e4d3f94ac9",
 								"exec": [
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -6230,7 +6230,7 @@
 									"tests[\"name\"] = jsonData.name === \"testtag1\";",
 									"tests[\"description\"] = jsonData.description === \"TestTag1 description\";"
 								],
-								"id": "7a0a923e-f31e-407d-a985-8ffabe379540"
+								"id": "5bfb6cc3-7f07-4049-b8b5-da74d4ce0e91"
 							}
 						}
 					],
@@ -6277,7 +6277,7 @@
 									"tests[\"name\"] = jsonData.name === \"updatedtesttag1\";",
 									"tests[\"description\"] = jsonData.description === \"Updated Tag description\";"
 								],
-								"id": "c713df71-0252-466d-a45f-e6d913b84983"
+								"id": "a5a9ea56-ba34-4c12-9c77-d03c318f5b0f"
 							}
 						}
 					],
@@ -6327,7 +6327,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "4c9b1cb1-573c-4d86-ac1c-5404eb787f3d"
+								"id": "f301e927-ec5c-4168-ae31-9fcc665dc108"
 							}
 						}
 					],
@@ -6377,7 +6377,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6d3669aa-e7a2-4fbd-a884-cd66895e2af5",
+								"id": "5731fd87-accd-44e9-ac5d-eea87c407701",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6430,7 +6430,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3c18b86c-b3f0-4e15-ace4-446c1a6b5a9a",
+								"id": "a75194e4-1b86-45b3-b986-834a0d4d3ec8",
 								"type": "text/javascript",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6474,6 +6474,142 @@
 			"protocolProfileBehavior": {}
 		},
 		{
+			"name": "Following",
+			"item": [
+				{
+					"name": "Get Following",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "45cc787f-6d64-44da-85fe-6981931f3d92",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"empty\"] = jsonData.id === [];"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/user/-999/following",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"user",
+								"-999",
+								"following"
+							]
+						},
+						"description": "Gets the users the super user is following"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Followers",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "7b1dee5f-5fba-4e01-ae64-92ce8441bf66",
+								"exec": [
+									"tests[\"response code is 200\"] = responseCode.code === 200;",
+									"var jsonData = JSON.parse(responseBody);",
+									"tests[\"empty\"] = jsonData.id === [];"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "apiKey",
+								"value": "test"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://localhost:9000/api/v2/user/-999/followers",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9000",
+							"path": [
+								"api",
+								"v2",
+								"user",
+								"-999",
+								"followers"
+							]
+						},
+						"description": "Gets the users following the super user"
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "e7949563-99b6-4eaf-9d16-1a48dcbfbfbd",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "c8c7c56d-4251-4eac-8446-f616e8f09c17",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
 			"name": "CooperativeWork",
 			"item": [
 				{
@@ -6482,7 +6618,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fa0f1dad-5323-4248-92c1-9fd10e1132ea",
+								"id": "edb8ce98-2b6d-4709-a371-e68a85e08ca9",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {",
 									"    pm.expect(pm.response.code).to.be.oneOf([200]);",
@@ -6562,7 +6698,7 @@
 									"tests[\"name\"] = jsonData.name === \"SimpleProject\";",
 									"tests[\"description\"] = jsonData.description === \"Test project containing all children used for api testing.\";"
 								],
-								"id": "f0655de2-828e-493e-a37c-5513e265d7fa"
+								"id": "6a150183-d8b8-4df3-b189-d9d302f0b972"
 							}
 						}
 					],
@@ -6605,7 +6741,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8cb790b5-bb25-4e36-91ff-77f67f99c1b0",
+								"id": "c7c911a0-4b91-46cc-9232-aca9b4ccab33",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID\", jsonData.id);",
@@ -6656,7 +6792,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "461dc094-b8ef-4f9d-9a8a-007cb6e8d07a",
+								"id": "a5024368-2dd5-4d77-915b-5099f4d4a50f",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SimpleChallengeID1\", jsonData.id);",
@@ -6707,7 +6843,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c6b14fd9-db8d-4d8f-9097-c77f7afc877d",
+								"id": "8f0c46bc-ab53-4c9e-b647-0cf4647081e5",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"SFTagID\", jsonData[0].id);",
@@ -6756,7 +6892,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fe152dc6-bf86-4422-b9a7-c1f9f6b7c493",
+								"id": "db0407bb-ad56-4d73-a63b-422b689044c4",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {",
 									"    pm.expect(pm.response.code).to.be.oneOf([200]);",
@@ -6832,7 +6968,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c8c4b30e-56c9-4fbf-a802-0507092c062e",
+								"id": "290a5678-6ca5-4fe0-8637-d05b49c4467a",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6879,7 +7015,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6e139508-ec97-4d85-9501-a02ec4dff2d5",
+								"id": "d763f75e-2230-46b6-a91c-55727638e540",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -6933,7 +7069,7 @@
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"Status\"] = jsonData.status === \"OK\";"
 								],
-								"id": "a975bd5a-c626-494e-8174-6793de1e793e"
+								"id": "a561d72e-6335-4835-842b-5152889ea681"
 							}
 						}
 					],
@@ -6989,7 +7125,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1a37dd1b-d59e-496e-9ecb-e3d682a3f1d2",
+								"id": "145c6bf3-d729-40e7-84e9-fa9351ef7954",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestBundleProject\", jsonData.id);",
@@ -7039,7 +7175,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9018e834-27f3-4b75-9b14-987a2110776e",
+								"id": "a5c33a6c-40c1-4b5d-9315-ca8b0e6ddef7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestBundleChallenge\", jsonData.id);",
@@ -7090,7 +7226,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "89711191-2bce-4544-acea-c0642b84da70",
+								"id": "9379b0f2-d14d-4b6f-a869-d03fd75041bf",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewTask1\", jsonData.id);",
@@ -7140,7 +7276,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "05b1017f-aa50-4871-8aa2-505bdd08e5b4",
+								"id": "bc20b05e-19d4-4a40-87ee-786e6e1c19d4",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewTask2\", jsonData.id);",
@@ -7190,7 +7326,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9ac992ba-af94-4aad-aa4f-25931b328ffa",
+								"id": "ebefc973-9b1b-400d-9ca1-43b2331ad6f7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewBundle\", jsonData.bundleId);",
@@ -7239,7 +7375,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "6c43123f-3c65-4ebc-a68c-4ce3e26c9817",
+								"id": "f68a6071-35f5-4e1f-9f43-7d553a4e133c",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"NewComment\", jsonData.id);",
@@ -7291,7 +7427,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5549ecab-74f2-450d-b5a9-d947fceb377f",
+								"id": "77619def-7485-4ef4-84f4-5d6f50189f0e",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7355,7 +7491,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f0b8f257-0237-4f65-8211-fdb5825b171a",
+								"id": "a438bcb6-f965-4312-a159-bec736d5cfa1",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7402,7 +7538,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "40f44926-d372-4e50-b769-c699489290a0",
+								"id": "88e4b7fd-10be-49e0-9ea4-b86d31d58510",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 400\"] = responseCode.code === 400;",
@@ -7450,7 +7586,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "35861575-10d6-4bf1-bb86-a30836752c64",
+								"id": "a8d420e5-f8a9-41ae-be6c-d2c290f6f87d",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 400\"] = responseCode.code === 400;",
@@ -7510,7 +7646,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "faa96c2e-b986-44b2-bcb2-8aa724c27f58",
+								"id": "e03a9f7f-8be1-4d62-a004-5a1085afcaa1",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7559,7 +7695,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8ccadf25-331f-4977-92b3-74003f8bf621",
+								"id": "9b3adbbd-12e8-411f-a0ab-4ec309704c0f",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7607,7 +7743,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "97513443-6811-4905-848f-bd627896fea2",
+								"id": "dce09935-e347-4c0f-a898-20997c91f1c7",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7668,7 +7804,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7611ff51-dc8a-406f-ae4b-b6e02924c31e",
+								"id": "ec363d52-0dea-464b-b0e9-37069dfdb95d",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7716,7 +7852,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8a30e337-fe69-4c4c-a464-b1fd40cd30bc",
+								"id": "2b0ae431-1e7c-4741-9fa3-67b6df263190",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7762,7 +7898,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1f72b20f-1674-49c9-a563-c8083797a534",
+								"id": "48361cb8-04dd-4968-836a-69a46dc0b510",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -7822,7 +7958,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "25ba7fe4-d1cf-4b42-8c92-bc3c4658a9ea",
+								"id": "d9b2c1d3-fc0b-44d3-b367-a9f6936d3292",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -7876,7 +8012,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "03c78f09-bc8a-4e88-8d67-4e487eca298d",
+								"id": "afdc9e9f-79ab-4218-8ad9-cdf70fa9c4d0",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -7937,7 +8073,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "560523f6-4e77-4ed7-b91e-a04905a29b36",
+								"id": "fc1cf417-3ced-4116-8a01-b27affe1fd71",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TestTeam\", jsonData.id);",
@@ -7995,7 +8131,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "a1f2b843-1522-454c-a40f-8429e3ef8911",
+								"id": "a5fd1ff4-83fd-4daf-82ff-ca89b7fe213a",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -8008,7 +8144,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "e2296478-d714-4a2c-b773-098c3ffa4106",
+								"id": "2297ad2f-e21f-4f15-b144-a12a74088d67",
 								"exec": [
 									""
 								],
@@ -8063,7 +8199,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9fafe2ad-c058-4b8a-8a02-1513ae1281c7",
+								"id": "474d18e0-b9fc-4366-9094-45af445c4f53",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -8115,7 +8251,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "743d20fb-7d78-48a3-b748-d391a89ea21a",
+								"id": "98023769-dd58-443b-a19b-f03ca8b8e132",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 201\"] = responseCode.code === 201;",
@@ -8173,7 +8309,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "06381495-8ac6-408b-bea1-8cde990be5c7",
+								"id": "642298d2-1d9b-41df-ab41-ddfa4b008909",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -8229,7 +8365,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d42fa429-2574-478f-bc72-6aab9d4aaed7",
+								"id": "412dbde4-ecdd-4652-8beb-2100945ad520",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"postman.setGlobalVariable(\"TeamProject\", jsonData.id);",
@@ -8279,7 +8415,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "48e3b1c9-2000-4d6c-b7cc-84ed9a8748da",
+								"id": "726ed35e-8ea2-4492-9aa0-e541a9b8ff8d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -8329,7 +8465,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "44a05e40-432e-4b02-ac6f-5bbb5e7a7c44",
+								"id": "79809ea8-81e5-4698-b3ad-70a60c674e06",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -8378,7 +8514,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "35e941d3-0d62-4305-8496-73452de95ef9",
+								"id": "c1c87302-4070-4751-9d33-c9a542f7980d",
 								"exec": [
 									"var jsonData = JSON.parse(responseBody);",
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
@@ -8430,7 +8566,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7ae508d8-eba6-49fb-a1dd-92d0ba26697a",
+								"id": "6823c5ad-c0f3-4779-a4ca-7bc8e81354f1",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -8480,7 +8616,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "52c7b98b-ad22-472d-8cbe-b41acefd4873",
+								"id": "0a6354db-c04c-49d3-adbd-9f0c96a1097d",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -8529,7 +8665,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "629c87dd-ad55-4983-ad6b-8c58dca3ea4b",
+								"id": "0daefbb3-d4fa-4bf5-b9c7-5e30e8db2ce9",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									""
@@ -8578,7 +8714,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9ec6df4d-9599-4181-81d0-e34a94177e82",
+								"id": "d800edbe-43b5-452a-b03b-a6715a309f0e",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",
@@ -8627,7 +8763,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "dae6bdf7-d5bd-4b6e-b9a1-0a531d386037",
+								"id": "a1c2b113-c2b0-4da2-811f-ca6f7e6126cd",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
@@ -8673,7 +8809,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3e4d87a9-749e-4d90-8689-f514e35892b1",
+								"id": "525cbd66-bc93-41e3-9d38-4adc89ddca2e",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;"
 								],
@@ -8719,7 +8855,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9355fa0b-7258-481e-8a7e-46285d3e631c",
+								"id": "f2c36863-1de7-4d3b-8b53-14d910907f7f",
 								"exec": [
 									"tests[\"response code is 200\"] = responseCode.code === 200;",
 									"var jsonData = JSON.parse(responseBody);",

--- a/test/org/maproulette/framework/service/FollowServiceSpec.scala
+++ b/test/org/maproulette/framework/service/FollowServiceSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import org.maproulette.framework.model._
+import org.maproulette.framework.util.{FrameworkHelper, UserTag}
+import org.maproulette.exception.{InvalidException}
+import org.scalatest.Matchers._
+import play.api.libs.json.Json
+import play.api.Application
+
+/**
+  * @author nrotstan
+  */
+class FollowServiceSpec(implicit val application: Application) extends FrameworkHelper {
+  val userService: UserService     = this.serviceManager.user
+  val followService: FollowService = this.serviceManager.follow
+
+  "FollowService" should {
+    "retrieve a user's Following group, creating it if necessary" taggedAs UserTag in {
+      val insertedUser =
+        this.userService.create(this.getTestUser(21, "FollowingGroupTest"), User.superUser)
+
+      insertedUser.followingGroupId mustEqual None
+      val followingGroup = this.followService.getFollowingGroup(insertedUser, User.superUser)
+      followingGroup.groupType mustEqual Group.GROUP_TYPE_FOLLOWING
+      followingGroup.name mustEqual s"User ${insertedUser.id} Following"
+
+      this.userService
+        .retrieve(insertedUser.id)
+        .get
+        .followingGroupId
+        .get mustEqual followingGroup.id
+
+      val groupAgain = this.followService.getFollowingGroup(insertedUser, User.superUser)
+      groupAgain.id mustEqual followingGroup.id
+    }
+
+    "retrieve a user's Followers group, creating it if necessary" taggedAs UserTag in {
+      val insertedUser =
+        this.userService.create(this.getTestUser(22, "FollowersGroupTest"), User.superUser)
+
+      insertedUser.followersGroupId mustEqual None
+      val followersGroup = this.followService.getFollowersGroup(insertedUser, User.superUser)
+      followersGroup.groupType mustEqual Group.GROUP_TYPE_FOLLOWERS
+      followersGroup.name mustEqual s"User ${insertedUser.id} Followers"
+
+      this.userService
+        .retrieve(insertedUser.id)
+        .get
+        .followersGroupId
+        .get mustEqual followersGroup.id
+
+      val groupAgain = this.followService.getFollowersGroup(insertedUser, User.superUser)
+      groupAgain.id mustEqual followersGroup.id
+    }
+
+    "follow a user" taggedAs UserTag in {
+      val firstUser =
+        this.userService.create(this.getTestUser(23, "FollowUserTest1"), User.superUser)
+      val secondUser =
+        this.userService.create(this.getTestUser(24, "FollowUserTest2"), User.superUser)
+      val thirdUser =
+        this.userService.create(this.getTestUser(25, "FollowUserTest3"), User.superUser)
+
+      this.followService.follow(firstUser, secondUser, User.superUser)
+      val followers = this.followService.getUserFollowers(secondUser.id, User.superUser)
+      followers.size mustEqual 1
+      followers.head.user.id mustEqual firstUser.id
+
+      val followed = this.followService.getUsersFollowedBy(firstUser.id, User.superUser)
+      followed.size mustEqual 1
+      followed.head.id mustEqual secondUser.id
+
+      this.followService.follow(thirdUser, firstUser, User.superUser)
+      this.followService.follow(thirdUser, secondUser, User.superUser)
+
+      this.followService.getUserFollowers(firstUser.id, User.superUser).size mustEqual 1
+      this.followService.getUserFollowers(secondUser.id, User.superUser).size mustEqual 2
+      this.followService.getUserFollowers(thirdUser.id, User.superUser).size mustEqual 0
+    }
+
+    "stop following a user" taggedAs UserTag in {
+      val firstUser =
+        this.userService.create(this.getTestUser(26, "UnfollowUserTest1"), User.superUser)
+      val secondUser =
+        this.userService.create(this.getTestUser(27, "UnfollowUserTest2"), User.superUser)
+      val thirdUser =
+        this.userService.create(this.getTestUser(28, "UnfollowUserTest3"), User.superUser)
+
+      this.followService.follow(firstUser, secondUser, User.superUser)
+      this.followService.follow(thirdUser, firstUser, User.superUser)
+      this.followService.follow(thirdUser, secondUser, User.superUser)
+
+      this.followService.getUserFollowers(firstUser.id, User.superUser).size mustEqual 1
+      this.followService.getUserFollowers(secondUser.id, User.superUser).size mustEqual 2
+      this.followService.getUserFollowers(thirdUser.id, User.superUser).size mustEqual 0
+
+      this.followService.stopFollowing(firstUser, secondUser, User.superUser)
+      this.followService.getUserFollowers(secondUser.id, User.superUser).size mustEqual 1
+
+      this.followService.stopFollowing(thirdUser, secondUser, User.superUser)
+      this.followService.getUserFollowers(secondUser.id, User.superUser).size mustEqual 0
+    }
+
+    "not allow following a user who has opted out" taggedAs UserTag in {
+      val insertedUser = this.userService
+        .update(
+          this.userService.create(this.getTestUser(29, "FollowOptOutUserTest"), User.superUser).id,
+          Json.parse(s"""{"settings": {"allowFollowing": false}}"""),
+          User.superUser
+        )
+        .get
+
+      an[InvalidException] should be thrownBy
+        this.followService.follow(this.defaultUser, insertedUser, User.superUser)
+
+      val updatedUser = this.userService.update(
+        insertedUser.id,
+        Json.parse(s"""{"settings": {"allowFollowing": true}}"""),
+        User.superUser
+      )
+
+      this.followService.follow(this.defaultUser, updatedUser.get, User.superUser)
+      this.followService.getUserFollowers(insertedUser.id, User.superUser).size mustEqual 1
+    }
+
+    "block and unblock a follower" taggedAs UserTag in {
+      val firstUser =
+        this.userService.create(this.getTestUser(30, "BlockFollowerTest1"), User.superUser)
+      val secondUser =
+        this.userService.create(this.getTestUser(31, "BlockFollowerTest2"), User.superUser)
+
+      this.followService.follow(secondUser, firstUser, User.superUser)
+      this.followService
+        .getUserFollowers(firstUser.id, User.superUser)
+        .head
+        .status mustEqual Follower.STATUS_FOLLOWING
+
+      this.followService.blockFollower(secondUser.id, firstUser, User.superUser)
+      this.followService
+        .getUserFollowers(firstUser.id, User.superUser)
+        .head
+        .status mustEqual Follower.STATUS_BLOCKED
+
+      this.followService.unblockFollower(secondUser.id, firstUser, User.superUser)
+      this.followService
+        .getUserFollowers(firstUser.id, User.superUser)
+        .head
+        .status mustEqual Follower.STATUS_FOLLOWING
+    }
+
+    "remove all existing followers when opting out of following" taggedAs UserTag in {
+      val firstUser =
+        this.userService.create(this.getTestUser(32, "OptOutWithFollowersTest1"), User.superUser)
+      val secondUser =
+        this.userService.create(this.getTestUser(33, "OptOutWithFollowersTest2"), User.superUser)
+
+      this.followService.follow(secondUser, firstUser, User.superUser)
+      this.followService.getUserFollowers(firstUser.id, User.superUser).size mustEqual 1
+      this.followService.getUsersFollowedBy(secondUser.id, User.superUser).size mustEqual 1
+
+      this.userService.update(
+        firstUser.id,
+        Json.parse(s"""{"settings": {"allowFollowing": false}}"""),
+        User.superUser
+      )
+      this.followService.getUserFollowers(firstUser.id, User.superUser).isEmpty mustEqual true
+      this.followService.getUsersFollowedBy(secondUser.id, User.superUser).isEmpty mustEqual true
+    }
+  }
+
+  override implicit val projectTestName: String = "FollowServiceSpecProject"
+}

--- a/test/org/maproulette/framework/service/UserServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserServiceSpec.scala
@@ -133,6 +133,30 @@ class UserServiceSpec(implicit val application: Application) extends FrameworkHe
       newAPIUser.get.apiKey must not be insertedUser.apiKey
     }
 
+    "add a user's Following group" taggedAs UserTag in {
+      val insertedUser =
+        this.userService.create(this.getTestUser(21, "AddFollowingGroupTest"), User.superUser)
+
+      insertedUser.followingGroupId mustEqual None
+      val followingGroupId = this.userService.addFollowingGroup(insertedUser, User.superUser)
+      followingGroupId.isDefined mustEqual true
+
+      val groupAgain = this.userService.addFollowingGroup(insertedUser, User.superUser)
+      groupAgain.get mustEqual followingGroupId.get
+    }
+
+    "add a user's Followers group" taggedAs UserTag in {
+      val insertedUser =
+        this.userService.create(this.getTestUser(22, "AddFollowersGroupTest"), User.superUser)
+
+      insertedUser.followersGroupId mustEqual None
+      val followersGroupId = this.userService.addFollowersGroup(insertedUser, User.superUser)
+      followersGroupId.isDefined mustEqual true
+
+      val groupAgain = this.userService.addFollowersGroup(insertedUser, User.superUser)
+      groupAgain.get mustEqual followersGroupId.get
+    }
+
     "retrieve list of users" taggedAs UserTag in {
       val user1 =
         this.userService.create(this.getTestUser(12, "ListRetrievalTestUser1"), User.superUser)

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -130,6 +130,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     taskClusterDAL,
     statusActionManager
   )
+  val followService            = mock[FollowService]
   val grantService             = mock[GrantService]
   val commentService           = mock[CommentService]
   val challengeService         = mock[ChallengeService]
@@ -146,6 +147,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     Providers.of[ProjectService](projectService),
     Providers.of[GrantService](grantService),
     Providers.of[UserService](userService),
+    Providers.of[FollowService](followService),
     Providers.of[GroupService](groupService),
     Providers.of[CommentService](commentService),
     Providers.of[TagService](tagService),


### PR DESCRIPTION
* Allow users to follow other users, using Groups to keep track of who a
user is following and who is following them

* Dynamically generate "following" and "followers" groups as needed for
a user when they begin following or are initially followed, respectively

* Allow users to block individual followers

* Add a new allows_following user field that can be used to disallow all
following of a user

* Fix bug in Teams that caused non-team groups to get picked up in some
situations

* Minor enhancements to Groups service