### PR TITLE
Moved where updateTaskPriorities is being called into future buildTasks

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -114,11 +114,6 @@ class ChallengeController @Inject() (
     }
     // we need to elevate the user permissions to super users to extract and create the tags
     this.extractTags(body, createdObject, User.superUser)
-
-    //we need to reapply task priority rules since task locations were updated
-    Future {
-      this.dal.updateTaskPriorities(user)(createdObject.id)
-    }
   }
 
   /**

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -106,6 +106,11 @@ class ChallengeProvider @Inject() (
             } else {
               this.createTasksFromJson(user, challenge, value)
             }
+
+            //we need to reapply task priority rules since task locations were updated
+            Future {
+              this.challengeDAL.updateTaskPriorities(user)(challenge.id)
+            }
           }
           true
         case _ => false


### PR DESCRIPTION
Tasks are being built as a future on challenge create so the
updating of the task priorities must be done in this future
so it happens when they are done.