### PR TITLE
Revert "Allow single task with line-by-line format GeoJSON"

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -577,21 +577,8 @@ class ChallengeProvider @Inject() (
     // execute regex matching against {{data:string}}, {{geocodeId:name}}, {{geocodeArea:name}}, {{geocodeBbox:name}}, {{geocodeCoords:name}}
   }
 
-  /**
-    * Determines if the given array of strings looks like line-by-line formatted
-    * GeoJSON. This check is rudimentary and only inspects up to the first 2
-    * lines to make a determination
-    */
   private def isLineByLineGeoJson(splitJson: Array[String]): Boolean = {
-    splitJson.length match {
-      case 0 => false
-      case 1 => isCompleteJSON(splitJson(0))
-      case _ => isCompleteJSON(splitJson(0)) && isCompleteJSON(splitJson(1))
-    }
+    splitJson.length > 1 && splitJson(0).startsWith("{") && splitJson(0).endsWith("}") &&
+    splitJson(1).startsWith("{") && splitJson(1).endsWith("}")
   }
-
-  /**
-    * Very rudimentary check to see if the string looks like complete json data
-    */
-  private def isCompleteJSON(data: String): Boolean = data.startsWith("{") && data.endsWith("}")
 }


### PR DESCRIPTION
This reverts commit d0f8f90744f7eb6185a1354ef94511c6fcdcbee5.

* Allowing single-line LxL resulted in the backend sometimes treating
standard challenges as LxL, which matters because in LxL the
FeatureCollection is treated as a single task with multiple features
rather than as a Challenge with multiple Tasks

* I'll make another stab at fixing the single-line LxL bug in the near
future by adding support for RFC 7464 for streaming JSON, which would
provide an explicit indicator as to when a single-line chunk is intended
to be treated as line-by-line (and would be good to support anyway as a
standard)