### PR TITLE
Apply bounds priority rules on challenge create

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -114,6 +114,11 @@ class ChallengeController @Inject() (
     }
     // we need to elevate the user permissions to super users to extract and create the tags
     this.extractTags(body, createdObject, User.superUser)
+
+    //we need to reapply task priority rules since task locations were updated
+    Future {
+      this.dal.updateTaskPriorities(user)(createdObject.id)
+    }
   }
 
   /**


### PR DESCRIPTION
When creating a challenge, apply priority rules again after
creating tasks so that location will be present for any
bounds check.