### PR TITLE
Add support for multiple custom basemaps

### DIFF
--- a/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
+++ b/app/org/maproulette/framework/graphql/schemas/MRSchemaTypes.scala
@@ -65,6 +65,8 @@ trait MRSchemaTypes {
   // User Types
   implicit val RequestTokenType: ObjectType[Unit, RequestToken] =
     deriveObjectType[Unit, RequestToken](ObjectTypeName("RequestToken"))
+  implicit val CustomBasemapType: ObjectType[Unit, CustomBasemap] =
+    deriveObjectType[Unit, CustomBasemap](ObjectTypeName("CustomBasemap"))
   implicit val UserSettingsType: ObjectType[Unit, UserSettings] =
     deriveObjectType[Unit, UserSettings](ObjectTypeName("UserSettings"))
   implicit val LocationType: ObjectType[Unit, Location] =

--- a/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
@@ -333,6 +333,12 @@ object UserSchema extends DefaultWrites {
   import sangria.marshalling.playJson._
   implicit val settingsReads: Reads[UserSettings] = User.settingsReads
 
+  implicit val CustomBasemapInputType: InputObjectType[CustomBasemap] =
+    deriveInputObjectType[CustomBasemap](
+      InputObjectTypeName("CustomBasemapInput"),
+      InputObjectTypeDescription("Custom Basemaps for a user settings object")
+    )
+
   implicit val UserSettingsInputType: InputObjectType[UserSettings] =
     deriveInputObjectType[UserSettings](
       InputObjectTypeName("UserSettingsInput"),

--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -101,6 +101,25 @@ object ProjectManager {
 }
 
 /**
+  * Custom basemaps defined by the user
+  *
+  * @param id           Id of this custom basemap
+  * @param name         Basemap name given by the user
+  * @param url          The url to the tile server
+  * @param overlay      Whether this basemap is an overlay
+  */
+case class CustomBasemap(
+    id: Long = -1,
+    name: String,
+    url: String,
+    overlay: Boolean = false
+)
+object CustomBasemap {
+  implicit val writes: Writes[CustomBasemap] = Json.writes[CustomBasemap]
+  implicit val reads: Reads[CustomBasemap]   = Json.reads[CustomBasemap]
+}
+
+/**
   * Wraps together a user with their follower status
   *
   * @param id     The member id of the follower from a (followed) user's followers group
@@ -109,6 +128,22 @@ object ProjectManager {
   */
 case class Follower(id: Long, user: User, status: Int) extends Identifiable
 object Follower {
+  implicit val tokenWrites: Writes[RequestToken]            = Json.writes[RequestToken]
+  implicit val tokenReads: Reads[RequestToken]              = Json.reads[RequestToken]
+  implicit val settingsWrites: Writes[UserSettings]         = Json.writes[UserSettings]
+  implicit val settingsReads: Reads[UserSettings]           = Json.reads[UserSettings]
+  implicit val userGrantWrites: Writes[Grant]               = Grant.writes
+  implicit val userGrantReads: Reads[Grant]                 = Grant.reads
+  implicit val locationWrites: Writes[Location]             = Json.writes[Location]
+  implicit val locationReads: Reads[Location]               = Json.reads[Location]
+  implicit val osmWrites: Writes[OSMProfile]                = Json.writes[OSMProfile]
+  implicit val osmReads: Reads[OSMProfile]                  = Json.reads[OSMProfile]
+  implicit val searchResultWrites: Writes[UserSearchResult] = Json.writes[UserSearchResult]
+  implicit val projectManagerWrites: Writes[ProjectManager] = Json.writes[ProjectManager]
+
+  implicit val userWrites: Writes[User] = Json.writes[User]
+  implicit val userReads: Reads[User]   = Json.reads[User]
+
   implicit val writes: Writes[Follower] = Json.writes[Follower]
   implicit val reads: Reads[Follower]   = Json.reads[Follower]
 
@@ -122,7 +157,6 @@ object Follower {
   * @param defaultEditor     The default editor that the user wants to use
   * @param defaultBasemap    The default basemap that the user wants to see, will be overridden by default basemap for the challenge if set
   * @param defaultBasemapId  The string id of the default basemap that the user wants to see
-  * @param customBasemap     It default basemap is custom, then this is the url to the tile server
   * @param locale            The locale for the user, if not set will default to en
   * @param email             The user's email address
   * @param emailOptIn        If the user has opted in to receive emails
@@ -132,12 +166,12 @@ object Follower {
   * @param theme             The theme to display in MapRoulette. Optionally - 0=skin-black, 1=skin-black-light,
   *                          2=skin-blue, 3=skin-blue-light, 4=skin-green, 5=skin-green-light,
   *                          6=skin-purple, 7=skin-purple-light, 8=skin-red, 9=skin-red-light, 10=skin-yellow, 11=skin-yellow-light
+  * @param customBasemaps    Custom basemaps defined by user, which basemap to show is the name selected by the defaultBasemap.
   */
 case class UserSettings(
     defaultEditor: Option[Int] = None,
     defaultBasemap: Option[Int] = None,
     defaultBasemapId: Option[String] = None,
-    customBasemap: Option[String] = None,
     locale: Option[String] = None,
     email: Option[String] = None,
     emailOptIn: Option[Boolean] = None,
@@ -145,7 +179,8 @@ case class UserSettings(
     needsReview: Option[Int] = None,
     isReviewer: Option[Boolean] = None,
     allowFollowing: Option[Boolean] = None,
-    theme: Option[Int] = None
+    theme: Option[Int] = None,
+    customBasemaps: Option[List[CustomBasemap]] = None
 ) {
   def getTheme: String = theme match {
     case Some(t) =>
@@ -302,22 +337,6 @@ object User extends CommonField {
   val THEME_RED_LIGHT    = 9
   val THEME_YELLOW       = 10
   val THEME_YELLOW_LIGHT = 11
-  val settingsForm = Form(
-    mapping(
-      "defaultEditor"     -> optional(number),
-      "defaultBasemap"    -> optional(number),
-      "defaultBasemapId"  -> optional(text),
-      "customBasemap"     -> optional(text),
-      "locale"            -> optional(text),
-      "email"             -> optional(text),
-      "emailOptIn"        -> optional(boolean),
-      "leaderboardOptOut" -> optional(boolean),
-      "needsReview"       -> optional(number),
-      "isReviewer"        -> optional(boolean),
-      "allowFollowing"    -> optional(boolean),
-      "theme"             -> optional(number)
-    )(UserSettings.apply)(UserSettings.unapply)
-  )
 
   val REVIEW_NOT_NEEDED = 0
   val REVIEW_NEEDED     = 1

--- a/conf/evolutions/default/68.sql
+++ b/conf/evolutions/default/68.sql
@@ -1,0 +1,37 @@
+# --- !Ups
+CREATE TABLE IF NOT EXISTS user_basemaps(
+  id SERIAL NOT NULL PRIMARY KEY,
+  created timestamp without time zone DEFAULT NOW(),
+  modified timestamp without time zone DEFAULT NOW(),
+  user_id INTEGER NOT NULL,
+  url VARCHAR NOT NULL,
+  name VARCHAR NOT NULL,
+  overlay BOOLEAN DEFAULT FALSE,
+  CONSTRAINT user_basemaps_user_id FOREIGN KEY (user_id)
+    REFERENCES users(id) MATCH SIMPLE
+    ON UPDATE CASCADE ON DELETE CASCADE
+);;
+
+SELECT create_index_if_not_exists('user_basemaps', 'user_basemaps_user', '(user_id)');;
+
+-- copy existing user custom_basemap_url into new table
+INSERT INTO user_basemaps (user_id, url, name)
+SELECT id, custom_basemap_url, 'Custom'
+FROM users WHERE custom_basemap_url IS NOT NULL;;
+
+ALTER TABLE users
+  DROP COLUMN custom_basemap_url;;
+
+# --- !Downs
+
+-- read add custom_basemap_url column
+ALTER TABLE users
+  ADD COLUMN custom_basemap_url VARCHAR;;
+
+-- copy custom basemap urls back into old column
+UPDATE users u SET custom_basemap_url = user_basemaps.url
+FROM user_basemaps
+WHERE u.id = user_basemaps.user_id AND user_basemaps.name = 'Custom' AND user_basemaps.url != '';;
+
+-- Drop table user_basemaps
+DROP TABLE user_basemaps;;

--- a/test/org/maproulette/framework/repository/UserRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/UserRepositorySpec.scala
@@ -51,7 +51,7 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
           Some(true),
           None,
           None,
-          Some(List())
+          None
         )
       )
       this.userRepository.update(updateUser, "POINT (14.0 22.0)")
@@ -86,12 +86,14 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
           Some(true),
           None,
           None,
-          Some(List(
-            CustomBasemap(
-              name = "my_custom_basemap",
-              url = "http://maproulette.org/this/is/a/url"
+          Some(
+            List(
+              CustomBasemap(
+                name = "my_custom_basemap",
+                url = "http://maproulette.org/this/is/a/url"
+              )
             )
-          ))
+          )
         )
       )
       this.userRepository.update(updateUser, "POINT (14.0 22.0)")
@@ -120,7 +122,7 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
       updatedUser2.settings.customBasemaps.get.length mustEqual 2
 
       val updatedBasemaps = updatedUser2.settings.customBasemaps.getOrElse(List())
-      val first = updatedBasemaps.head
+      val first           = updatedBasemaps.head
       first.id mustEqual basemaps.head.id
       first.name mustEqual "updated_custom_basemap"
       first.url mustEqual "http://updated/url"
@@ -161,7 +163,7 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
       )
       this.userRepository.update(user5, "POINT (14.0 22.0)")
       val updatedUser5 = this.repositoryGet(user5.id).get
-      updatedUser5.settings.customBasemaps.get.length mustEqual 0
+      updatedUser5.settings.customBasemaps mustEqual None
     }
 
     "update API key" taggedAs UserRepoTag in {

--- a/test/org/maproulette/framework/repository/UserRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/UserRepositorySpec.scala
@@ -7,7 +7,7 @@ package org.maproulette.framework.repository
 
 import java.util.UUID
 
-import org.maproulette.framework.model.{User, UserMetrics, UserSettings}
+import org.maproulette.framework.model.{User, UserMetrics, UserSettings, CustomBasemap}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.{BaseParameter, Operator}
 import org.maproulette.framework.service.UserService
@@ -43,13 +43,15 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
           Some(1),
           Some(2),
           Some("id"),
-          Some("basemap"),
           Some("en-US"),
           Some("email_address"),
           Some(true),
           Some(false),
           Some(5),
-          Some(true)
+          Some(true),
+          None,
+          None,
+          Some(List())
         )
       )
       this.userRepository.update(updateUser, "POINT (14.0 22.0)")
@@ -60,6 +62,106 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
       // API Key should not be allowed to updated here
       updatedUser.apiKey mustEqual insertedUser.apiKey
       updatedUser.settings mustEqual updateUser.settings
+    }
+
+    "update user's customBasemaps" taggedAs UserRepoTag in {
+      val insertedUser  = this.insertBaseUser(30, "name30")
+      val updatedApiKey = UUID.randomUUID().toString
+      val updateUser = insertedUser.copy(
+        osmProfile = insertedUser.osmProfile.copy(
+          displayName = "name31",
+          avatarURL = "UPDATE_avatarURL",
+          requestToken = RequestToken("UPDATED_TOKEN", "UPDATED_SECRET")
+        ),
+        apiKey = Some(updatedApiKey),
+        settings = UserSettings(
+          Some(1),
+          Some(2),
+          Some("id"),
+          Some("en-US"),
+          Some("email_address2"),
+          Some(true),
+          Some(false),
+          Some(5),
+          Some(true),
+          None,
+          None,
+          Some(List(
+            CustomBasemap(
+              name = "my_custom_basemap",
+              url = "http://maproulette.org/this/is/a/url"
+            )
+          ))
+        )
+      )
+      this.userRepository.update(updateUser, "POINT (14.0 22.0)")
+      val updatedUser = this.repositoryGet(insertedUser.id).get
+      updatedUser.osmProfile.displayName mustEqual updateUser.osmProfile.displayName
+      updatedUser.settings.customBasemaps.get.length mustEqual 1
+      updatedUser.settings.customBasemaps.get.head.name mustEqual "my_custom_basemap"
+      updatedUser.settings.customBasemaps.get.head.url mustEqual "http://maproulette.org/this/is/a/url"
+
+      // Change basemaps
+      val basemaps = List(
+        CustomBasemap(
+          id = updatedUser.settings.customBasemaps.get.head.id,
+          name = "updated_custom_basemap",
+          url = "http://updated/url",
+          overlay = true
+        ),
+        CustomBasemap(name = "new_basemap", url = "new_url")
+      )
+
+      val user2 = updatedUser.copy(
+        settings = updatedUser.settings.copy(customBasemaps = Some(basemaps))
+      )
+      this.userRepository.update(user2, "POINT (14.0 22.0)")
+      val updatedUser2 = this.repositoryGet(user2.id).get
+      updatedUser2.settings.customBasemaps.get.length mustEqual 2
+
+      val updatedBasemaps = updatedUser2.settings.customBasemaps.getOrElse(List())
+      val first = updatedBasemaps.head
+      first.id mustEqual basemaps.head.id
+      first.name mustEqual "updated_custom_basemap"
+      first.url mustEqual "http://updated/url"
+      first.overlay mustEqual true
+
+      val second = updatedBasemaps(1)
+      second.id must not be -1
+      second.name mustEqual "new_basemap"
+      second.url mustEqual "new_url"
+
+      // Remove basemap by not including in list
+      val LessBasemaps = List(
+        CustomBasemap(
+          id = first.id,
+          name = "updated_custom_basemap",
+          url = "http://updated/url",
+          overlay = true
+        )
+      )
+      val user3 = updatedUser2.copy(
+        settings = updatedUser2.settings.copy(customBasemaps = Some(LessBasemaps))
+      )
+      this.userRepository.update(user3, "POINT (14.0 22.0)")
+      val updatedUser3 = this.repositoryGet(user3.id).get
+      updatedUser3.settings.customBasemaps.get.length mustEqual 1
+
+      // Not passing customBasemaps preserves existing ones.
+      val user4 = updatedUser3.copy(
+        settings = updatedUser.settings.copy(customBasemaps = None)
+      )
+      this.userRepository.update(user4, "POINT (14.0 22.0)")
+      val updatedUser4 = this.repositoryGet(user4.id).get
+      updatedUser4.settings.customBasemaps.get.length mustEqual 1
+
+      //Passing an empty list of customBasemaps deletes all
+      val user5 = updatedUser4.copy(
+        settings = updatedUser4.settings.copy(customBasemaps = Some(List()))
+      )
+      this.userRepository.update(user5, "POINT (14.0 22.0)")
+      val updatedUser5 = this.repositoryGet(user5.id).get
+      updatedUser5.settings.customBasemaps.get.length mustEqual 0
     }
 
     "update API key" taggedAs UserRepoTag in {


### PR DESCRIPTION
* Create new user_basemaps table and move existing custom
  basemaps into new table

* When updating a user allow for customBasemaps to be specified
  in JSON

* When returning a user return customBasemaps as an array of json
  objects