### PR TITLE
Fix challenge creation requiring optional fields

### DIFF
--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -77,13 +77,23 @@ trait ChallengeReads extends DefaultReads {
 
   implicit val challengeExtraReads = new Reads[ChallengeExtra] {
     def reads(json: JsValue): JsResult[ChallengeExtra] = {
-      val jsonWithStyles =
+      var jsonWithExtras =
         (json \ "taskStyles").asOpt[JsValue] match {
           case Some(value) => Utils.insertIntoJson(json, "taskStyles", value.toString(), true)
           case None        => json
         }
 
-      Json.fromJson[ChallengeExtra](jsonWithStyles)(Json.reads[ChallengeExtra])
+      jsonWithExtras = (jsonWithExtras \ "limitTags").asOpt[JsValue] match {
+          case Some(value) => jsonWithExtras
+          case None        => Utils.insertIntoJson(jsonWithExtras, "limitTags", false, true)
+        }
+
+      jsonWithExtras = (jsonWithExtras \ "limitReviewTags").asOpt[JsValue] match {
+          case Some(value) => jsonWithExtras
+          case None        => Utils.insertIntoJson(jsonWithExtras, "limitReviewTags", false, true)
+        }
+
+      Json.fromJson[ChallengeExtra](jsonWithExtras)(Json.reads[ChallengeExtra])
     }
   }
 

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -286,6 +286,12 @@ object SearchParameters {
         Map[String, JsValue](),
         false
       )
+      jsonWithAdditionalParams = Utils.insertIntoJson(
+        jsonWithAdditionalParams,
+        "leaderboardParams",
+        Map[String, JsValue]("onlyEnabled" -> JsBoolean(true)),
+        false
+      )
 
       Json.fromJson[SearchParameters](jsonWithAdditionalParams)(Json.reads[SearchParameters])
     }


### PR DESCRIPTION
* Challenge creation was requiring 'limitTags' and 'limitReviewTags'

* VirtualChallenge creation was missing leaderboardParams