### PR TITLE
Allow specific tasks to be excluded from search

### DIFF
--- a/app/org/maproulette/models/dal/TaskClusterDAL.scala
+++ b/app/org/maproulette/models/dal/TaskClusterDAL.scala
@@ -217,6 +217,12 @@ class TaskClusterDAL @Inject() (override val db: Database, challengeDAL: Challen
         """
       )
 
+      params.taskParams.excludeTaskIds match {
+        case Some(excludedIds) if !excludedIds.isEmpty =>
+          this.appendInWhereClause(whereClause, s"(tasks.id NOT IN (${excludedIds.mkString(",")}))")
+        case _ => // do nothing
+      }
+
       if (!excludeLocked) {
         joinClause ++= " LEFT JOIN locked l ON l.item_id = tasks.id "
         this.appendInWhereClause(whereClause, s"(l.id IS NULL OR l.user_id = ${user.id})")

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -50,7 +50,8 @@ case class SearchTaskParameters(
     taskProperties: Option[Map[String, String]] = None,
     taskPropertySearchType: Option[String] = None,
     taskPropertySearch: Option[TaskPropertySearch] = None,
-    taskPriorities: Option[List[Int]] = None
+    taskPriorities: Option[List[Int]] = None,
+    excludeTaskIds: Option[List[Long]] = None
 )
 
 case class SearchLeaderboardParameters(
@@ -459,6 +460,11 @@ object SearchParameters {
         request.getQueryString("priorities") match {
           case Some(v) => Utils.toIntList(v)
           case None => params.taskParams.taskPriorities
+        },
+
+        request.getQueryString("tExcl") match {
+          case Some(ids) => Utils.toLongList(ids)
+          case None => params.taskParams.excludeTaskIds
         }
       ),
       // Search Review Parameters


### PR DESCRIPTION
* Add `tExcl` search parameter for specifying id(s) of tasks to
be explicitly excluded from search results