### PR TITLE
Fix custom date range search for leaderboard

### DIFF
--- a/app/org/maproulette/framework/service/LeaderboardService.scala
+++ b/app/org/maproulette/framework/service/LeaderboardService.scala
@@ -400,6 +400,9 @@ class LeaderboardService @Inject() (
       endDate = new DateTime()
       if (monthDuration.get == -1) {
         startDate = new DateTime(2000, 1, 1, 12, 0, 0, 0)
+      }
+      else if (monthDuration.get == 0) {
+        startDate = new DateTime().withDayOfMonth(1)
       } else {
         startDate = new DateTime().minusMonths(monthDuration.get)
       }

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -465,8 +465,8 @@ object SearchParameters {
           case Some(r) => Utils.toLongList(r)
           case None => params.reviewParams.reviewers
         },
-        this.getStringParameter(request.getQueryString("startDate"), params.reviewParams.startDate),
-        this.getStringParameter(request.getQueryString("endDate"), params.reviewParams.endDate)
+        this.getStringParameter(request.getQueryString("start"), params.reviewParams.startDate),
+        this.getStringParameter(request.getQueryString("end"), params.reviewParams.endDate)
       ),
       // Search Leaderboard Parameters
       new SearchLeaderboardParameters(


### PR DESCRIPTION
After refactor, code was looking at wrong url parameter names for 'start' and 'end' dates.