### PR TITLE
Allow tasks to have attachments

### DIFF
--- a/app/org/maproulette/framework/controller/TaskController.scala
+++ b/app/org/maproulette/framework/controller/TaskController.scala
@@ -4,6 +4,7 @@
  */
 package org.maproulette.framework.controller
 
+import akka.util.ByteString
 import javax.inject.Inject
 import org.maproulette.data.ActionManager
 import org.maproulette.framework.service.TaskService
@@ -13,6 +14,7 @@ import org.maproulette.session.SessionManager
 import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
+import play.api.http.HttpEntity
 import org.maproulette.exception.NotFoundException
 
 /**
@@ -48,4 +50,67 @@ class TaskController @Inject() (
       NoContent
     }
   }
+
+  /**
+    * Retrieve a task attachment
+    */
+  def attachment(id: Long, attachmentId: String): Action[AnyContent] = Action.async {
+    implicit request =>
+      this.sessionManager.userAwareRequest { implicit user =>
+        this.taskService.getTaskAttachment(id, attachmentId) match {
+          case Some(attachment) => Ok(attachment)
+          case None             => throw new NotFoundException(s"Attachment not found.")
+        }
+      }
+  }
+
+  /**
+    * Download the data from a task attachment as a file, decoded if necessary,
+    * and with the correct mime type
+    */
+  def attachmentData(id: Long, attachmentId: String, filename: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      this.sessionManager.userAwareRequest { implicit user =>
+        this.taskService.getTaskAttachment(id, attachmentId) match {
+          case Some(attachment) =>
+            var mimeType: Option[String] = None
+            val fileContent: String = (attachment \ "type").asOpt[String] match {
+              case Some(dataType) if dataType == "geojson" || dataType == "json" =>
+                mimeType = Some("application/json")
+                Json.stringify((attachment \ "data").get)
+              case _ =>
+                (attachment \ "format").asOpt[String] match {
+                  case Some(format) if format == "json" =>
+                    mimeType = Some("application/json")
+                    Json.stringify((attachment \ "data").get)
+                  case Some(format) if format == "xml" =>
+                    mimeType = Some("text/xml")
+                    (attachment \ "encoding").asOpt[String] match {
+                      case Some(encoding) if encoding == "base64" =>
+                        new String(
+                          java.util.Base64.getDecoder.decode((attachment \ "data").as[String])
+                        )
+                      case Some(encoding) =>
+                        throw new UnsupportedOperationException("Data encoding not supported")
+                      case None => (attachment \ "data").as[String]
+                    }
+                  case _ => throw new UnsupportedOperationException("Data format not supported")
+                }
+            }
+
+            Result(
+              header = ResponseHeader(
+                OK,
+                Map(CONTENT_DISPOSITION -> s"attachment; filename=${filename}")
+              ),
+              body = HttpEntity.Strict(
+                ByteString.fromString(fileContent),
+                mimeType
+              )
+            )
+          case None =>
+            throw new NotFoundException(s"Attachment not found.")
+        }
+      }
+    }
 }

--- a/app/org/maproulette/framework/service/TaskService.scala
+++ b/app/org/maproulette/framework/service/TaskService.scala
@@ -7,7 +7,7 @@ package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.FiniteDuration
-import play.api.libs.json.JsValue
+import play.api.libs.json._
 
 import org.maproulette.exception.NotFoundException
 import org.maproulette.framework.model._
@@ -67,4 +67,13 @@ class TaskService @Inject() (repository: TaskRepository, taskDAL: TaskDAL) {
       Some(task.copy(completionResponses = Some(completionResponses.toString())))
     }
   }
+
+  /**
+    * Retrieve a task attachment identified by attachmentId
+    *
+    * @param taskId       The id of the task with the attachment
+    * @param attachmentId The id of the attachment
+    */
+  def getTaskAttachment(taskId: Long, attachmentId: String): Option[JsObject] =
+    this.repository.getTaskAttachment(taskId, attachmentId)
 }

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -479,6 +479,7 @@ class TaskDAL @Inject() (
         cooperativeWorkJson = Some(workMatch.head.toString())
       }
 
+      val attachments   = (geoJson \ "attachments").toOption
       val mrTransformer = (__ \ "properties" \ "maproulette").json.prune
       val extractedGeometries = JsArray(
         (geoJson \ "features")
@@ -511,7 +512,19 @@ class TaskDAL @Inject() (
         case None => // do nothing
       }
 
-      (JsObject(Seq("features" -> extractedGeometries)).toString, cooperativeWorkJson)
+      (
+        JsObject(
+          Seq(
+            Some("features" -> extractedGeometries),
+            Some("type"     -> JsString("FeatureCollection")),
+            attachments match {
+              case Some(a) => Some("attachments" -> a)
+              case None    => None
+            }
+          ).flatten
+        ).toString,
+        cooperativeWorkJson
+      )
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play"  %% "scalatestplus-play" % "5.0.0" % Test,
   "org.webjars"             % "swagger-ui"          % "3.25.0",
   "org.playframework.anorm" %% "anorm"              % "2.6.5",
+  "org.playframework.anorm" %% "anorm-postgres"     % "2.6.5",
   "org.postgresql"          % "postgresql"          % "42.2.10",
   "net.postgis"             % "postgis-jdbc"        % "2.3.0",
   "joda-time"               % "joda-time"           % "2.10.5",

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -233,6 +233,55 @@ GET     /task/:id/start                               @org.maproulette.controlle
 #                  underscores, dashes, and dots.
 ###
 GET     /task/:id/cooperative/change/$filename<\w[\w\d-_\.]*>            @org.maproulette.controllers.api.TaskController.cooperativeWorkChangeXML(id:Long, filename:String)
+
+###
+# tags: [ Task ]
+# summary: Retrieve task attachment
+# produces: [ application/json ]
+# description: Retrieve attachment identified by attachmentId on specified task
+#
+# responses:
+#   '200':
+#     description: The attachment data
+#   '404':
+#     description: No Task found matching the id, or no attachment found matching attachmentId
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Task for which attachment is desired
+#   - name: attachmentId
+#     in: path
+#     description: The id of the desired task attachment
+###
+GET     /task/:id/attachment/$attachmentId<[\w\d-_~\.]+>                 @org.maproulette.framework.controller.TaskController.attachment(id:Long, attachmentId:String)
+
+###
+# tags: [ Task ]
+# summary: Download task attachment data as file
+# produces: [ application/json ]
+# description: Download attachment attachment data as file
+#
+# responses:
+#   '200':
+#     description: The attachment data
+#   '404':
+#     description: No Task found matching the id, or no attachment found matching attachmentId
+# parameters:
+#   - name: id
+#     in: path
+#     description: The id of the Task for which attachment is desired
+#   - name: attachmentId
+#     in: path
+#     description: The id of the desired task attachment
+#   - name: filename
+#     in: path
+#     description: A filename to use. Some editors will use this as a hint as
+#                  to the format of the data. Must be alphanumeric with optional
+#                  underscores, dashes, and dots.
+###
+GET     /task/:id/attachment/$attachmentId<[\w\d-_~\.]+>/data/$filename<[\w\d-_\.]+>           @org.maproulette.framework.controller.TaskController.attachmentData(id:Long, attachmentId:String, filename:String)
+
+
 ###
 # tags: [ Task ]
 # summary: Release a Task (unlocks it)

--- a/test/org/maproulette/framework/FrameworkMasterSuite.scala
+++ b/test/org/maproulette/framework/FrameworkMasterSuite.scala
@@ -34,6 +34,7 @@ class FrameworkMasterSuite extends Suites with BeforeAndAfterAll with TestDataba
     new ProjectRepositorySpec,
     new TagServiceSpec,
     new TagRepositorySpec,
+    new TaskRepositorySpec,
     new TaskServiceSpec,
     new TaskReviewServiceSpec,
     new UserMetricsServiceSpec,

--- a/test/org/maproulette/framework/repository/TaskRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/TaskRepositorySpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.repository
+
+import java.util.UUID
+
+import org.maproulette.models.Task
+import org.maproulette.framework.model.User
+import org.maproulette.framework.util.{TaskTag, FrameworkHelper}
+import play.api.Application
+
+/**
+  * @author nrotstan
+  */
+class TaskRepositorySpec(implicit val application: Application) extends FrameworkHelper {
+  val repository: TaskRepository =
+    this.application.injector.instanceOf(classOf[TaskRepository])
+
+  "TaskRepository" should {
+    "retrieve task attachment" taggedAs TaskTag in {
+      val task = this.taskDAL.insert(this.getTestTaskWithAttachments(), User.superUser)
+      val attachment =
+        this.repository.getTaskAttachment(task.id, "74bc872f-8448-45ff-b8f2-66517a35b41e")
+
+      attachment.isDefined mustEqual true
+      (attachment.get \ "id").as[String] mustEqual "74bc872f-8448-45ff-b8f2-66517a35b41e"
+    }
+
+    "return None for non-existent attachment" taggedAs TaskTag in {
+      val task       = this.taskDAL.insert(this.getTestTaskWithAttachments(), User.superUser)
+      val attachment = this.repository.getTaskAttachment(task.id, "no-such-attachment-id")
+
+      attachment.isDefined mustEqual false
+    }
+  }
+
+  override implicit val projectTestName: String = "TaskRepositorySpecProject"
+
+  protected def getTestTaskWithAttachments(): Task =
+    Task(
+      -1,
+      UUID.randomUUID().toString,
+      null,
+      null,
+      this.defaultChallenge.id,
+      geometries =
+        """{"features":[{"type":"Feature","geometry":{"type":"LineString","coordinates":[[-60.811801,-32.9199812],[-60.8117804,-32.9199856],[-60.8117816,-32.9199896],[-60.8117873,-32.919984]]},"properties":{"osm_id":"OSM_W_378169283_000000_000","pbfHistory":["20200110-043000"]}}], "attachments": [{"id": "74bc872f-8448-45ff-b8f2-66517a35b41e", "kind": "referenceLayer", "type": "geojson", "name": "geojson boundary", "data": {"type": "Feature", "geometry": {"type": "Polygon", "coordinates": [[[-121.0, 48.0],[-120.0, 48.0],[-120.0, 49.0],[-121.0, 49],[-121.0, 48.0]]]}}}]}"""
+    )
+}


### PR DESCRIPTION
* Allow attachments on task FeatureCollection so that additional data
can be attached to a task, such as reference layers for use during
editing, links to relevant street-level imagery, data for consumption by
external processes, etc.

* Add API endpoint for retrieving the complete JSON representation of a
task attachment, including its raw data and metadata

* Add API endpoint for downloading task attachment data as a file,
decoded if necessary and with the proper mime type (for use with editors
importing reference layers)

* Fix missing `"type": "FeatureCollection"` on task geojson

* Fix typo in TaskRepository.scala filename

* Create TaskRepositorySpec