### PR TITLE
Add preferredReviewTags field to Challenge

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -643,7 +643,7 @@ class TaskController @Inject() (
 
       val tagList = tags.split(",").toList
       if (tagList.nonEmpty) {
-        this.addTagstoItem(id, tagList.map(new Tag(-1, _, tagType = this.dal.tableName)), user)
+        this.addTagstoItem(id, tagList.map(new Tag(-1, _, tagType = "review")), user)
       }
 
       NoContent

--- a/app/org/maproulette/framework/controller/TagController.scala
+++ b/app/org/maproulette/framework/controller/TagController.scala
@@ -137,7 +137,7 @@ class TagController @Inject() (
   def getTags(prefix: String, tagType: String, limit: Int, offset: Int): Action[AnyContent] =
     Action.async { implicit request =>
       this.sessionManager.userAwareRequest { implicit user =>
-        Ok(Json.toJson(this.service.find(prefix, tagType, Paging(limit, offset))))
+        Ok(Json.toJson(this.service.find(prefix, Utils.split(tagType.trim), Paging(limit, offset))))
       }
     }
 

--- a/app/org/maproulette/framework/graphql/schemas/TagSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/TagSchema.scala
@@ -42,7 +42,7 @@ class TagSchema @Inject() (override val service: TagService)
       resolve = context =>
         this.service.find(
           context.arg(TagSchema.searchStringArg),
-          context.arg(TagSchema.tagTypeArg),
+          List(context.arg(TagSchema.tagTypeArg)),
           Paging(context.arg(MRSchema.pagingLimitArg), context.arg(MRSchema.pagingOffsetArg)),
           Order(context.arg(MRSchema.orderArg).getOrElse(Seq.empty).toList.map(OrderField(_))),
           context.arg(TagSchema.usePrefixArg)

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -321,7 +321,7 @@ trait SearchParametersMixin {
       val tagList = params.taskParams.taskTags.get
         .map(t => {
           SQLUtils.testColumnName(t)
-          s"'${t}'"
+          s"'${t.trim.toLowerCase()}'"
         })
         .mkString(",")
 

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -127,6 +127,9 @@ case class ChallengeExtra(
     exportableProperties: Option[String] = None,
     osmIdProperty: Option[String] = None,
     preferredTags: Option[String] = None,
+    preferredReviewTags: Option[String] = None,
+    limitTags: Boolean = false,       // If true, only preferred tags should be used
+    limitReviewTags: Boolean = false, // If true, only preferred review tags should be used
     taskStyles: Option[String] = None
 ) extends DefaultWrites
 

--- a/app/org/maproulette/framework/model/TaskReview.scala
+++ b/app/org/maproulette/framework/model/TaskReview.scala
@@ -60,8 +60,9 @@ case class ReviewMetrics(
     alreadyFixed: Int,
     tooHard: Int,
     avgReviewTime: Double,
-    userId: Option[Long] = None,   // If these metrics apply to a particular user
-    tagName: Option[String] = None // If these metrics apply for a particular tag
+    userId: Option[Long] = None,    // If these metrics apply to a particular user
+    tagName: Option[String] = None, // If these metrics apply for a particular tag
+    tagType: Option[String] = None  // If these metrics apply for a particular tag with tag type
 )
 object ReviewMetrics {
   implicit val reviewMetricsWrites = Json.writes[ReviewMetrics]

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -133,6 +133,9 @@ object ChallengeRepository {
       get[Option[String]]("challenges.exportable_properties") ~
       get[Option[String]]("challenges.osm_id_property") ~
       get[Option[String]]("challenges.preferred_tags") ~
+      get[Option[String]]("challenges.preferred_review_tags") ~
+      get[Boolean]("challenges.limit_tags") ~
+      get[Boolean]("challenges.limit_review_tags") ~
       get[Option[String]]("challenges.task_styles") ~
       get[Option[DateTime]]("challenges.last_task_refresh") ~
       get[Option[DateTime]]("challenges.data_origin_date") ~
@@ -145,7 +148,8 @@ object ChallengeRepository {
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
-            customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ taskStyles ~ lastTaskRefresh ~
+            customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ preferredReviewTags ~
+            limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
             dataOriginDate ~ requiresLocal ~ location ~ bounding ~ deleted ~ virtualParents =>
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
@@ -195,6 +199,9 @@ object ChallengeRepository {
             exportableProperties,
             osmIdProperty,
             preferredTags,
+            preferredReviewTags,
+            limitTags,
+            limitReviewTags,
             taskStyles
           ),
           status,

--- a/app/org/maproulette/framework/service/LeaderboardService.scala
+++ b/app/org/maproulette/framework/service/LeaderboardService.scala
@@ -400,8 +400,7 @@ class LeaderboardService @Inject() (
       endDate = new DateTime()
       if (monthDuration.get == -1) {
         startDate = new DateTime(2000, 1, 1, 12, 0, 0, 0)
-      }
-      else if (monthDuration.get == 0) {
+      } else if (monthDuration.get == 0) {
         startDate = new DateTime().withDayOfMonth(1)
       } else {
         startDate = new DateTime().minusMonths(monthDuration.get)

--- a/app/org/maproulette/framework/service/TagService.scala
+++ b/app/org/maproulette/framework/service/TagService.scala
@@ -105,7 +105,7 @@ class TagService @Inject() (
     */
   def find(
       searchString: String,
-      tagType: String = "challenges",
+      tagTypes: List[String] = List("challenges"),
       paging: Paging = Paging(),
       order: Order = Order(),
       usePrefix: Boolean = false
@@ -116,8 +116,9 @@ class TagService @Inject() (
           BaseParameter(Tag.FIELD_NAME, SQLUtils.search(searchString, usePrefix), Operator.ILIKE),
           FilterParameter.conditional(
             Tag.FIELD_TAG_TYPE,
-            tagType.trim,
-            includeOnlyIfTrue = tagType.trim.nonEmpty
+            tagTypes.mkString(","),
+            Operator.IN,
+            includeOnlyIfTrue = tagTypes.nonEmpty
           )
         ),
         paging = paging,

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -102,6 +102,9 @@ class ChallengeDAL @Inject() (
       get[Option[String]]("challenges.exportable_properties") ~
       get[Option[String]]("challenges.osm_id_property") ~
       get[Option[String]]("challenges.preferred_tags") ~
+      get[Option[String]]("challenges.preferred_review_tags") ~
+      get[Boolean]("challenges.limit_tags") ~
+      get[Boolean]("challenges.limit_review_tags") ~
       get[Option[String]]("challenges.task_styles") ~
       get[Option[DateTime]]("challenges.last_task_refresh") ~
       get[Option[DateTime]]("challenges.data_origin_date") ~
@@ -113,7 +116,8 @@ class ChallengeDAL @Inject() (
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
-            customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ taskStyles ~ lastTaskRefresh ~
+            customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ preferredReviewTags ~
+            limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
             dataOriginDate ~ location ~ bounding ~ requiresLocal ~ deleted =>
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
@@ -163,6 +167,9 @@ class ChallengeDAL @Inject() (
             exportableProperties,
             osmIdProperty,
             preferredTags,
+            preferredReviewTags,
+            limitTags,
+            limitReviewTags,
             taskStyles
           ),
           status,
@@ -215,6 +222,9 @@ class ChallengeDAL @Inject() (
       get[Option[String]]("challenges.exportable_properties") ~
       get[Option[String]]("challenges.osm_id_property") ~
       get[Option[String]]("challenges.preferred_tags") ~
+      get[Option[String]]("challenges.preferred_review_tags") ~
+      get[Boolean]("challenges.limit_tags") ~
+      get[Boolean]("challenges.limit_review_tags") ~
       get[Option[String]]("challenges.task_styles") ~
       get[Option[DateTime]]("challenges.last_task_refresh") ~
       get[Option[DateTime]]("challenges.data_origin_date") ~
@@ -228,7 +238,8 @@ class ChallengeDAL @Inject() (
             checkin_comment ~ checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~
             defaultPriority ~ highPriorityRule ~ mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~
             minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~ customBasemap ~ updateTasks ~
-            exportableProperties ~ osmIdProperty ~ preferredTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~
+            exportableProperties ~ osmIdProperty ~ preferredTags ~ preferredReviewTags ~ limitTags ~
+            limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~
             location ~ bounding ~ requiresLocal ~ deleted ~ virtualParents =>
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
@@ -278,6 +289,9 @@ class ChallengeDAL @Inject() (
             exportableProperties,
             osmIdProperty,
             preferredTags,
+            preferredReviewTags,
+            limitTags,
+            limitReviewTags,
             taskStyles
           ),
           status,
@@ -419,7 +433,8 @@ class ChallengeDAL @Inject() (
                                       overpass_ql, remote_geo_json, status, status_message, default_priority, high_priority_rule,
                                       medium_priority_rule, low_priority_rule, default_zoom, min_zoom, max_zoom,
                                       default_basemap, default_basemap_id, custom_basemap, updatetasks, exportable_properties,
-                                      osm_id_property, last_task_refresh, data_origin_date, preferred_tags, task_styles, requires_local)
+                                      osm_id_property, last_task_refresh, data_origin_date, preferred_tags, preferred_review_tags,
+                                      limit_tags, limit_review_tags, task_styles, requires_local)
               VALUES (${challenge.name}, ${challenge.general.owner}, ${challenge.general.parent}, ${challenge.general.difficulty},
                       ${challenge.description}, ${challenge.infoLink}, ${challenge.general.blurb}, ${challenge.general.instruction},
                       ${challenge.general.enabled}, ${challenge.general.featured},
@@ -430,7 +445,8 @@ class ChallengeDAL @Inject() (
                       ${challenge.extra.exportableProperties}, ${challenge.extra.osmIdProperty},
                       ${challenge.lastTaskRefresh.getOrElse(DateTime.now()).toString}::timestamptz,
                       ${challenge.dataOriginDate.getOrElse(DateTime.now()).toString}::timestamptz,
-                      ${challenge.extra.preferredTags}, ${challenge.extra.taskStyles}, ${challenge.general.requiresLocal})
+                      ${challenge.extra.preferredTags}, ${challenge.extra.preferredReviewTags}, ${challenge.extra.limitTags},
+                      ${challenge.extra.limitReviewTags}, ${challenge.extra.taskStyles}, ${challenge.general.requiresLocal})
                       ON CONFLICT(parent_id, LOWER(name)) DO NOTHING RETURNING #${this.retrieveColumns}"""
           .as(this.parser.*)
           .headOption
@@ -556,6 +572,15 @@ class ChallengeDAL @Inject() (
           val preferredTags = (updates \ "preferredTags")
             .asOpt[String]
             .getOrElse(cachedItem.extra.preferredTags.getOrElse(null))
+          val preferredReviewTags = (updates \ "preferredReviewTags")
+            .asOpt[String]
+            .getOrElse(cachedItem.extra.preferredReviewTags.getOrElse(null))
+          val limitTags = (updates \ "limitTags")
+            .asOpt[Boolean]
+            .getOrElse(cachedItem.extra.limitTags)
+          val limitReviewTags = (updates \ "limitReviewTags")
+            .asOpt[Boolean]
+            .getOrElse(cachedItem.extra.limitReviewTags)
           val taskStyles = (updates \ "taskStyles").asOpt[JsValue] match {
             case Some(ts) => ts.toString()
             case _        => cachedItem.extra.taskStyles.getOrElse(null)
@@ -586,7 +611,8 @@ class ChallengeDAL @Inject() (
           }},
                 default_zoom = $defaultZoom, min_zoom = $minZoom, max_zoom = $maxZoom, default_basemap = $defaultBasemap, default_basemap_id = $defaultBasemapId,
                 custom_basemap = $customBasemap, updatetasks = $updateTasks, exportable_properties = $exportableProperties,
-                osm_id_property = $osmIdProperty, preferred_tags = $preferredTags, task_styles = $taskStyles,
+                osm_id_property = $osmIdProperty, preferred_tags = $preferredTags, preferred_review_tags = $preferredReviewTags,
+                limit_tags = $limitTags, limit_review_tags = $limitReviewTags, task_styles = $taskStyles,
                 requires_local = $requiresLocal
               WHERE id = $id RETURNING #${this.retrieveColumns}""".as(parser.*).headOption
         }

--- a/conf/evolutions/default/67.sql
+++ b/conf/evolutions/default/67.sql
@@ -1,0 +1,13 @@
+# --- !Ups
+-- Add preferred_review_tags, limit_tags and limit_review_tags
+ALTER TABLE IF EXISTS challenges
+  ADD COLUMN preferred_review_tags VARCHAR,
+  ADD COLUMN limit_tags BOOLEAN DEFAULT false,
+  ADD COLUMN limit_review_tags BOOLEAN DEFAULT false;;
+
+# --- !Downs
+-- Remove added columns
+ALTER TABLE IF EXISTS challenges
+  DROP COLUMN preferred_review_tags,
+  DROP COLUMN limit_tags,
+  DROP COLUMN limit_review_tags;;


### PR DESCRIPTION
* Add preferredReviewTags to challenge which are the tags
  the challenge owner prefers to be used during review

* Add limitTags and limitReviewTags to Challenge which
  indicates the tags should be limited exclusively to the
  preferred list.

* Add tagType field to return with tag metrics

* When calling setTaskReviewStatus with tags, the tags
  will be stored as 'review' tags.

* Tag metrics api to accept an array (a comma string)
  of tag types (ie. "tasks,review").