### PR TITLE
Add timezone value for exporting csv and geojson

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -652,6 +652,7 @@ class ChallengeController @Inject() (
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
+        // Verify timzone offset is valid (eg. -10:00 or +04:00 or 06:30:00)
         val tzRegex = "^[\\+]?([\\-]?[\\d]?\\d)\\:([\\d]?\\d)(\\:\\d\\d)?$".r
         val dateTimeZone =
           timezone match {

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -11,7 +11,7 @@ import java.util.zip.{ZipEntry, ZipOutputStream}
 import akka.util.ByteString
 import javax.inject.Inject
 import org.apache.commons.lang3.StringUtils
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 import org.maproulette.Config
 import org.maproulette.controllers.ParentController
 import org.maproulette.data._
@@ -141,7 +141,8 @@ class ChallengeController @Inject() (
       challengeId: Long,
       statusFilter: String,
       reviewStatusFilter: String,
-      priorityFilter: String
+      priorityFilter: String,
+      timezone: String
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
@@ -171,7 +172,7 @@ class ChallengeController @Inject() (
               body = HttpEntity.Strict(
                 ByteString(
                   this.dal
-                    .getChallengeGeometry(challengeId, status, reviewStatus, priority, Some(params))
+                    .getChallengeGeometry(challengeId, status, reviewStatus, priority, Some(params), timezone)
                 ),
                 Some("application/json;charset=utf-8;header=present")
               )
@@ -586,11 +587,12 @@ class ChallengeController @Inject() (
     * Extracts all the tasks belonging to the challenges in the project and
     * returns them in a nice format like csv.
     *
-    * @param projectId The id of the project
-    * @param cId Optional list of challenges
+    * @param projectId    The id of the project
+    * @param cId          Optional list of challenges
+    * @param timezone     The timezone offset (ie. -07:00)
     * @return A csv list of tasks for the project
     */
-  def extractAllTaskSummaries(projectId: Long, cId: Option[String]): Action[AnyContent] = {
+  def extractAllTaskSummaries(projectId: Long, cId: Option[String], timezone: String = Utils.UTC_TIMEZONE): Action[AnyContent] = {
     var challengeIds: List[Long] = cId match {
       case Some(c) => Utils.toLongList(c).getOrElse(List())
       case None    => List()
@@ -601,7 +603,8 @@ class ChallengeController @Inject() (
         case None    => throw new NotFoundException(s"Project with id $projectId not found")
       }
     }
-    this._extractTaskSummaries(challengeIds, -1, 0, "-1", "", "", s"project_${projectId}_tasks.csv")
+    this._extractTaskSummaries(challengeIds, -1, 0, "-1", "", "", s"project_${projectId}_tasks.csv",
+                               timezone = timezone)
   }
 
   /**
@@ -610,6 +613,7 @@ class ChallengeController @Inject() (
     * @param challengeId The id of the challenge
     * @param limit       limit the number of results
     * @param page        Used for paging
+    * @param timezone    The timezone offset (ie. -07:00)
     * @return A csv list of tasks for the challenge
     */
   def extractTaskSummaries(
@@ -619,7 +623,8 @@ class ChallengeController @Inject() (
       statusFilter: String,
       reviewStatusFilter: String,
       priorityFilter: String,
-      exportProperties: String = ""
+      exportProperties: String = "",
+      timezone: String = Utils.UTC_TIMEZONE
   ): Action[AnyContent] = {
     this._extractTaskSummaries(
       List(challengeId),
@@ -629,7 +634,8 @@ class ChallengeController @Inject() (
       reviewStatusFilter,
       priorityFilter,
       s"challenge_${challengeId}_tasks.csv",
-      exportProperties
+      exportProperties,
+      timezone
     )
   }
 
@@ -641,10 +647,23 @@ class ChallengeController @Inject() (
       reviewStatusFilter: String,
       priorityFilter: String,
       filename: String,
-      exportProperties: String = ""
+      exportProperties: String = "",
+      timezone: String
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
+        val tzRegex = "^[\\+]?([\\-]?[\\d]?\\d)\\:([\\d]?\\d)(\\:\\d\\d)?$".r
+        val dateTimeZone =
+          timezone match {
+            case tzRegex(hours, minutes, seconds) =>
+              DateTimeZone.forOffsetHoursMinutes(hours.toInt, minutes.toInt)
+            case _  =>
+              if (timezone.isEmpty())
+                DateTimeZone.getDefault
+              else
+                throw new InvalidException("Timezone is not a valid time zone. [" + timezone + "]")
+          }
+
         val status = if (StringUtils.isEmpty(statusFilter)) {
           None
         } else {
@@ -782,18 +801,26 @@ class ChallengeController @Inject() (
 
           var comments      = allComments(task.taskId).replaceAll("\"", "\"\"")
           var challengeLink = s"[[hyperlink URL link=${urlPrefix}browse/challenges/${task.parent}]]"
+          val mappedOn = task.mappedOn match {
+            case Some(m) => m.withZone(dateTimeZone)
+            case _ => ""
+          }
+
+          val reviewedAt = task.reviewedAt match {
+            case Some(d) => d.withZone(dateTimeZone)
+            case _ => ""
+          }
+
           var taskLink =
             s"[[hyperlink URL link=${urlPrefix}challenge/${task.parent}/task/${task.taskId}]]"
 
           s"""${task.taskId},${taskLink},${task.parent},${challengeLink},"${task.name}","${Task.statusMap
             .get(task.status)
             .get}",""" +
-            s""""${Challenge.priorityMap.get(task.priority).get}",${task.mappedOn
-              .getOrElse("")},""" +
+            s""""${Challenge.priorityMap.get(task.priority).get}",${mappedOn},""" +
             s"""${task.completedTimeSpent.getOrElse("")},"${mapper}",""" +
             s"""${Task.reviewStatusMap.get(task.reviewStatus.getOrElse(-1)).get},""" +
-            s""""${task.reviewedBy.getOrElse("")}",${task.reviewedAt
-              .getOrElse("")},"${reviewTimeSeconds}",""" +
+            s""""${task.reviewedBy.getOrElse("")}",${reviewedAt},"${reviewTimeSeconds}",""" +
             s""""${comments}","${task.bundleId.getOrElse("")}","${task.isBundlePrimary
               .getOrElse("")}",""" +
             s""""${task.tags.getOrElse("")}"${propData}${responseData}""".stripMargin

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -950,6 +950,7 @@ class ChallengeDAL @Inject() (
     this.withMRConnection { implicit c =>
       val filters = new StringBuilder()
 
+      // Verify timzone offset is valid (eg. -10:00 or +04:00 or 06:30:00)
       val tzOffset =
         timezone.matches("^[\\+\\-]*\\d\\d\\:\\d\\d(\\:\\d\\d)?$") match {
           case true => timezone

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -22,6 +22,7 @@ import org.maproulette.models._
 import org.maproulette.models.dal.mixin.{OwnerMixin, TagDALMixin}
 import org.maproulette.permissions.Permission
 import org.maproulette.session.SearchParameters
+import org.maproulette.utils.Utils
 import play.api.db.Database
 import play.api.libs.json.JodaReads._
 import play.api.libs.json.{JsString, JsValue, Json}
@@ -934,6 +935,7 @@ class ChallengeDAL @Inject() (
     * @param reviewStatusFilter To view the geojson for only challenges with a specific review status
     * @param priorityFilter     To view the geojson for only challenges with a specific priority
     * @param params             SearchParameters for filtering by taskPropertySearch
+    * @param timezone           The timezone offset (ie. -07:00)
     * @param c                  The implicit connection for the function
     * @return
     */
@@ -942,10 +944,21 @@ class ChallengeDAL @Inject() (
       statusFilter: Option[List[Int]] = None,
       reviewStatusFilter: Option[List[Int]] = None,
       priorityFilter: Option[List[Int]] = None,
-      params: Option[SearchParameters] = None
+      params: Option[SearchParameters] = None,
+      timezone: String = Utils.UTC_TIMEZONE
   )(implicit c: Option[Connection] = None): String = {
     this.withMRConnection { implicit c =>
       val filters = new StringBuilder()
+
+      val tzOffset =
+        timezone.matches("^[\\+\\-]*\\d\\d\\:\\d\\d(\\:\\d\\d)?$") match {
+          case true => timezone
+          case false =>
+            if (timezone.isEmpty)
+              Utils.UTC_TIMEZONE
+            else
+              throw new InvalidException("Timezone is not a valid time zone. [" + timezone + "]")
+        }
 
       statusFilter match {
         case Some(s) => filters.append(s"AND t.status IN (${s.mkString(",")})")
@@ -1041,7 +1054,11 @@ class ChallengeDAL @Inject() (
                                             WHEN t.priority = #${Challenge.PRIORITY_MEDIUM} THEN ${Challenge.PRIORITY_MEDIUM_NAME}
                                             WHEN t.priority = #${Challenge.PRIORITY_LOW} THEN ${Challenge.PRIORITY_LOW_NAME}
                                            END)) ||
-                                        hstore('mr_mappedOn', t.mapped_on::text) ||
+                                        hstore('mr_mappedOn',
+                                                TO_CHAR(t.mapped_on::TIMESTAMPTZ at time zone
+                                                  (select name from pg_timezone_names where utc_offset='#${tzOffset}' limit 1),
+                                                  'YYYY-MM-DD"T"HH24:MI:SS#${tzOffset}'))
+                                        ||
                                         hstore('mr_mapper',
                                           (CASE WHEN t.review_requested_by = NULL
                                            THEN (select name from users where osm_id=t.osm_user_id)::text
@@ -1057,7 +1074,11 @@ class ChallengeDAL @Inject() (
                                             WHEN t.review_status = #${Task.REVIEW_STATUS_UNNECESSARY} THEN ${Task.REVIEW_STATUS_UNNECESSARY_NAME}
                                            END)) ||
                                         hstore('mr_reviewer', (select name from users where id=t.reviewed_by)::text) ||
-                                        hstore('mr_reviewedAt', t.reviewed_at::text) ||
+                                        hstore('mr_reviewedAt',
+                                          TO_CHAR(t.reviewed_at::TIMESTAMPTZ at time zone
+                                            (select name from pg_timezone_names where utc_offset='#${tzOffset}' limit 1),
+                                            'YYYY-MM-DD"T"HH24:MI:SS#${tzOffset}'))
+                                        ||
                                         hstore('mr_reviewTimeSeconds', FLOOR(EXTRACT(EPOCH FROM (t.reviewed_at - t.review_started_at)))::text) ||
                                         hstore('mr_tags', (SELECT STRING_AGG(tg.name, ',') AS tags
                                                             FROM tags_on_tasks tot, tags tg

--- a/app/org/maproulette/utils/Utils.scala
+++ b/app/org/maproulette/utils/Utils.scala
@@ -23,6 +23,7 @@ import scala.util.{Failure, Random, Success, Try}
   * @author cuthbertm
   */
 object Utils extends DefaultWrites {
+  val UTC_TIMEZONE = "+00:00"
 
   def randomStringFromCharList(
       length: Int,

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -863,8 +863,12 @@ GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers
 #   - name: taskPropertySearch
 #     in: POST form data
 #     description: Can filter by specific task properties.
+#   - name: timezone
+#     in: query
+#     description: A timezone offset to apply to time fields. Format should be like '+HH:MM'. Default is GMT (+00:00)
+#     required: optional
 ###
-GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
+GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves Challenge GeoJSON
@@ -892,7 +896,7 @@ GET     /challenge/view/:id                         @org.maproulette.controllers
 #     in: POST form data
 #     description: Can filter by specific task properties.
 ###
-POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "")
+POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves clustered Task points
@@ -1040,8 +1044,12 @@ GET     /challenge/:id/comments/extract             @org.maproulette.controllers
 #   - name: taskPropertySearch
 #     in: POST form data
 #     description: Can filter by specific task properties.
+#   - name: timezone
+#     in: query
+#     description: A timezone offset to apply to time fields. Format should be like '+HH:MM'. Default is GMT (+00:00)
+#     required: optional
 ###
-GET     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", exportProperties:String ?= "")
+GET     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", exportProperties:String ?= "", timezone:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieve summaries of all tasks for Challenge
@@ -1074,8 +1082,12 @@ GET     /challenge/:id/tasks/extract             @org.maproulette.controllers.ap
 #   - name: taskPropertySearch
 #     in: POST form data
 #     description: Can filter by specific task properties.
+#   - name: timezone
+#     in: query
+#     description: A timezone offset to apply to time fields. Format should be like '+HH:MM'. Default is GMT (+00:00)
+#     required: optional
 ###
-POST     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", exportProperties:String ?= "")
+POST     /challenge/:id/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractTaskSummaries(id:Long, limit:Int ?= -1, page:Int ?= 0, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", exportProperties:String ?= "", timezone:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Match OSM Changesets

--- a/conf/v2_route/project.api
+++ b/conf/v2_route/project.api
@@ -364,8 +364,12 @@ GET     /project/:id/comments                     @org.maproulette.framework.con
 #     in: query
 #     description: A list of challengeIds to include. If not provided, then all challenges in the project are used.
 #     required: optional
+#   - name: timezone
+#     in: query
+#     description: A timezone offset to apply to time fields. Format should be like '+HH:MM'. Default is GMT (+00:00)
+#     required: optional
 ###
-GET     /project/:projectId/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractAllTaskSummaries(projectId:Long, cId:Option[String])
+GET     /project/:projectId/tasks/extract             @org.maproulette.controllers.api.ChallengeController.extractAllTaskSummaries(projectId:Long, cId:Option[String], timezone:String ?= "")
 ###
 # tags: [ Project ]
 # summary: Retrieves random Task


### PR DESCRIPTION
When exporting challenge csv and geoson allow for an optional
timezone offset that will convert mappedOn and reviewedAt dates