### PR TITLE
Fix user metrics date range returning wrong results

### DIFF
--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -78,7 +78,7 @@ class UserMetricService @Inject() (
       startDate,
       endDate,
       s"${StatusActions.FIELD_CREATED}",
-      Task.TABLE
+      StatusActions.TABLE
     )
     val taskCounts = this.repository.getUserTaskCounts(userId, timeClause)
 
@@ -166,7 +166,6 @@ class UserMetricService @Inject() (
         case _: IllegalArgumentException => (None, None)
         case e: Throwable                => throw new InvalidException(e.getMessage)
       }
-
     duration match {
       case _ if dates._1.isDefined =>
         DateParameter(


### PR DESCRIPTION
Change user metrics date search to search on StatusActions.created
instead of Tasks.created field.