### PR TITLE
Add evolution to remove any negative timestamps

### DIFF
--- a/conf/evolutions/default/66.sql
+++ b/conf/evolutions/default/66.sql
@@ -1,0 +1,6 @@
+# --- !Ups
+-- Remove negative timestamps. Prior to PR #728 if the database and server
+-- ran on different machines and had different times than this could occur
+UPDATE TASKS SET completed_time_spent = NULL WHERE completed_time_spent <= 0
+
+# --- !Downs


### PR DESCRIPTION
There is a possiblity that until maproulette/maproulette2#728
was applied if the server and database had different times than
a negative timestamp could be saved for a task's
completed_time_spent. If there were enough negative timestamps
then average time per task would be negative.