### PR TITLE
Support searching for users based on task id

### DIFF
--- a/app/org/maproulette/framework/controller/UserController.scala
+++ b/app/org/maproulette/framework/controller/UserController.scala
@@ -12,7 +12,7 @@ import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.service.ServiceManager
 import org.maproulette.permissions.Permission
 import org.maproulette.models.Task
-import org.maproulette.session.SessionManager
+import org.maproulette.session.{SessionManager, SearchParameters}
 import org.maproulette.data.{UserType}
 import org.maproulette.utils.{Crypto, Utils}
 import play.api.libs.json._
@@ -152,13 +152,11 @@ class UserController @Inject() (
   def searchUserByOSMUsername(username: String, limit: Int): Action[AnyContent] = Action.async {
     implicit request =>
       this.sessionManager.authenticatedRequest { implicit user =>
-        if (StringUtils.isEmpty(username)) {
-          Ok(Json.toJson(List[JsValue]()))
-        } else {
+        SearchParameters.withSearch { implicit params =>
           Ok(
             Json.toJson(
               this.serviceManager.user
-                .searchByOSMUsername(username, Paging(limit))
+                .searchByOSMUsername(username, Paging(limit), params)
                 .map(_.toSearchResult)
             )
           )

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -196,8 +196,11 @@ PUT     /user/:userId/apikey                        @org.maproulette.framework.c
 #     description: The user is not authorized to make this request
 # parameters:
 #   - name: username
-#     in: path
-#     description: The OSM username or username fragment to search
+#     in: path (or in query)
+#     description: The OSM username or username fragment to search. May be excluded when including tid
+#   - name: tid
+#     in: query
+#     description: Optional field to allow searching for users who participated in a task.
 #   - name: apiKey
 #     in: header
 #     description: The user's apiKey to authorize the request
@@ -211,6 +214,7 @@ PUT     /user/:userId/apikey                        @org.maproulette.framework.c
 #     description: Used in conjunction with the limit parameter to page through X number of responses.
 ###
 GET     /users/find/:username                          @org.maproulette.framework.controller.UserController.searchUserByOSMUsername(username:String, limit:Int ?= 10)
+GET     /users/find                                    @org.maproulette.framework.controller.UserController.searchUserByOSMUsername(username:String ?= "", limit:Int ?= 10)
 ###
 # tags: [ User ]
 # summary: Retrieves Users Saved Challenged


### PR DESCRIPTION
* Allow a taskId parameter to be passed in when searching for users
  that will return those who have participated (commented or changed
  status) in that task. Username is optional in this case.

eg. ```/api/v2/users/find?tid=2326765&username=c``` 