### PR TITLE
Add support for fetch nearby review tasks.

### DIFF
--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -118,6 +118,31 @@ class TaskReviewController @Inject() (
     }
 
   /**
+    * Gets tasks near the given task id within the given challenge
+    *
+    * @param challengeId  The challenge id that is the parent of the tasks that you would be searching for
+    * @param proximityId  Id of task for which nearby tasks are desired
+    * @param excludeSelfLocked Also exclude tasks locked by requesting user
+    * @param limit        The maximum number of nearby tasks to return
+    * @return
+    */
+  def getNearbyReviewTasks(
+      proximityId: Long,
+      limit: Int,
+      excludeOtherReviewers: Boolean = false,
+      onlySaved: Boolean = false
+  ): Action[AnyContent] = Action.async { implicit request =>
+    this.sessionManager.userAwareRequest { implicit user =>
+      SearchParameters.withSearch { params =>
+        val results = this.service
+          .getNearbyReviewTasks(User.userOrMocked(user), params, proximityId, limit,
+                                excludeOtherReviewers, onlySaved)
+        Ok(Json.toJson(results))
+      }
+    }
+  }
+
+  /**
     * Gets reviewed tasks where the user has reviewed or requested review
     *
     * @param reviewTasksType - 1: To Be Reviewed 2: User's reviewed Tasks 3: All reviewed by users

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -135,8 +135,14 @@ class TaskReviewController @Inject() (
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { params =>
         val results = this.service
-          .getNearbyReviewTasks(User.userOrMocked(user), params, proximityId, limit,
-                                excludeOtherReviewers, onlySaved)
+          .getNearbyReviewTasks(
+            User.userOrMocked(user),
+            params,
+            proximityId,
+            limit,
+            excludeOtherReviewers,
+            onlySaved
+          )
         Ok(Json.toJson(results))
       }
     }
@@ -220,7 +226,7 @@ class TaskReviewController @Inject() (
 
     prioritiesToFetch.foreach(p => {
       val newParams =
-        params.copy(reviewParams = params.reviewParams.copy(priorities = Some(List(p))))
+        params.copy(taskParams = params.taskParams.copy(taskPriorities = Some(List(p))))
 
       val pResult = this.service.getReviewMetrics(
         user,

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -1,0 +1,495 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+package org.maproulette.framework.mixins
+
+import anorm.NamedParameter
+import org.maproulette.session.{SearchParameters, SearchLocation}
+import org.maproulette.framework.psql.SQLUtils
+import org.maproulette.framework.psql.filter._
+import org.maproulette.framework.psql.{AND, OR}
+import play.api.libs.json.JsDefined
+
+import scala.collection.mutable.ListBuffer
+
+trait SearchParametersMixin {
+
+  /**
+    * Filters by p.display_name with a like %projectSearch%
+    * @param params with inverting on 'ps'
+    */
+  def filterProjectSearch(params: SearchParameters): Parameter[String] = {
+    FilterParameter.conditional(
+      "display_name",
+      s"'${SQLUtils.search(params.projectSearch.getOrElse("").replace("'", "''"))}'",
+      Operator.LIKE,
+      params.invertFields.getOrElse(List()).contains("ps"),
+      true,
+      params.projectSearch != None,
+      Some("p")
+    )
+  }
+
+  /**
+    * Filters by tasks.location with a @ MAKE_ENVELOPE etc.
+    * @param params with inverting on 'tbb'
+    */
+  def filterLocation(params: SearchParameters): Parameter[String] = {
+    this.locationSearch(
+      "location",
+      params.location,
+      "tasks",
+      params.invertFields.getOrElse(List()).contains("tbb")
+    )
+  }
+
+  /**
+    * Filters by c.bounding with a @ MAKE_ENVELOPE etc.
+    * @param params with inverting on 'bb'
+    */
+  def filterBounding(params: SearchParameters): Parameter[String] = {
+    this.locationSearch(
+      "bounding",
+      params.bounding,
+      "c",
+      params.invertFields.getOrElse(List()).contains("bb")
+    )
+  }
+
+  /**
+    * Filters by tasks.status
+    * @param params with inverting on 'tStatus'
+    * @param defaultStatus - used when no params.taskStatus is given, if you want to use all statuses
+    *                        in this case pass in List()
+    */
+  def filterTaskStatus(
+      params: SearchParameters,
+      defaultStatuses: List[Int] = List(0, 3, 6)
+  ): Parameter[String] = {
+    // Do not filter if taskStatus list has -1 or list is empty
+    val dontFilter =
+      params.taskParams.taskStatus.getOrElse(defaultStatuses).isEmpty ||
+        params.taskParams.taskStatus.getOrElse(defaultStatuses).contains(-1)
+
+    FilterParameter.conditional(
+      "status",
+      // If taskStatus is not present then default taskStatus to 0,3,6
+      params.taskParams.taskStatus.getOrElse(defaultStatuses).mkString(","),
+      Operator.IN,
+      params.invertFields.getOrElse(List()).contains("tStatus"),
+      true,
+      !dontFilter,
+      Some("tasks")
+    )
+  }
+
+  /**
+    * Filters by tasks.id
+    * @param params with inverting on 'tid'
+    */
+  def filterTaskId(params: SearchParameters): Parameter[String] = {
+    val invert = if (params.invertFields.getOrElse(List()).contains("tid")) "NOT " else ""
+
+    params.taskParams.taskId match {
+      case Some(tid) =>
+        CustomParameter(s"${invert}CAST(tasks.id AS TEXT) LIKE '${tid}%'")
+      case _ => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters by tasks.priority
+    * @param params with inverting on 'priorities'
+    */
+  def filterTaskPriorities(params: SearchParameters): Parameter[String] = {
+    FilterParameter.conditional(
+      "priority",
+      params.taskParams.taskPriorities.getOrElse(List()).mkString(","),
+      Operator.IN,
+      params.invertFields.getOrElse(List()).contains("priorities"),
+      true,
+      params.taskParams.taskPriorities != None &&
+        !params.taskParams.taskPriorities.getOrElse(List()).isEmpty,
+      Some("tasks")
+    )
+  }
+
+  /**
+    * Filters by tasks.priority
+    * @param params with inverting on 'tp'
+    */
+  def filterPriority(params: SearchParameters): Parameter[String] = {
+    FilterParameter.conditional(
+      "priority",
+      params.priority.getOrElse("").toString,
+      Operator.EQ,
+      params.invertFields.getOrElse(List()).contains("tp"),
+      true,
+      params.priority != None &&
+        (params.priority.get == 0 || params.priority.get == 1 || params.priority.get == 2),
+      Some("tasks")
+    )
+  }
+
+  /**
+    * Filters by task tags
+    * @param params with inverting on 'tt'
+    */
+  def filterTaskTags(params: SearchParameters): Parameter[String] = {
+    if (params.hasTaskTags) {
+      val tagList = params.taskParams.taskTags.get
+        .map(t => {
+          SQLUtils.testColumnName(t)
+          s"'${t}'"
+        })
+        .mkString(",")
+
+      val invert = if (params.invertFields.getOrElse(List()).contains("tt")) "NOT " else ""
+
+      CustomParameter(
+        s"""${invert}tasks.id IN (SELECT task_id from tags_on_tasks tt
+              | INNER JOIN tags ON tags.id = tt.tag_id
+              | WHERE tags.name IN (${tagList}))
+        """.stripMargin
+      )
+    } else {
+      CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters by task review status
+    * @param params with inverting on 'trStatus'
+    */
+  def filterTaskReviewStatus(params: SearchParameters): Parameter[String] = {
+    params.taskParams.taskReviewStatus match {
+      case Some(statuses) if statuses.nonEmpty =>
+        val invert = params.invertFields.getOrElse(List()).contains("trStatus")
+        val filter = new StringBuilder(s"""${if (invert) "NOT " else ""}(tasks.id IN
+              | (SELECT task_id FROM task_review
+              | WHERE task_review.task_id = tasks.id AND task_review.review_status
+              | IN (${statuses.mkString(",")}))""".stripMargin)
+        if (statuses.contains(-1)) {
+          filter.append(s""" OR tasks.id NOT IN (SELECT task_id FROM task_review task_review
+              | WHERE task_review.task_id = tasks.id)""".stripMargin)
+        }
+        filter.append(")")
+        CustomParameter(filter.toString())
+      case Some(statuses) if statuses.isEmpty => CustomParameter("")
+      case _                                  => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters by c.difficulty
+    * @param params with inverting on 'cd'
+    */
+  def filterChallengeDifficulty(params: SearchParameters): Parameter[String] = {
+    FilterParameter.conditional(
+      "difficulty",
+      params.challengeParams.challengeDifficulty.getOrElse("").toString,
+      Operator.EQ,
+      params.invertFields.getOrElse(List()).contains("cd"),
+      true,
+      params.challengeParams.challengeDifficulty != None,
+      Some("c")
+    )
+  }
+
+  /**
+    * Filters by c.status
+    * @param params with inverting on 'cStatus'
+    */
+  def filterChallengeStatus(params: SearchParameters): FilterGroup = {
+    val searchList = params.challengeParams.challengeStatus.getOrElse(List())
+    val invert     = params.invertFields.getOrElse(List()).contains("cStatus")
+
+    FilterGroup(
+      List(
+        BaseParameter(
+          "status",
+          searchList.mkString(","),
+          Operator.IN,
+          invert,
+          true,
+          Some("c")
+        ),
+        FilterParameter.conditional(
+          "status",
+          None,
+          Operator.NULL,
+          invert,
+          true,
+          searchList.contains(-1),
+          Some("c")
+        )
+      ),
+      (if (invert) AND() else OR()),
+      params.challengeParams.challengeStatus != None
+    )
+  }
+
+  /**
+    * Filters by c.requires_local
+    */
+  def filterChallengeRequiresLocal(params: SearchParameters): FilterGroup = {
+    FilterGroup(
+      List(
+        params.challengeParams.challengeIds match {
+          case Some(ids) if ids.nonEmpty => CustomParameter("")
+          // do nothing, we don't want to restrict to requiresLocal if we have
+          // specific challenge ids
+          case _ =>
+            params.challengeParams.requiresLocal match {
+              case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE) =>
+                BaseParameter(
+                  "requires_local",
+                  None,
+                  Operator.BOOL,
+                  true, // negate
+                  table = Some("c")
+                )
+              case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY) =>
+                BaseParameter(
+                  "requires_local",
+                  None,
+                  Operator.BOOL,
+                  false, // don't negate
+                  table = Some("c")
+                )
+              case _ => CustomParameter("")
+            }
+        }
+      )
+    )
+  }
+
+  /**
+    * Filters on tasks.location @ GEOMETRY
+    */
+  def filterBoundingGeometries(params: SearchParameters): Parameter[String] = {
+    params.boundingGeometries match {
+      case Some(bp) =>
+        val allPolygons = new StringBuilder()
+        bp.foreach(value =>
+          value \ "bounding" match {
+            case locationJSON: JsDefined => {
+              val polygonLinestring = new StringBuilder()
+              if (allPolygons.toString() != "")
+                allPolygons.append(" OR ")
+
+              (locationJSON \ "type").as[String] match {
+                case "Polygon" => {
+                  (locationJSON \ "coordinates")
+                    .as[List[List[List[Double]]]]
+                    .foreach(p =>
+                      p.foreach(coordinates => {
+                        if (polygonLinestring.toString() != "")
+                          polygonLinestring.append(",")
+                        polygonLinestring.append(s"${coordinates.head} ${coordinates(1)}")
+                      })
+                    )
+                  allPolygons.append(
+                    s"tasks.location @ ST_MakePolygon( ST_GeomFromText('LINESTRING($polygonLinestring)'))"
+                  )
+                }
+                case "LineString" => {
+                  (locationJSON \ "coordinates")
+                    .as[List[List[Double]]]
+                    .foreach(coordinates => {
+                      if (polygonLinestring.toString() != "") {
+                        polygonLinestring.append(",")
+                      }
+                      polygonLinestring.append(s"${coordinates.head} ${coordinates(1)}")
+                    })
+                  allPolygons.append(
+                    s"tasks.location @ ST_GeomFromText('LINESTRING($polygonLinestring)')"
+                  )
+                }
+                case "Point" => {
+                  val coordinates = (locationJSON \ "coordinates").as[List[Double]]
+                  allPolygons.append(
+                    s"tasks.location @ ST_GeomFromText('POINT(${coordinates.head} ${coordinates(1)})')"
+                  )
+                }
+                case _ => // do nothing
+              }
+            }
+            case _ => // do nothing
+          }
+        )
+        CustomParameter("(" + allPolygons.toString + ")")
+      case _ => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters on tasks features
+    */
+  def filterTaskProps(params: SearchParameters): Parameter[String] = {
+    params.getChallengeIds match {
+      case Some(l) =>
+        params.taskParams.taskPropertySearch match {
+          case Some(tps) =>
+            val query = new StringBuilder(s"""tasks.id IN (
+                | SELECT id FROM tasks,
+                | jsonb_array_elements(geojson->'features') features
+                | WHERE parent_id IN (${l.mkString(",")})
+                | AND (${tps.toSQL}))""".stripMargin)
+            CustomParameter(query.toString())
+          case _ =>
+            params.taskParams.taskProperties match {
+              case Some(tp) =>
+                val searchType = params.taskParams.taskPropertySearchType.getOrElse("equals")
+
+                val query = new StringBuilder(s"""tasks.id IN (
+                    | SELECT id FROM tasks,
+                    | jsonb_array_elements(geojson->'features') features
+                    | WHERE parent_id IN (${l.mkString(",")})
+                    | AND (true""".stripMargin)
+                for ((k, v) <- tp) {
+                  searchType match {
+                    case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS =>
+                      query ++= s" AND features->'properties'->>'${k}' = '${v}' "
+                    case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL =>
+                      query ++= s" AND features->'properties'->>'${k}' != '${v}' "
+                    case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS =>
+                      query ++= s" AND features->'properties'->>'${k}' LIKE '%${v}%' "
+                    case SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS =>
+                      query ++= s" AND features->'properties'->>'${k}' IS NOT NULL "
+                    case SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING =>
+                      query ++= s" AND features->'properties'->>'${k}' IS NULL "
+                    case _ => // should not happen
+                  }
+                }
+                query ++= "))"
+                CustomParameter(query.toString())
+              case _ => CustomParameter("")
+            }
+        }
+      case None => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters on tasks task_review.review_requested_by
+    * @param params with inverting on 'o'
+    */
+  def filterOwner(params: SearchParameters): Parameter[String] = {
+    params.owner match {
+      case Some(o) if o.nonEmpty =>
+        val invert = if (params.invertFields.getOrElse(List()).contains("o")) "NOT" else ""
+        CustomParameter(s"""(tasks.id ${invert} IN
+            | (SELECT task_id
+            | FROM task_review tr
+            | INNER JOIN users u ON u.id = tr.review_requested_by
+            | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%${o}%') ))""".stripMargin)
+      case _ => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters on tasks task_review.reviewed_by
+    * @param params with inverting on 'r'
+    */
+  def filterReviewer(params: SearchParameters): Parameter[String] = {
+    params.reviewer match {
+      case Some(r) if r.nonEmpty =>
+        val invert = if (params.invertFields.getOrElse(List()).contains("r")) "NOT" else ""
+        CustomParameter(s"""(tasks.id ${invert} IN
+            | (SELECT task_id
+            | FROM task_review tr
+            | INNER JOIN users u ON u.id = tr.reviewed_by
+            | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%${r}%') ))""".stripMargin)
+      case _ => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters on tasks.completedBy
+    * @param params with inverting on 'm'
+    */
+  def filterMapper(params: SearchParameters): Parameter[String] = {
+    params.mapper match {
+      case Some(o) if o.nonEmpty =>
+        val invert = if (params.invertFields.getOrElse(List()).contains("m")) "NOT" else ""
+        CustomParameter(s"""(tasks.id ${invert} IN
+             | (SELECT t2.id
+             | FROM tasks t2
+             | INNER JOIN users u ON u.id = t2.completed_by
+             | WHERE t2.id = tasks.id AND LOWER(u.name) LIKE LOWER('%${o}%') ))""".stripMargin)
+      case _ => CustomParameter("")
+    }
+  }
+
+  /**
+    * Filters on task_review.review_requested_by.
+    * Will always check that the field is not null
+    *
+    * @param params with inverting on 'mappers'
+    */
+  def filterReviewMappers(params: SearchParameters): FilterGroup = {
+    FilterGroup(
+      List(
+        FilterParameter.conditional(
+          "review_requested_by",
+          params.reviewParams.mappers.getOrElse(List()).mkString(","),
+          Operator.IN,
+          params.invertFields.getOrElse(List()).contains("mappers"),
+          true,
+          !params.reviewParams.mappers.getOrElse(List()).isEmpty,
+          Some("task_review")
+        ),
+        BaseParameter(
+          "review_requested_by",
+          None,
+          Operator.NULL,
+          true,
+          true,
+          Some("task_review")
+        )
+      )
+    )
+  }
+
+  /**
+    * Filters on task_review.reviewed_by.
+    *
+    * @param params with inverting on 'reviewers'
+    */
+  def filterReviewers(params: SearchParameters): Parameter[String] = {
+    FilterParameter.conditional(
+      "reviewed_by",
+      params.reviewParams.reviewers.getOrElse(List()).mkString(","),
+      Operator.IN,
+      params.invertFields.getOrElse(List()).contains("reviewers"),
+      true,
+      !params.reviewParams.reviewers.getOrElse(List()).isEmpty,
+      Some("task_review")
+    )
+  }
+
+  /**
+    * Private method to build a bounding box search
+    */
+  private def locationSearch(
+      key: String,
+      bounds: Option[SearchLocation],
+      table: String,
+      invert: Boolean = false
+  ): Parameter[String] = {
+    bounds match {
+      case Some(sl) =>
+        BaseParameter(
+          key,
+          s"ST_MakeEnvelope (${sl.left}, ${sl.bottom}, ${sl.right}, ${sl.top}, 4326)",
+          Operator.AT,
+          invert,
+          true,
+          Some(table)
+        )
+      case None => CustomParameter("")
+    }
+  }
+}

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -260,6 +260,7 @@ object Challenge extends CommonField {
   val TABLE           = "challenges"
   val FIELD_PARENT_ID = "parent_id"
   val FIELD_ENABLED   = "enabled"
+  val FIELD_STATUS    = "status"
 
   /**
     * This will check to make sure that the rule string is fully valid.

--- a/app/org/maproulette/framework/psql/filter/Operator.scala
+++ b/app/org/maproulette/framework/psql/filter/Operator.scala
@@ -13,7 +13,8 @@ import org.maproulette.framework.psql.SQLUtils
   */
 object Operator extends Enumeration {
   type Operator = Value
-  val EQ, NE, GT, GTE, LT, LTE, IN, LIKE, ILIKE, CUSTOM, BETWEEN, NULL, SIMILAR_TO, EXISTS, BOOL =
+  val EQ, NE, GT, GTE, LT, LTE, IN, LIKE, ILIKE, CUSTOM, BETWEEN, NULL, SIMILAR_TO, EXISTS, BOOL,
+      AT =
     Value
 
   def format(
@@ -47,6 +48,7 @@ object Operator extends Enumeration {
       case SIMILAR_TO => s"$negation$key SIMILAR TO $rightValue"
       case EXISTS     => s"${negation}EXISTS ($rightValue)"
       case BOOL       => s"${negation}$key"
+      case AT         => s"${negation}$key @ $rightValue"
       case _ =>
         throw new InvalidException("Operator not supported by standard filter")
     }

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -79,4 +79,25 @@ class TaskReviewService @Inject() (repository: TaskReviewRepository, taskReviewD
     )
   }
 
+  /**
+    * Gets tasks near the given task id within the given challenge
+    *
+    * @param challengeId  The challenge id that is the parent of the tasks that you would be searching for
+    * @param proximityId  Id of task for which nearby tasks are desired
+    * @param excludeSelfLocked Also exclude tasks locked by requesting user
+    * @param limit        The maximum number of nearby tasks to return
+    * @return
+    */
+  def getNearbyReviewTasks(
+      user: User,
+      params: SearchParameters,
+      proximityId: Long,
+      limit: Int,
+      excludeOtherReviewers: Boolean = false,
+      onlySaved: Boolean = false
+  ): List[Task] = {
+        this.taskReviewDAL.getNearbyReviewTasks(user, params, proximityId, limit,
+          excludeOtherReviewers, onlySaved)
+  }
+
 }

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -96,8 +96,14 @@ class TaskReviewService @Inject() (repository: TaskReviewRepository, taskReviewD
       excludeOtherReviewers: Boolean = false,
       onlySaved: Boolean = false
   ): List[Task] = {
-        this.taskReviewDAL.getNearbyReviewTasks(user, params, proximityId, limit,
-          excludeOtherReviewers, onlySaved)
+    this.taskReviewDAL.getNearbyReviewTasks(
+      user,
+      params,
+      proximityId,
+      limit,
+      excludeOtherReviewers,
+      onlySaved
+    )
   }
 
 }

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.maproulette.data.{ItemType, TaskType}
 import org.maproulette.framework.model.Challenge
+import org.maproulette.framework.psql.CommonField
 import org.maproulette.utils.Utils
 import play.api.data.format.Formats
 import play.api.libs.json._
@@ -110,7 +111,13 @@ case class Task(
   }
 }
 
-object Task {
+object Task extends CommonField {
+  // TASK FIELDS
+  val TABLE          = "tasks"
+  val FIELD_LOCATION = "location"
+  val FIELD_STATUS   = "status"
+  val FIELD_PRIORITY = "priority"
+
   implicit object TaskFormat extends Format[Task] {
     override def writes(o: Task): JsValue = {
       implicit val mapillaryWrites: Writes[MapillaryImage] = Json.writes[MapillaryImage]

--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -826,7 +826,7 @@ class TaskReviewDAL @Inject() (
 
     this.paramsMappers(searchParameters, whereClause)
     this.paramsReviewers(searchParameters, whereClause)
-    this.paramsPriorities(searchParameters, whereClause)
+    this.paramsTaskPriorities(searchParameters, whereClause)
 
     if (onlySaved) {
       joinClause ++= "INNER JOIN saved_challenges sc ON sc.challenge_id = c.id "
@@ -983,22 +983,7 @@ class TaskReviewDAL @Inject() (
     this.paramsOwner(searchParameters, whereClause)
     this.paramsReviewer(searchParameters, whereClause)
     this.paramsMapper(searchParameters, whereClause)
-
-    searchParameters.taskParams.taskStatus match {
-      case Some(statuses) if statuses.nonEmpty =>
-        val invert =
-          if (searchParameters.invertFields.getOrElse(List()).contains("tStatus")) "NOT" else ""
-        val statusClause = new StringBuilder(
-          s"(tasks.status ${invert} IN (${statuses.mkString(",")})"
-        )
-        if (statuses.contains(-1)) {
-          statusClause ++= " OR c.status IS NULL"
-        }
-        statusClause ++= ")"
-        this.appendInWhereClause(whereClause, statusClause.toString())
-      case Some(statuses) if statuses.isEmpty => //ignore this scenario
-      case _                                  =>
-    }
+    this.paramsTaskStatus(searchParameters, whereClause, List())
 
     searchParameters.taskParams.taskReviewStatus match {
       case Some(statuses) if statuses.nonEmpty =>

--- a/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
+++ b/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
@@ -20,7 +20,9 @@ import scala.collection.mutable.ListBuffer
   * @author mcuthbert
   */
 @deprecated
-trait SearchParametersMixin extends DALHelper {
+trait SearchParametersMixin
+    extends DALHelper
+    with org.maproulette.framework.mixins.SearchParametersMixin {
 
   def updateWhereClause(
       params: SearchParameters,
@@ -55,380 +57,106 @@ trait SearchParametersMixin extends DALHelper {
   }
 
   def paramsProjectSearch(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.projectSearch match {
-      case Some(ps) =>
-        val invert      = if (params.invertFields.getOrElse(List()).contains("ps")) "NOT" else ""
-        val projectName = ps.replace("'", "''")
-        this.appendInWhereClause(
-          whereClause,
-          s"""LOWER(p.display_name) ${invert} LIKE LOWER('%${projectName}%')"""
-        )
-      case None => // do nothing
-    }
+    this.appendInWhereClause(whereClause, this.filterProjectSearch(params).sql())
   }
 
   def paramsLocation(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.location match {
-      case Some(sl) =>
-        this.appendInWhereClause(
-          whereClause,
-          s"tasks.location @ ST_MakeEnvelope (${sl.left}, ${sl.bottom}, ${sl.right}, ${sl.top}, 4326)"
-        )
-      case None => // do nothing
-    }
+    this.appendInWhereClause(whereClause, this.filterLocation(params).sql())
   }
 
   def paramsBounding(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.bounding match {
-      case Some(sl) =>
-        this.appendInWhereClause(
-          whereClause,
-          s"c.bounding @ ST_MakeEnvelope (${sl.left}, ${sl.bottom}, ${sl.right}, ${sl.top}, 4326)"
-        )
-      case None => // do nothing
-    }
+    this.appendInWhereClause(whereClause, this.filterBounding(params).sql())
   }
 
-  def paramsTaskStatus(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.taskParams.taskStatus match {
-      case Some(sl) if sl.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("tStatus")) "NOT" else ""
-
-        // If list contains -1 then ignore filtering by status
-        if (!sl.contains(-1)) {
-          this.appendInWhereClause(whereClause, s"tasks.status ${invert} IN (${sl.mkString(",")})")
-        }
-      case Some(sl) if sl.isEmpty => //ignore this scenario
-      case _ =>
-        this.appendInWhereClause(whereClause, "tasks.status IN (0,3,6)")
-    }
+  def paramsTaskStatus(
+      params: SearchParameters,
+      whereClause: StringBuilder,
+      defaultStatuses: List[Int] = List(0, 3, 6)
+  ): Unit = {
+    this.appendInWhereClause(whereClause, this.filterTaskStatus(params, defaultStatuses).sql())
   }
 
   def paramsTaskId(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.taskParams.taskId match {
-      case Some(tid) =>
-        this.appendInWhereClause(whereClause, s"CAST(tasks.id AS TEXT) LIKE '${tid}%'")
-      case _ => // do nothing
-    }
+    this.appendInWhereClause(whereClause, this.filterTaskId(params).sql())
   }
 
   def paramsTaskPriorities(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.taskParams.taskPriorities match {
-      case Some(sl) if sl.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("priorities")) "NOT" else ""
-        this.appendInWhereClause(whereClause, s"tasks.priority ${invert} IN (${sl.mkString(",")})")
-      case Some(sl) if sl.isEmpty => //ignore this scenario
-      case _                      => // do nothing
-    }
+    this.appendInWhereClause(whereClause, this.filterTaskPriorities(params).sql())
   }
 
   def paramsPriority(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.priority match {
-      case Some(p) if p == 0 || p == 1 || p == 2 =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("tp")) "!" else ""
-        this.appendInWhereClause(whereClause, s"tasks.priority ${invert}= $p")
-      case _ => // ignore
-    }
+    this.appendInWhereClause(whereClause, this.filterPriority(params).sql())
   }
 
   def paramsTaskTags(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    if (params.hasTaskTags) {
-      val tagList = params.taskParams.taskTags.get
-        .map(t => {
-          SQLUtils.testColumnName(t)
-          s"'${t}'"
-        })
-        .mkString(",")
-      this.appendInWhereClause(
-        whereClause,
-        s"""tasks.id IN (SELECT task_id from tags_on_tasks tt
-                         INNER JOIN tags ON tags.id = tt.tag_id
-                         WHERE tags.name IN (${tagList}))
-        """
-      )
-    }
-  }
-
-  def paramsChallengeDifficulty(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.challengeParams.challengeDifficulty match {
-      case Some(v) if v > 0 && v < 4 =>
-        this.appendInWhereClause(whereClause, s"c.difficulty = ${v}")
-      case _ =>
-    }
+    this.appendInWhereClause(whereClause, this.filterTaskTags(params).sql())
   }
 
   def paramsTaskReviewStatus(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.taskParams.taskReviewStatus match {
-      case Some(statuses) if statuses.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("trStatus")) "NOT" else ""
-        val filter = new StringBuilder(s"""(tasks.id ${invert} IN (SELECT task_id FROM task_review
-                                                    WHERE task_review.task_id = tasks.id AND task_review.review_status
-                                                          IN (${statuses.mkString(",")})) """)
-        if (statuses.contains(-1)) {
-          val includeNOT =
-            if (!params.invertFields.getOrElse(List()).contains("trStatus")) "NOT" else ""
-          filter.append(
-            s" OR tasks.id ${includeNOT} IN (SELECT task_id FROM task_review task_review WHERE task_review.task_id = tasks.id)"
-          )
-        }
-        filter.append(")")
-        this.appendInWhereClause(whereClause, filter.toString())
-      case Some(statuses) if statuses.isEmpty => //ignore this scenario
-      case _                                  =>
-    }
+    this.appendInWhereClause(whereClause, this.filterTaskReviewStatus(params).sql())
+  }
+
+  def paramsChallengeDifficulty(params: SearchParameters, whereClause: StringBuilder): Unit = {
+    this.appendInWhereClause(whereClause, this.filterChallengeDifficulty(params).sql())
   }
 
   def paramsChallengeStatus(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.challengeParams.challengeStatus match {
-      case Some(sl) if sl.nonEmpty =>
-        val statusClause = new StringBuilder(s"(c.status IN (${sl.mkString(",")})")
-        if (sl.contains(-1)) {
-          statusClause ++= " OR c.status IS NULL"
-        }
-        statusClause ++= ")"
-        this.appendInWhereClause(whereClause, statusClause.toString())
-      case Some(sl) if sl.isEmpty => //ignore this scenario
-      case _                      =>
-    }
+    this.appendInWhereClause(whereClause, this.filterChallengeStatus(params).sql())
   }
 
   def paramsChallengeRequiresLocal(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.challengeParams.challengeIds match {
-      case Some(ids) if ids.nonEmpty =>
-      // do nothing, we don't want to restrict to requiresLocal if we have
-      // specific challenge ids
-      case _ =>
-        params.challengeParams.requiresLocal match {
-          case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE) =>
-            this.appendInWhereClause(whereClause, s"c.requires_local = false")
-          case Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY) =>
-            this.appendInWhereClause(whereClause, s"c.requires_local = true")
-          case _ =>
-          // allow everything
-        }
-    }
+    this.appendInWhereClause(whereClause, this.filterChallengeRequiresLocal(params).sql())
   }
 
   def paramsBoundingGeometries(params: SearchParameters, whereClause: StringBuilder): Unit = {
-    params.boundingGeometries match {
-      case Some(bp) =>
-        val allPolygons = new StringBuilder()
-        bp.foreach(value =>
-          value \ "bounding" match {
-            case locationJSON: JsDefined => {
-              val polygonLinestring = new StringBuilder()
-              if (allPolygons.toString() != "")
-                allPolygons.append(" OR ")
-
-              (locationJSON \ "type").as[String] match {
-                case "Polygon" => {
-                  (locationJSON \ "coordinates")
-                    .as[List[List[List[Double]]]]
-                    .foreach(p =>
-                      p.foreach(coordinates => {
-                        if (polygonLinestring.toString() != "")
-                          polygonLinestring.append(",")
-                        polygonLinestring.append(s"${coordinates.head} ${coordinates(1)}")
-                      })
-                    )
-                  allPolygons.append(
-                    s"tasks.location @ ST_MakePolygon( ST_GeomFromText('LINESTRING($polygonLinestring)'))"
-                  )
-                }
-                case "LineString" => {
-                  (locationJSON \ "coordinates")
-                    .as[List[List[Double]]]
-                    .foreach(coordinates => {
-                      if (polygonLinestring.toString() != "") {
-                        polygonLinestring.append(",")
-                      }
-                      polygonLinestring.append(s"${coordinates.head} ${coordinates(1)}")
-                    })
-                  allPolygons.append(
-                    s"tasks.location @ ST_GeomFromText('LINESTRING($polygonLinestring)')"
-                  )
-                }
-                case "Point" => {
-                  val coordinates = (locationJSON \ "coordinates").as[List[Double]]
-                  allPolygons.append(
-                    s"tasks.location @ ST_GeomFromText('POINT(${coordinates.head} ${coordinates(1)})')"
-                  )
-                }
-                case _ => // do nothing
-              }
-            }
-            case _ => // do nothing
-          }
-        )
-        this.appendInWhereClause(whereClause, "(" + allPolygons.toString + ")")
-      case _ => // value not present
-    }
+    this.appendInWhereClause(whereClause, this.filterBoundingGeometries(params).sql())
   }
 
-  def paramsTaskProps(
-      params: SearchParameters,
-      whereClause: StringBuilder
-  ): Unit = {
-    params.getChallengeIds match {
-      case Some(l) =>
-        params.taskParams.taskPropertySearch match {
-          case Some(tps) =>
-            val query = new StringBuilder(s"""tasks.id IN (
-                SELECT id FROM tasks,
-                               jsonb_array_elements(geojson->'features') features
-                WHERE parent_id IN (${l.mkString(",")})
-                AND (${tps.toSQL}))
-               """)
-            this.appendInWhereClause(whereClause, query.toString())
-          case _ =>
-            params.taskParams.taskProperties match {
-              case Some(tp) =>
-                val searchType = params.taskParams.taskPropertySearchType.getOrElse("equals")
-
-                val query = new StringBuilder(s"""tasks.id IN (
-                    SELECT id FROM tasks,
-                                   jsonb_array_elements(geojson->'features') features
-                    WHERE parent_id IN (${l.mkString(",")})
-                    AND (true
-                   """)
-                for ((k, v) <- tp) {
-                  searchType match {
-                    case SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS =>
-                      query ++= s" AND features->'properties'->>'${k}' = '${v}' "
-                    case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL =>
-                      query ++= s" AND features->'properties'->>'${k}' != '${v}' "
-                    case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS =>
-                      query ++= s" AND features->'properties'->>'${k}' LIKE '%${v}%' "
-                    case SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS =>
-                      query ++= s" AND features->'properties'->>'${k}' IS NOT NULL "
-                    case SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING =>
-                      query ++= s" AND features->'properties'->>'${k}' IS NULL "
-                    case _ => // should not happen
-                  }
-                }
-                query ++= "))"
-                this.appendInWhereClause(whereClause, query.toString())
-              case _ =>
-            }
-        }
-      case None => // ignore
-    }
+  def paramsTaskProps(params: SearchParameters, whereClause: StringBuilder): Unit = {
+    this.appendInWhereClause(whereClause, this.filterTaskProps(params).sql())
   }
 
   def paramsOwner(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.owner match {
-      case Some(o) if o.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("o")) "NOT" else ""
-        this.appendInWhereClause(
-          whereClause,
-          s""" (tasks.id ${invert} IN (SELECT task_id
-                                       FROM task_review tr
-                                       INNER JOIN users u ON u.id = tr.review_requested_by
-                                       WHERE tr.task_id = tasks.id AND
-                                             LOWER(u.name) LIKE LOWER('%${o}%') ))
-           """
-        )
-      case _ => // ignore
-    }
+    this.appendInWhereClause(whereClause, this.filterOwner(params).sql())
   }
 
   def paramsReviewer(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.reviewer match {
-      case Some(r) if r.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("r")) "NOT" else ""
-        this.appendInWhereClause(
-          whereClause,
-          s""" (tasks.id ${invert} IN (SELECT task_id
-                                       FROM task_review tr
-                                       INNER JOIN users u ON u.id = tr.reviewed_by
-                                       WHERE tr.task_id = tasks.id AND
-                                             LOWER(u.name) LIKE LOWER('%${r}%') ))
-           """
-        )
-      case _ => // ignore
-    }
+    this.appendInWhereClause(whereClause, this.filterReviewer(params).sql())
   }
 
   def paramsMapper(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.mapper match {
-      case Some(o) if o.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("m")) "NOT" else ""
-        this.appendInWhereClause(
-          whereClause,
-          s""" (tasks.id ${invert} IN (SELECT t2.id
-                                       FROM tasks t2
-                                       INNER JOIN users u ON u.id = t2.completed_by
-                                       WHERE t2.id = tasks.id AND
-                                             LOWER(u.name) LIKE LOWER('%${o}%') ))
-           """
-        )
-      case _ => // ignore
-    }
+    this.appendInWhereClause(whereClause, this.filterMapper(params).sql())
   }
 
   def paramsMappers(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.reviewParams.mappers match {
-      case Some(m) =>
-        if (m.size > 0) {
-          this.appendInWhereClause(
-            whereClause,
-            s"task_review.review_requested_by IN (${m.mkString(",")}) "
-          )
-        } else {
-          this.appendInWhereClause(whereClause, s"task_review.review_requested_by IS NOT NULL ")
-        }
-      case _ =>
-        this.appendInWhereClause(whereClause, s"task_review.review_requested_by IS NOT NULL ")
-    }
+    this.appendInWhereClause(whereClause, this.filterReviewMappers(params).sql())
   }
 
   def paramsReviewers(
       params: SearchParameters,
       whereClause: StringBuilder
   ): Unit = {
-    params.reviewParams.reviewers match {
-      case Some(r) =>
-        if (r.size > 0) {
-          this.appendInWhereClause(whereClause, s"task_review.reviewed_by IN (${r.mkString(",")}) ")
-        }
-      case _ => // do nothing
-    }
-  }
-
-  def paramsPriorities(
-      params: SearchParameters,
-      whereClause: StringBuilder
-  ): Unit = {
-    params.reviewParams.priorities match {
-      case Some(priority) if priority.nonEmpty =>
-        val invert = if (params.invertFields.getOrElse(List()).contains("priorities")) "NOT" else ""
-        val priorityClause = new StringBuilder(
-          s"(tasks.priority ${invert} IN (${priority.mkString(",")}))"
-        )
-        this.appendInWhereClause(whereClause, priorityClause.toString())
-      case Some(priority) if priority.isEmpty => //ignore this scenario
-      case _                                  =>
-    }
+    this.appendInWhereClause(whereClause, this.filterReviewers(params).sql())
   }
 }

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -35,7 +35,6 @@ case class SearchChallengeParameters(
 case class SearchReviewParameters(
     mappers: Option[List[Long]] = None,
     reviewers: Option[List[Long]] = None,
-    priorities: Option[List[Int]] = None,
     startDate: Option[String] = None,
     endDate: Option[String] = None
 )
@@ -441,10 +440,6 @@ object SearchParameters {
         request.getQueryString("reviewers") match {
           case Some(r) => Utils.toLongList(r)
           case None => params.reviewParams.reviewers
-        },
-        request.getQueryString("priorities") match {
-          case Some(p) => Utils.toIntList(p)
-          case None => params.reviewParams.priorities
         },
         this.getStringParameter(request.getQueryString("startDate"), params.reviewParams.startDate),
         this.getStringParameter(request.getQueryString("endDate"), params.reviewParams.endDate)

--- a/conf/v2_route/review.api
+++ b/conf/v2_route/review.api
@@ -171,6 +171,34 @@ GET     /tasks/reviewed                          @org.maproulette.controllers.ap
 GET     /tasks/review/next                       @org.maproulette.controllers.api.TaskReviewController.nextTaskReview(onlySaved:Boolean ?= false, sort:String ?= "", order:String ?= "ASC", lastTaskId:Long ?= -1, excludeOtherReviewers:Boolean ?= false)
 ###
 # tags: [ Review ]
+# summary: Retrieves nearby Tasks
+# produces: [ application/json ]
+# description: Retrieves review tasks geographically closest to the specified task within the given filters
+# responses:
+#   '200':
+#     description: The list of geographically closest review tasks
+#     schema:
+#       type: array
+#       items:
+#         type: object
+#         $ref: '#/definitions/org.maproulette.models.Task'
+# parameters:
+#   - name: limit
+#     in: query
+#     description: Limit the number of results returned in the response. Default value is 5.
+#   - name: proximity
+#     in: query
+#     description: Id of task around which geographically closest tasks are desired
+#   - name: excludeOtherReviewers
+#     in: query
+#     description: exclude tasks that have been reviewed by someone else
+#   - name: onlySaved
+#     in: query
+#     description: Only show challenges that have been saved.
+###
+GET     /tasks/review/nearby/:proximityId           @org.maproulette.framework.controller.TaskReviewController.getNearbyReviewTasks(proximityId:Long, limit:Int ?= 5, excludeOtherReviewers:Boolean ?= false, onlySaved:Boolean ?= false)
+###
+# tags: [ Review ]
 # summary: Retrieves tasks that need review
 # produces: [ application/json ]
 # description: Retrieves list of Tasks and total count

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -1,0 +1,535 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.mixins
+
+import org.scalatestplus.play.PlaySpec
+import org.maproulette.framework.mixins.SearchParametersMixin
+import org.maproulette.session._
+
+/**
+  * @author krotstan
+  */
+class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
+  implicit var challengeID: Long = -1
+
+  "filterProjectSearch" should {
+    "match on project name" in {
+      val params = new SearchParameters(projectSearch = Some("my_project"))
+      this.filterProjectSearch(params).sql() mustEqual "p.display_name LIKE '%my_project%'"
+    }
+
+    "allow apostrophes in project name" in {
+      val params = new SearchParameters(projectSearch = Some("my project's"))
+      this.filterProjectSearch(params).sql() mustEqual "p.display_name LIKE '%my project''s%'"
+    }
+
+    "be empty" in {
+      this.filterProjectSearch(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params =
+        new SearchParameters(projectSearch = Some("my_project"), invertFields = Some(List("ps")))
+      this.filterProjectSearch(params).sql() mustEqual "NOT p.display_name LIKE '%my_project%'"
+    }
+  }
+
+  "filterLocation" should {
+    "match on location" in {
+      val params = new SearchParameters(location = Some(SearchLocation(0.0, 0.0, 1.0, 1.0)))
+      this.filterLocation(params).sql() mustEqual
+        "tasks.location @ ST_MakeEnvelope (0.0, 0.0, 1.0, 1.0, 4326)"
+    }
+
+    "be inverted" in {
+      val params = new SearchParameters(
+        location = Some(SearchLocation(0.0, 0.0, 1.0, 1.0)),
+        invertFields = Some(List("tbb"))
+      )
+      this.filterLocation(params).sql() mustEqual
+        "NOT tasks.location @ ST_MakeEnvelope (0.0, 0.0, 1.0, 1.0, 4326)"
+    }
+
+    "be empty" in {
+      this.filterLocation(SearchParameters()).sql() mustEqual ""
+    }
+  }
+
+  "filterBounding" should {
+    "match on location" in {
+      val params = new SearchParameters(bounding = Some(SearchLocation(0.0, 0.0, 1.0, 1.0)))
+      this.filterBounding(params).sql() mustEqual
+        "c.bounding @ ST_MakeEnvelope (0.0, 0.0, 1.0, 1.0, 4326)"
+    }
+
+    "be inverted" in {
+      val params = new SearchParameters(
+        bounding = Some(SearchLocation(0.0, 0.0, 1.0, 1.0)),
+        invertFields = Some(List("bb"))
+      )
+      this.filterBounding(params).sql() mustEqual
+        "NOT c.bounding @ ST_MakeEnvelope (0.0, 0.0, 1.0, 1.0, 4326)"
+    }
+
+    "be empty" in {
+      this.filterBounding(SearchParameters()).sql() mustEqual ""
+    }
+  }
+
+  "filterTaskStatus" should {
+    "match on task status" in {
+      val params =
+        SearchParameters(taskParams = SearchTaskParameters(taskStatus = Some(List(1, 2))))
+      this.filterTaskStatus(params).sql() mustEqual "tasks.status IN (1,2)"
+    }
+
+    "use default open statuses if no params given" in {
+      val params = SearchParameters()
+      this.filterTaskStatus(params).sql() mustEqual "tasks.status IN (0,3,6)"
+    }
+
+    "be empty if given an empty default statuses" in {
+      this.filterTaskStatus(SearchParameters(), List()).sql() mustEqual ""
+    }
+
+    "be empty if statuses include -1" in {
+      val params = SearchParameters(taskParams = SearchTaskParameters(taskStatus = Some(List(-1))))
+      this.filterTaskStatus(params).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        taskParams = SearchTaskParameters(taskStatus = Some(List(1, 2))),
+        invertFields = Some(List("tStatus"))
+      )
+      this.filterTaskStatus(params).sql() mustEqual "NOT tasks.status IN (1,2)"
+    }
+  }
+
+  "filterTaskId" should {
+    "match on task id" in {
+      val params = SearchParameters(taskParams = SearchTaskParameters(taskId = Some(123)))
+      this.filterTaskId(params).sql() mustEqual "CAST(tasks.id AS TEXT) LIKE '123%'"
+    }
+
+    "be empty" in {
+      this.filterTaskId(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        taskParams = SearchTaskParameters(taskId = Some(12345)),
+        invertFields = Some(List("tid"))
+      )
+      this.filterTaskId(params).sql() mustEqual "NOT CAST(tasks.id AS TEXT) LIKE '12345%'"
+    }
+  }
+
+  "filterTaskPriorities" should {
+    "match on task priority" in {
+      val params =
+        SearchParameters(taskParams = SearchTaskParameters(taskPriorities = Some(List(0, 1, 2))))
+      this.filterTaskPriorities(params).sql() mustEqual "tasks.priority IN (0,1,2)"
+    }
+
+    "be empty" in {
+      this.filterTaskPriorities(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be empty when given empty list" in {
+      val params =
+        SearchParameters(taskParams = SearchTaskParameters(taskPriorities = Some(List())))
+      this.filterTaskPriorities(params).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        taskParams = SearchTaskParameters(taskPriorities = Some(List(0, 1, 2))),
+        invertFields = Some(List("priorities"))
+      )
+      this.filterTaskPriorities(params).sql() mustEqual "NOT tasks.priority IN (0,1,2)"
+    }
+  }
+
+  "filterPriority" should {
+    "match on task priority" in {
+      val params = SearchParameters(priority = Some(1))
+      this.filterPriority(params).sql() mustEqual "tasks.priority = 1"
+    }
+
+    "be empty" in {
+      this.filterPriority(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(priority = Some(2), invertFields = Some(List("tp")))
+      this.filterPriority(params).sql() mustEqual "NOT tasks.priority = 2"
+    }
+
+    "only filter if valid priority level (0,1,2)" in {
+      val params = SearchParameters(priority = Some(3))
+      this.filterPriority(params).sql() mustEqual ""
+    }
+  }
+
+  "filterChallengeDifficulty" should {
+    "match on challenge difficulty" in {
+      val params =
+        SearchParameters(challengeParams = SearchChallengeParameters(challengeDifficulty = Some(1)))
+      this.filterChallengeDifficulty(params).sql() mustEqual "c.difficulty = 1"
+    }
+
+    "be empty" in {
+      this.filterChallengeDifficulty(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        challengeParams = SearchChallengeParameters(challengeDifficulty = Some(2)),
+        invertFields = Some(List("cd"))
+      )
+      this.filterChallengeDifficulty(params).sql() mustEqual "NOT c.difficulty = 2"
+    }
+  }
+
+  "filterTaskTags" should {
+    "match on task tags" in {
+      val params =
+        SearchParameters(taskParams = SearchTaskParameters(taskTags = Some(List("my_tag", "tag2"))))
+      this.filterTaskTags(params).sql() mustEqual
+        s"""tasks.id IN (SELECT task_id from tags_on_tasks tt
+              | INNER JOIN tags ON tags.id = tt.tag_id
+              | WHERE tags.name IN ('my_tag','tag2'))
+        """.stripMargin
+    }
+
+    "be empty" in {
+      this.filterTaskTags(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        taskParams = SearchTaskParameters(taskTags = Some(List("my_tag", "tag2"))),
+        invertFields = Some(List("tt"))
+      )
+      this.filterTaskTags(params).sql() mustEqual
+        s"""NOT tasks.id IN (SELECT task_id from tags_on_tasks tt
+              | INNER JOIN tags ON tags.id = tt.tag_id
+              | WHERE tags.name IN ('my_tag','tag2'))
+        """.stripMargin
+    }
+  }
+
+  "filterTaskReviewStatus" should {
+    "match on task review status" in {
+      val params =
+        SearchParameters(taskParams = SearchTaskParameters(taskReviewStatus = Some(List(1, 2))))
+      this.filterTaskReviewStatus(params).sql() mustEqual
+        s"""(tasks.id IN
+          | (SELECT task_id FROM task_review
+          | WHERE task_review.task_id = tasks.id AND task_review.review_status
+          | IN (1,2)))""".stripMargin
+    }
+
+    "include tasks without review status when params contains -1" in {
+      val params =
+        SearchParameters(taskParams = SearchTaskParameters(taskReviewStatus = Some(List(1, 2, -1))))
+      this.filterTaskReviewStatus(params).sql() mustEqual
+        s"""(tasks.id IN
+          | (SELECT task_id FROM task_review
+          | WHERE task_review.task_id = tasks.id AND task_review.review_status
+          | IN (1,2,-1)) OR tasks.id NOT IN (SELECT task_id FROM task_review task_review
+          | WHERE task_review.task_id = tasks.id))""".stripMargin
+    }
+
+    "be empty" in {
+      this.filterTaskReviewStatus(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        taskParams = SearchTaskParameters(taskReviewStatus = Some(List(1, 2))),
+        invertFields = Some(List("trStatus"))
+      )
+      this.filterTaskReviewStatus(params).sql() mustEqual
+        s"""NOT (tasks.id IN
+          | (SELECT task_id FROM task_review
+          | WHERE task_review.task_id = tasks.id AND task_review.review_status
+          | IN (1,2)))""".stripMargin
+    }
+
+    "invert when contains -1" in {
+      val params = SearchParameters(
+        taskParams = SearchTaskParameters(taskReviewStatus = Some(List(1, 2, -1))),
+        invertFields = Some(List("trStatus"))
+      )
+      this.filterTaskReviewStatus(params).sql() mustEqual
+        s"""NOT (tasks.id IN
+          | (SELECT task_id FROM task_review
+          | WHERE task_review.task_id = tasks.id AND task_review.review_status
+          | IN (1,2,-1)) OR tasks.id NOT IN (SELECT task_id FROM task_review task_review
+          | WHERE task_review.task_id = tasks.id))""".stripMargin
+    }
+  }
+
+  "filterChallengeStatus" should {
+    "match on challenge status" in {
+      val params = SearchParameters(challengeParams =
+        SearchChallengeParameters(challengeStatus = Some(List(1, 2)))
+      )
+      this.filterChallengeStatus(params).sql() mustEqual
+        s"""c.status IN (1,2)"""
+    }
+
+    "include challenge with null status when params contains -1" in {
+      val params = SearchParameters(challengeParams =
+        SearchChallengeParameters(challengeStatus = Some(List(1, 2, -1)))
+      )
+      this.filterChallengeStatus(params).sql() mustEqual
+        s"""c.status IN (1,2,-1) OR c.status IS NULL""".stripMargin
+    }
+
+    "be empty" in {
+      this.filterChallengeStatus(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(
+        challengeParams = SearchChallengeParameters(challengeStatus = Some(List(1, 2))),
+        invertFields = Some(List("cStatus"))
+      )
+      this.filterChallengeStatus(params).sql() mustEqual
+        s"""NOT c.status IN (1,2)""".stripMargin
+    }
+
+    "invert when contains -1" in {
+      val params = SearchParameters(
+        challengeParams = SearchChallengeParameters(challengeStatus = Some(List(1, 2, -1))),
+        invertFields = Some(List("cStatus"))
+      )
+      this.filterChallengeStatus(params).sql() mustEqual
+        s"""NOT c.status IN (1,2,-1) AND c.status IS NOT NULL""".stripMargin
+    }
+  }
+
+  "filterChallengeRequiresLocal" should {
+    "match on challenge requires local" in {
+      val params = SearchParameters(challengeParams = SearchChallengeParameters(requiresLocal =
+        Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE)
+      )
+      )
+      this.filterChallengeRequiresLocal(params).sql() mustEqual "NOT c.requires_local"
+
+      val params2 = SearchParameters(challengeParams = SearchChallengeParameters(requiresLocal =
+        Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_ONLY)
+      )
+      )
+      this.filterChallengeRequiresLocal(params2).sql() mustEqual "c.requires_local"
+
+      val params3 = SearchParameters(challengeParams = SearchChallengeParameters(requiresLocal =
+        Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_INCLUDE)
+      )
+      )
+      this.filterChallengeRequiresLocal(params3).sql() mustEqual ""
+    }
+
+    "if given challenge ids then not filter" in {
+      val params = SearchParameters(challengeParams = SearchChallengeParameters(
+        requiresLocal = Some(SearchParameters.CHALLENGE_REQUIRES_LOCAL_EXCLUDE),
+        challengeIds = Some(List(1, 2, 3))
+      )
+      )
+      this.filterChallengeRequiresLocal(params).sql() mustEqual ""
+    }
+  }
+
+  "filterBoundingGeometries" should {
+    "be empty" in {
+      this.filterBoundingGeometries(SearchParameters()).sql() mustEqual ""
+    }
+  }
+
+  "filterTaskProps" should {
+    "be empty" in {
+      this.filterTaskProps(SearchParameters()).sql() mustEqual ""
+    }
+
+    "be empty if no challenge ids are given" in {
+      val params = SearchParameters(taskParams = SearchTaskParameters(taskPropertySearch = Some(
+        TaskPropertySearch(
+          Some("x"),
+          Some("1"),
+          Some(SearchParameters.TASK_PROP_VALUE_TYPE_NUMBER),
+          Some(SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS)
+        )
+      )
+      )
+      )
+      this.filterTaskProps(params).sql() mustEqual ""
+    }
+
+    "match on task props when using params.taskPropertySearch" in {
+      val params = SearchParameters(
+        challengeParams = SearchChallengeParameters(challengeIds = Some(List(12345))),
+        taskParams = SearchTaskParameters(taskPropertySearch = Some(
+          TaskPropertySearch(
+            Some("x"),
+            Some("1"),
+            Some(SearchParameters.TASK_PROP_VALUE_TYPE_NUMBER),
+            Some(SearchParameters.TASK_PROP_SEARCH_TYPE_EQUALS)
+          )
+        )
+        )
+      )
+      this.filterTaskProps(params).sql() mustEqual
+        """tasks.id IN (
+             | SELECT id FROM tasks,
+             | jsonb_array_elements(geojson->'features') features
+             | WHERE parent_id IN (12345)
+             | AND ( CAST(features->'properties'->>'x' AS DOUBLE PRECISION)=1))""".stripMargin
+    }
+
+    "match on task props when using params.taskProperties" in {
+      val params = SearchParameters(
+        challengeParams = SearchChallengeParameters(challengeIds = Some(List(12345))),
+        taskParams = SearchTaskParameters(taskProperties = Some(Map("x" -> "1")))
+      )
+      this.filterTaskProps(params).sql() mustEqual
+        """tasks.id IN (
+             | SELECT id FROM tasks,
+             | jsonb_array_elements(geojson->'features') features
+             | WHERE parent_id IN (12345)
+             | AND (true AND features->'properties'->>'x' = '1' ))""".stripMargin
+    }
+  }
+
+  "filterOwner" should {
+    "be empty" in {
+      this.filterOwner(SearchParameters()).sql() mustEqual ""
+    }
+
+    "match on review_requested_by" in {
+      val params = SearchParameters(owner = Some("123"))
+      this.filterOwner(params).sql() mustEqual
+        """(tasks.id  IN
+              | (SELECT task_id
+              | FROM task_review tr
+              | INNER JOIN users u ON u.id = tr.review_requested_by
+              | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(owner = Some("123"), invertFields = Some(List("o")))
+      this.filterOwner(params).sql() mustEqual
+        """(tasks.id NOT IN
+              | (SELECT task_id
+              | FROM task_review tr
+              | INNER JOIN users u ON u.id = tr.review_requested_by
+              | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+    }
+  }
+
+  "filterReviewer" should {
+    "be empty" in {
+      this.filterOwner(SearchParameters()).sql() mustEqual ""
+    }
+
+    "match on reviewer" in {
+      val params = SearchParameters(reviewer = Some("123"))
+      this.filterReviewer(params).sql() mustEqual
+        """(tasks.id  IN
+            | (SELECT task_id
+            | FROM task_review tr
+            | INNER JOIN users u ON u.id = tr.reviewed_by
+            | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(reviewer = Some("123"), invertFields = Some(List("r")))
+      this.filterReviewer(params).sql() mustEqual
+        """(tasks.id NOT IN
+            | (SELECT task_id
+            | FROM task_review tr
+            | INNER JOIN users u ON u.id = tr.reviewed_by
+            | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+    }
+  }
+
+  "filterMapper" should {
+    "be empty" in {
+      this.filterMapper(SearchParameters()).sql() mustEqual ""
+    }
+
+    "match on mapper" in {
+      val params = SearchParameters(mapper = Some("123"))
+      this.filterMapper(params).sql() mustEqual
+        """(tasks.id  IN
+            | (SELECT t2.id
+            | FROM tasks t2
+            | INNER JOIN users u ON u.id = t2.completed_by
+            | WHERE t2.id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+    }
+
+    "be inverted" in {
+      val params = SearchParameters(mapper = Some("123"), invertFields = Some(List("m")))
+      this.filterMapper(params).sql() mustEqual
+        """(tasks.id NOT IN
+            | (SELECT t2.id
+            | FROM tasks t2
+            | INNER JOIN users u ON u.id = t2.completed_by
+            | WHERE t2.id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+    }
+  }
+
+  "filterReviewMappers" should {
+    "match on mappers" in {
+      val params =
+        SearchParameters(reviewParams = SearchReviewParameters(mappers = Some(List(1, 2, 3))))
+      this.filterReviewMappers(params).sql() mustEqual
+        "task_review.review_requested_by IN (1,2,3) AND task_review.review_requested_by IS NOT NULL"
+    }
+
+    "not match on no mappers" in {
+      val params = SearchParameters(reviewParams = SearchReviewParameters(mappers = Some(List())))
+      this.filterReviewMappers(params).sql() mustEqual
+        "task_review.review_requested_by IS NOT NULL"
+    }
+
+    "make sure the field is not null" in {
+      this.filterReviewMappers(SearchParameters()).sql() mustEqual
+        "task_review.review_requested_by IS NOT NULL"
+    }
+
+    "can be inverted" in {
+      val params = SearchParameters(
+        reviewParams = SearchReviewParameters(mappers = Some(List(1, 2, 3))),
+        invertFields = Some(List("mappers"))
+      )
+      this.filterReviewMappers(params).sql() mustEqual
+        "NOT task_review.review_requested_by IN (1,2,3) AND task_review.review_requested_by IS NOT NULL"
+    }
+  }
+
+  "filterReviewers" should {
+    "match on reviewers" in {
+      val params =
+        SearchParameters(reviewParams = SearchReviewParameters(reviewers = Some(List(1, 2, 3))))
+      this.filterReviewers(params).sql() mustEqual "task_review.reviewed_by IN (1,2,3)"
+    }
+
+    "be empty" in {
+      this.filterReviewers(SearchParameters()).sql() mustEqual ""
+    }
+
+    "can be inverted" in {
+      val params = SearchParameters(
+        reviewParams = SearchReviewParameters(reviewers = Some(List(1, 2, 3))),
+        invertFields = Some(List("reviewers"))
+      )
+      this.filterReviewers(params).sql() mustEqual "NOT task_review.reviewed_by IN (1,2,3)"
+    }
+  }
+}

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -414,21 +414,17 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
     "match on review_requested_by" in {
       val params = SearchParameters(owner = Some("123"))
       this.filterOwner(params).sql() mustEqual
-        """(tasks.id  IN
-              | (SELECT task_id
-              | FROM task_review tr
-              | INNER JOIN users u ON u.id = tr.review_requested_by
-              | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+        "tasks.id IN (SELECT task_id FROM task_review tr " +
+          "INNER JOIN users u ON u.id = tr.review_requested_by " +
+          "WHERE tr.task_id = tasks.id AND u.name ILIKE '%123%')"
     }
 
     "be inverted" in {
       val params = SearchParameters(owner = Some("123"), invertFields = Some(List("o")))
       this.filterOwner(params).sql() mustEqual
-        """(tasks.id NOT IN
-              | (SELECT task_id
-              | FROM task_review tr
-              | INNER JOIN users u ON u.id = tr.review_requested_by
-              | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+        "NOT tasks.id IN (SELECT task_id FROM task_review tr " +
+          "INNER JOIN users u ON u.id = tr.review_requested_by " +
+          "WHERE tr.task_id = tasks.id AND u.name ILIKE '%123%')"
     }
   }
 
@@ -440,21 +436,17 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
     "match on reviewer" in {
       val params = SearchParameters(reviewer = Some("123"))
       this.filterReviewer(params).sql() mustEqual
-        """(tasks.id  IN
-            | (SELECT task_id
-            | FROM task_review tr
-            | INNER JOIN users u ON u.id = tr.reviewed_by
-            | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+        "tasks.id IN (SELECT task_id FROM task_review tr " +
+          "INNER JOIN users u ON u.id = tr.reviewed_by " +
+          "WHERE tr.task_id = tasks.id AND u.name ILIKE '%123%')"
     }
 
     "be inverted" in {
       val params = SearchParameters(reviewer = Some("123"), invertFields = Some(List("r")))
       this.filterReviewer(params).sql() mustEqual
-        """(tasks.id NOT IN
-            | (SELECT task_id
-            | FROM task_review tr
-            | INNER JOIN users u ON u.id = tr.reviewed_by
-            | WHERE tr.task_id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+        "NOT tasks.id IN (SELECT task_id FROM task_review tr " +
+          "INNER JOIN users u ON u.id = tr.reviewed_by " +
+          "WHERE tr.task_id = tasks.id AND u.name ILIKE '%123%')"
     }
   }
 
@@ -466,21 +458,17 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
     "match on mapper" in {
       val params = SearchParameters(mapper = Some("123"))
       this.filterMapper(params).sql() mustEqual
-        """(tasks.id  IN
-            | (SELECT t2.id
-            | FROM tasks t2
-            | INNER JOIN users u ON u.id = t2.completed_by
-            | WHERE t2.id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+        "tasks.id IN (SELECT t2.id FROM tasks t2 " +
+          "INNER JOIN users u ON u.id = t2.completed_by " +
+          "WHERE t2.id = tasks.id AND u.name ILIKE '%123%')"
     }
 
     "be inverted" in {
       val params = SearchParameters(mapper = Some("123"), invertFields = Some(List("m")))
       this.filterMapper(params).sql() mustEqual
-        """(tasks.id NOT IN
-            | (SELECT t2.id
-            | FROM tasks t2
-            | INNER JOIN users u ON u.id = t2.completed_by
-            | WHERE t2.id = tasks.id AND LOWER(u.name) LIKE LOWER('%123%') ))""".stripMargin
+        "NOT tasks.id IN (SELECT t2.id FROM tasks t2 " +
+          "INNER JOIN users u ON u.id = t2.completed_by " +
+          "WHERE t2.id = tasks.id AND u.name ILIKE '%123%')"
     }
   }
 

--- a/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterOperatorSpec.scala
@@ -109,6 +109,14 @@ class FilterOperatorSpec extends PlaySpec {
       Operator.format(KEY, parameterKey, Operator.BOOL) mustEqual s"key"
     }
 
+    "format AT operator correctly" in {
+      Operator.format(KEY, parameterKey, Operator.AT) mustEqual s"$KEY @ {$parameterKey}"
+    }
+
+    "format NOT AT operator correctly" in {
+      Operator.format(KEY, parameterKey, Operator.AT, negate = true) mustEqual s"NOT $KEY @ {$parameterKey}"
+    }
+
     "format rightValue correctly if set" in {
       Operator.format(KEY, parameterKey, Operator.EQ, value = Some("test.key")) mustEqual s"$KEY = test.key"
     }


### PR DESCRIPTION
* Add new api  /tasks/review/nearby/:proximityId which supports
  passing search parameters to determine which tasks require
  review and are closest to the given proximityId task.

* Also refactored SearchParametersMixin to use new query framework 
  as a first step to moving Tasks and TaskReview into new framework