### PR TITLE
Add parens when building an 'OR' filter group

### DIFF
--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -411,7 +411,7 @@ trait SearchParametersMixin {
             ),
             if (invert) AND() else OR()
           )
-        FilterGroup(List(CustomParameter(s"(${query.sql()})")))
+        query
       case Some(statuses) if statuses.isEmpty => FilterGroup(List())
       case _                                  => FilterGroup(List())
     }

--- a/app/org/maproulette/framework/psql/filter/Filter.scala
+++ b/app/org/maproulette/framework/psql/filter/Filter.scala
@@ -6,7 +6,7 @@
 package org.maproulette.framework.psql.filter
 
 import anorm.NamedParameter
-import org.maproulette.framework.psql.{AND, Query, SQLKey}
+import org.maproulette.framework.psql.{OR, AND, Query, SQLKey}
 
 /**
   * This class handles any filters that you want to add onto a query. Repositories only handle one
@@ -34,7 +34,7 @@ case class FilterGroup(params: List[Parameter[_]], key: SQLKey = AND(), conditio
     extends SQLClause {
   override def sql()(implicit tableKey: String = ""): String =
     if (condition) {
-      params
+      val result = params
         .flatMap(param =>
           param.sql() match {
             case ""  => None
@@ -42,6 +42,11 @@ case class FilterGroup(params: List[Parameter[_]], key: SQLKey = AND(), conditio
           }
         )
         .mkString(s" ${key.getSQLKey()} ")
+
+      // If we OR the results together they need to be wrapped in parens
+      if (key == OR())
+        s"(${result})"
+      else result
     } else {
       ""
     }

--- a/test/org/maproulette/framework/mixins/ReviewSearchMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/ReviewSearchMixinSpec.scala
@@ -39,7 +39,7 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
       insertParameters(query.sql(), query.parameters()) mustEqual
         "WHERE (task_review.review_requested_by IS NOT NULL) AND " +
           "(task_review.review_status <> {5}) AND " +
-          "(tasks.bundle_id IS NULL OR tasks.is_bundle_primary)"
+          "((tasks.bundle_id IS NULL OR tasks.is_bundle_primary))"
     }
 
     "enforce a permission check" in {
@@ -50,7 +50,7 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
       insertParameters(query.sql(), query.parameters()) mustEqual
         "WHERE (task_review.review_requested_by IS NOT NULL) AND " +
           "(task_review.review_status <> {5}) AND " +
-          "(tasks.bundle_id IS NULL OR tasks.is_bundle_primary) AND " +
+          "((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND " +
           "(((p.enabled AND c.enabled) OR (p.id IN ()) OR " +
           "(task_review.review_requested_by = -998) OR " +
           "(task_review.reviewed_by = -998)))"
@@ -68,9 +68,9 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
 
       insertParameters(query.sql(), query.parameters()) mustEqual
         "WHERE (task_review.review_requested_by IS NOT NULL) AND " +
-          "(task_review.review_status = {0} OR task_review.review_status = {4}) " +
+          "((task_review.review_status = {0} OR task_review.review_status = {4})) " +
           "AND (task_review.review_status <> {5}) AND " +
-          "(tasks.bundle_id IS NULL OR tasks.is_bundle_primary) AND " +
+          "((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND " +
           "(((p.enabled AND c.enabled) OR (p.id IN ())) AND " +
           "task_review.review_requested_by <> -998)"
     }
@@ -88,9 +88,9 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
 
       insertParameters(query.sql(), query.parameters()) mustEqual
         "WHERE (task_review.review_requested_by IS NOT NULL) AND " +
-          "(task_review.review_status = {0}) " +
+          "((task_review.review_status = {0})) " +
           "AND (task_review.review_status <> {5}) " +
-          "AND (tasks.bundle_id IS NULL OR tasks.is_bundle_primary) AND " +
+          "AND ((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND " +
           "(((p.enabled AND c.enabled) OR (p.id IN ())) AND task_review.review_requested_by <> -998)"
     }
 
@@ -108,8 +108,8 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
       insertParameters(query.sql(), query.parameters()) mustEqual
         "WHERE (task_review.review_requested_by IS NOT NULL) AND " +
           "(c.id IN (SELECT challenge_id from saved_challenges sc WHERE sc.user_id = -998)) AND " +
-          "(task_review.review_status = {0}) AND (task_review.review_status <> {5}) AND " +
-          "(tasks.bundle_id IS NULL OR tasks.is_bundle_primary) AND " +
+          "((task_review.review_status = {0})) AND (task_review.review_status <> {5}) AND " +
+          "((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND " +
           "(((p.enabled AND c.enabled) OR (p.id IN ())) AND " +
           "task_review.review_requested_by <> -998)"
     }
@@ -129,10 +129,10 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
 
       insertParameters(query.sql(), query.parameters()) mustEqual
         "WHERE (task_review.review_requested_by IS NOT NULL) AND " +
-          "(task_review.reviewed_by IS NULL OR task_review.reviewed_by = -998) AND " +
-          "(task_review.review_status = {0}) AND " +
+          "((task_review.reviewed_by IS NULL OR task_review.reviewed_by = -998)) AND " +
+          "((task_review.review_status = {0})) AND " +
           "(task_review.review_status <> {5}) AND " +
-          "(tasks.bundle_id IS NULL OR tasks.is_bundle_primary) AND " +
+          "((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND " +
           "(((p.enabled AND c.enabled) OR (p.id IN ())) AND task_review.review_requested_by <> -998)"
     }
 
@@ -152,7 +152,7 @@ class ReviewSearchMixinSpec() extends TestSpec with ReviewSearchMixin {
           "(tasks.status IN (1)) AND (c.id IN (123)) AND " +
           "(task_review.review_status IN (1)) AND " +
           "(task_review.review_status <> {5}) AND " +
-          "(tasks.bundle_id IS NULL OR tasks.is_bundle_primary) AND " +
+          "((tasks.bundle_id IS NULL OR tasks.is_bundle_primary)) AND " +
           "(((p.enabled AND c.enabled) OR (p.id IN ()) OR " +
           "(task_review.review_requested_by = -998) OR " +
           "(task_review.reviewed_by = -998)))"

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -276,8 +276,8 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
         invertFields = Some(List("trStatus"))
       )
       this.filterTaskReviewStatus(params).sql() mustEqual
-        "(NOT tasks.id IN (SELECT task_id FROM task_review " +
-          "WHERE task_review.task_id = tasks.id AND task_review.review_status IN (1,2)))"
+        "NOT tasks.id IN (SELECT task_id FROM task_review " +
+          "WHERE task_review.task_id = tasks.id AND task_review.review_status IN (1,2))"
     }
 
     "invert when contains -1" in {
@@ -286,10 +286,10 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
         invertFields = Some(List("trStatus"))
       )
       this.filterTaskReviewStatus(params).sql() mustEqual
-        "(NOT tasks.id IN (SELECT task_id FROM task_review " +
+        "NOT tasks.id IN (SELECT task_id FROM task_review " +
           "WHERE task_review.task_id = tasks.id AND task_review.review_status IN (1,2,-1)) " +
           "AND tasks.id IN (SELECT task_id FROM task_review task_review " +
-          "WHERE task_review.task_id = tasks.id))"
+          "WHERE task_review.task_id = tasks.id)"
     }
   }
 
@@ -299,7 +299,7 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
         SearchChallengeParameters(challengeStatus = Some(List(1, 2)))
       )
       this.filterChallengeStatus(params).sql() mustEqual
-        s"""c.status IN (1,2)"""
+        s"""(c.status IN (1,2))"""
     }
 
     "include challenge with null status when params contains -1" in {
@@ -307,7 +307,7 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
         SearchChallengeParameters(challengeStatus = Some(List(1, 2, -1)))
       )
       this.filterChallengeStatus(params).sql() mustEqual
-        s"""c.status IN (1,2,-1) OR c.status IS NULL""".stripMargin
+        s"""(c.status IN (1,2,-1) OR c.status IS NULL)""".stripMargin
     }
 
     "be empty" in {
@@ -629,10 +629,10 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
     "does search on display name and virtual project names" in {
       val params = SearchParameters(projectSearch = Some("abc"))
       this.filterProjects(params).sql() mustEqual
-        "p.display_name ILIKE '%abc%' OR " +
+        "(p.display_name ILIKE '%abc%' OR " +
           "(c.id IN (SELECT vp2.challenge_id FROM virtual_project_challenges vp2  " +
           "INNER JOIN projects p2 ON p2.id = vp2.project_id WHERE  LOWER(p2.display_name) " +
-          "LIKE LOWER('%abc%') AND p2.enabled=true))"
+          "LIKE LOWER('%abc%') AND p2.enabled=true)))"
     }
 
     "can be empty" in {

--- a/test/org/maproulette/framework/psql/FilterParameterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterParameterSpec.scala
@@ -171,7 +171,7 @@ class FilterParameterSpec extends PlaySpec {
       val filter =
         SubQueryFilter(KEY, Query.simple(List(parameter1, parameter2), "SELECT * FROM table", OR()))
       filter
-        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE key2 = {${parameter1.getKey}} OR key3 <= {${parameter2.getKey}})"
+        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE (key2 = {${parameter1.getKey}} OR key3 <= {${parameter2.getKey}}))"
       val params = filter.parameters()
       params.size mustEqual 2
       params.head mustEqual SQLUtils.buildNamedParameter(

--- a/test/org/maproulette/framework/psql/FilterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterSpec.scala
@@ -35,7 +35,7 @@ class FilterSpec extends PlaySpec {
     "Create a group of OR filter parameters" in {
       val group =
         FilterGroup(List(parameter1, parameter2), OR())
-      group.sql() mustEqual s"KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}}"
+      group.sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}})"
       val params = group.parameters()
       params.size mustEqual 2
       params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
@@ -55,7 +55,7 @@ class FilterSpec extends PlaySpec {
 
     "generate standard sql for OR parameters" in {
       val filter = Filter.simple(List(parameter1, parameter2), OR())
-      filter.sql() mustEqual s"KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}}"
+      filter.sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 2
       params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
@@ -77,7 +77,7 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR parameters" in {
       val filter = this.genericFilter(OR(), OR(), OR())
       filter
-        .sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}}) OR (KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}})"
+        .sql() mustEqual s"((KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}})) OR ((KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}}))"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -93,7 +93,7 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR/AND/OR parameters" in {
       val filter = this.genericFilter(AND(), OR(), OR())
       filter
-        .sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}}) AND (KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}})"
+        .sql() mustEqual s"((KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}})) AND ((KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}}))"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -101,7 +101,7 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR/OR/AND parameters" in {
       val filter = this.genericFilter(OR(), OR(), AND())
       filter
-        .sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}}) OR (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
+        .sql() mustEqual s"((KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}})) OR (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }

--- a/test/org/maproulette/framework/psql/QuerySpec.scala
+++ b/test/org/maproulette/framework/psql/QuerySpec.scala
@@ -139,7 +139,7 @@ class QuerySpec extends PlaySpec {
     )
 
     query
-      .sql() mustEqual s"""SELECT * FROM table WHERE (KEY = {$setKey} OR key2 = {${parameter2.getKey}}) AND (a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2}) AND (${FilterParameterSpec
+      .sql() mustEqual s"""SELECT * FROM table WHERE ((KEY = {$setKey} OR key2 = {${parameter2.getKey}})) AND ((a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2})) AND (${FilterParameterSpec
       .DEFAULT_FUZZY_SQL(
         "fuzzy",
         keyPrefix = parameter5.randomPrefix


### PR DESCRIPTION
  There are cases where a filter group with an OR condition
  would not be wrapped in parenthesis and thus cause an
  incorrect search. To be on the safe side wrap all OR
  filter groups with ( )

fixes osmlab/maproulette3#1297