### PR TITLE
Allow task status to be changed during review revision

### DIFF
--- a/app/org/maproulette/controllers/api/TaskBundleController.scala
+++ b/app/org/maproulette/controllers/api/TaskBundleController.scala
@@ -118,6 +118,7 @@ class TaskBundleController @Inject() (
     * @param reviewStatus The review status id to set the task's review status to
     * @param comment      An optional comment to add to the task
     * @param tags         Optional tags to add to the task
+    * @param newTaskStatus  Optional new taskStatus to change on all tasks in bundle
     * @return 400 BadRequest if task with supplied id not found.
     *         If successful then 200 NoContent
     */
@@ -125,12 +126,32 @@ class TaskBundleController @Inject() (
       id: Long,
       reviewStatus: Int,
       comment: String = "",
-      tags: String = ""
+      tags: String = "",
+      newTaskStatus: String = ""
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      val tasks = this.dalManager.taskBundle.getTaskBundle(user, id).tasks match {
+      var tasks = this.dalManager.taskBundle.getTaskBundle(user, id).tasks match {
         case Some(t) => t
         case None    => throw new InvalidException("No tasks found in this bundle.")
+      }
+
+      // If the mapper wants to change the task status while revising the task after review
+      if (!newTaskStatus.isEmpty) {
+        val taskStatus = newTaskStatus.toInt
+
+        for (task <- tasks) {
+          // Make sure to remove user's score credit for the prior task status first.
+          this.serviceManager.userMetrics.rollbackUserScore(task.status.get, user.id)
+        }
+
+        // Change task status. This will also credit user's score for new task status.
+        this.dalManager.task.setTaskStatus(tasks, taskStatus, user, Some(false))
+        tasks = this.dalManager.task.retrieveListById()(tasks.map(_.id))
+
+        for (task <- tasks) {
+          this.actionManager
+            .setAction(Some(user), new TaskItem(task.id), TaskStatusSet(taskStatus), task.name)
+        }
       }
 
       for (task <- tasks) {

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -628,25 +628,25 @@ class TaskController @Inject() (
       newTaskStatus: String = ""
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedRequest { implicit user =>
-      var task = this.dal.retrieveById(id) match {
-        case Some(t) => t
+      val task = this.dal.retrieveById(id) match {
+        case Some(t) => {
+          // If the mapper wants to change the task status while revising the task after review
+          if (!newTaskStatus.isEmpty) {
+            val taskStatus = newTaskStatus.toInt
+
+            // Make sure to remove user's score credit for the prior task status first.
+            this.serviceManager.userMetrics.rollbackUserScore(t.status.get, user.id)
+
+            // Change task status. This will also credit user's score for new task status.
+            this.dal.setTaskStatus(List(t), taskStatus, user, Some(false))
+            this.actionManager
+              .setAction(Some(user), new TaskItem(t.id), TaskStatusSet(taskStatus), t.name)
+            // Refetch Task
+            this.dal.retrieveById(id).get
+          } else t
+        }
         case None =>
           throw new NotFoundException(s"Task with $id not found, cannot set review status.")
-      }
-
-      // If the mapper wants to change the task status while revising the task after review
-      if (!newTaskStatus.isEmpty) {
-        val taskStatus = newTaskStatus.toInt
-
-        // Make sure to remove user's score credit for the prior task status first.
-        this.serviceManager.userMetrics.rollbackUserScore(task.status.get, user.id)
-
-        // Change task status. This will also credit user's score for new task status.
-        this.dal.setTaskStatus(List(task), taskStatus, user, Some(false))
-        this.actionManager
-          .setAction(Some(user), new TaskItem(task.id), TaskStatusSet(taskStatus), task.name)
-        // Refetch Task
-        task = this.dal.retrieveById(id).get
       }
 
       val action = this.actionManager

--- a/conf/v2_route/task.api
+++ b/conf/v2_route/task.api
@@ -729,8 +729,11 @@ PUT     /taskBundle/:bundleId/:status                           @org.maproulette
 #     description: Any comment that is provided by the user when setting the review status
 #   - name: tags
 #     description: Optional tags to associate with this task
+#   - name: newTaskStatus
+#     in: query
+#     description: Optional int taskStatus to change the task status on this task to
 ###
-PUT     /task/:id/review/:status                           @org.maproulette.controllers.api.TaskController.setTaskReviewStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="")
+PUT     /task/:id/review/:status                           @org.maproulette.controllers.api.TaskController.setTaskReviewStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="", newTaskStatus:String ?= "")
 ###
 # tags: [ Task ]
 # summary: Changes review status to "Unnecessary" on tasks matching criteria
@@ -782,8 +785,11 @@ PUT     /tasks/review/remove                               @org.maproulette.cont
 #     description: Any comment that is provided by the user when setting the review status
 #   - name: tags
 #     description: Optional tags to associate with this task
+#   - name: newTaskStatus
+#     in: query
+#     description: Optional int taskStatus to change the task status on all tasks in this bundle to
 ###
-PUT     /taskBundle/:id/review/:status                     @org.maproulette.controllers.api.TaskBundleController.setBundleTaskReviewStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="")
+PUT     /taskBundle/:id/review/:status                     @org.maproulette.controllers.api.TaskBundleController.setBundleTaskReviewStatus(id:Long, status:Int, comment:String ?= "", tags:String ?="", newTaskStatus:String ?= "")
 ###
 # tags: [ Task ]
 # summary: Retrieves task clusters.

--- a/test/org/maproulette/framework/service/UserMetricsServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserMetricsServiceSpec.scala
@@ -50,6 +50,25 @@ class UserMetricsServiceSpec(implicit val application: Application) extends Fram
         Some(0),
         insertedUser.id
       )
+      updatedUser.get.score.get mustEqual (insertedUser.score.getOrElse(0) + 5)
+    }
+
+    "rolls back the users score" taggedAs UserMetricsTag in {
+      val insertedUser =
+        this.userService.create(this.getTestUser(19, "UpdateUserService"), User.superUser)
+      val currentScore = insertedUser.score.getOrElse(0)
+
+      var updatedUser = this.service.updateUserScore(
+        Some(Task.STATUS_ALREADY_FIXED),
+        Some(1000),
+        Some(1),
+        true,
+        true,
+        Some(0),
+        insertedUser.id
+      )
+      updatedUser = this.service.rollbackUserScore(Task.STATUS_ALREADY_FIXED, insertedUser.id)
+      updatedUser.get.score.get mustEqual currentScore
     }
   }
   override implicit val projectTestName: String = "UserMetricsSpecProject"

--- a/test/org/maproulette/models/TaskSpec.scala
+++ b/test/org/maproulette/models/TaskSpec.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.models
+
+import org.maproulette.models.Task
+import org.scalatestplus.play.PlaySpec
+import org.joda.time.DateTime
+
+class TaskSpec() extends PlaySpec {
+  "isValidStatusProgression" should {
+    "allow unchanged progressions" in {
+      Task.isValidStatusProgression(10, 10) mustEqual true
+    }
+
+    "allow deleting and disabling from any status" in {
+      Task.isValidStatusProgression(10, Task.STATUS_DELETED) mustEqual true
+      Task.isValidStatusProgression(10, Task.STATUS_DISABLED) mustEqual true
+    }
+
+    "allow created to anything" in {
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_FALSE_POSITIVE) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_ALREADY_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_TOO_HARD) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_SKIPPED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_ANSWERED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_CREATED, Task.STATUS_VALIDATED) mustEqual true
+    }
+
+    "disallow fix if not allowing change" in {
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_FALSE_POSITIVE) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_ALREADY_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_SKIPPED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_ANSWERED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_VALIDATED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_CREATED) mustEqual false
+    }
+
+    "allow fix to another completion status if allowing change" in {
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_FALSE_POSITIVE, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_ALREADY_FIXED, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_TOO_HARD, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_SKIPPED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_ANSWERED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_VALIDATED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FIXED, Task.STATUS_CREATED, true) mustEqual false
+    }
+
+    "only allow false positive to fixed if not allowing change" in {
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_ALREADY_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_SKIPPED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_ANSWERED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_VALIDATED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_CREATED) mustEqual false
+    }
+
+    "allow false positive to another completion status if allowing change" in {
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_FIXED, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_ALREADY_FIXED, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_TOO_HARD, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_SKIPPED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_ANSWERED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_VALIDATED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_FALSE_POSITIVE, Task.STATUS_CREATED, true) mustEqual false
+    }
+
+    "allow skipped and too hard to all except created" in {
+      Task.isValidStatusProgression(Task.STATUS_SKIPPED, Task.STATUS_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_SKIPPED, Task.STATUS_ALREADY_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_SKIPPED, Task.STATUS_TOO_HARD) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_SKIPPED, Task.STATUS_FALSE_POSITIVE) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_SKIPPED, Task.STATUS_ANSWERED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_SKIPPED, Task.STATUS_CREATED) mustEqual false
+
+      Task.isValidStatusProgression(Task.STATUS_TOO_HARD, Task.STATUS_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_TOO_HARD, Task.STATUS_ALREADY_FIXED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_TOO_HARD, Task.STATUS_SKIPPED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_TOO_HARD, Task.STATUS_FALSE_POSITIVE) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_TOO_HARD, Task.STATUS_ANSWERED) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_TOO_HARD, Task.STATUS_CREATED) mustEqual false
+    }
+
+    "only allow deleted back to created" in {
+      Task.isValidStatusProgression(Task.STATUS_DELETED, Task.STATUS_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DELETED, Task.STATUS_ALREADY_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DELETED, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DELETED, Task.STATUS_FALSE_POSITIVE) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DELETED, Task.STATUS_ANSWERED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DELETED, Task.STATUS_CREATED) mustEqual true
+    }
+
+    "disallow already fix if not allowing change" in {
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_FALSE_POSITIVE) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_SKIPPED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_ANSWERED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_VALIDATED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_CREATED) mustEqual false
+    }
+
+    "allow already fix to another completion status if allowing change" in {
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_FALSE_POSITIVE, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_FIXED, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_TOO_HARD, true) mustEqual true
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_SKIPPED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_ANSWERED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_VALIDATED, true) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ALREADY_FIXED, Task.STATUS_CREATED, true) mustEqual false
+    }
+
+    "disallow answered to change" in {
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_FALSE_POSITIVE) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_ALREADY_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_SKIPPED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_VALIDATED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_ANSWERED, Task.STATUS_CREATED) mustEqual false
+    }
+
+    "disallow validate to change" in {
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_FALSE_POSITIVE) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_ALREADY_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_SKIPPED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_ANSWERED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_VALIDATED, Task.STATUS_CREATED) mustEqual false
+    }
+
+    "allow disabled to only created" in {
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_FALSE_POSITIVE) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_ALREADY_FIXED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_TOO_HARD) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_SKIPPED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_ANSWERED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_VALIDATED) mustEqual false
+      Task.isValidStatusProgression(Task.STATUS_DISABLED, Task.STATUS_CREATED) mustEqual true
+    }
+  }
+}


### PR DESCRIPTION
  When user is revising a rejected task (or task bundle), allow
  the user to change the task status by passing in a new task status
  to setTaskReviewStatus