### PR TITLE
Fix mapped_on being cleared on task rebuild

### DIFF
--- a/conf/evolutions/default/69.sql
+++ b/conf/evolutions/default/69.sql
@@ -1,0 +1,167 @@
+# --- !Ups
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change makes sure not to reset the mapped_on to null when we have an existing task
+DROP FUNCTION IF EXISTS update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp without time zone,integer,integer,integer,timestamp without time zone);;
+CREATE OR REPLACE FUNCTION update_task(task_name text,
+                                        task_parent_id bigint,
+                                        task_instruction text,
+                                        task_status integer,
+                                        geo_json jsonb,
+                                        cooperative_work jsonb DEFAULT NULL,
+                                        task_id bigint DEFAULT -1,
+                                        task_priority integer DEFAULT 0,
+                                        task_changeset_id bigint DEFAULT -1,
+                                        reset_interval text DEFAULT '7 days',
+                                        task_mapped_on timestamp DEFAULT NULL,
+                                        task_review_status integer DEFAULT NULL,
+                                        task_review_requested_by integer DEFAULT NULL,
+                                        task_reviewed_by integer DEFAULT NULL,
+                                        task_reviewed_at timestamp DEFAULT NULL
+                                      ) RETURNS integer as $$
+  DECLARE
+    update_id integer;;
+    update_modified timestamp without time zone;;
+    update_status integer;;
+    new_status integer;;
+    geojson_geom geometry;;
+  BEGIN
+    IF (SELECT task_id) = -1 THEN
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+    ELSE
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+    END IF;;
+    -- Only if task status is not null set/update it to the new status
+    IF task_status IS NOT NULL THEN
+      new_status := task_status;;
+    ELSE
+      new_status := update_status;;
+    END IF;;
+    -- only reset the status if the task is not currently disabled or set as a false positive and all other criteria is met.
+    IF update_status = task_status AND NOT (update_status = 9 OR update_status = 2) AND (SELECT AGE(NOW(), update_modified)) > reset_interval::INTERVAL THEN
+      new_status := 0;;
+    END IF;;
+    SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+    UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status, priority = task_priority,
+                     changeset_id = task_changeset_id, geojson = geo_json,
+                     cooperative_work_json = cooperative_work,
+                     location = ST_Centroid(geojson_geom),
+                     geom = geojson_geom
+                     WHERE id = update_id;;
+
+    -- Note in status actions if status has changed
+    -- Since only when someone with admin privileges to a challenge can call this update
+    -- to change the status we just set osm_user_id to -1 (thereby not impacting any user scores).
+    -- To determine who did the update check the actions table.
+    IF update_status != new_status THEN
+      INSERT INTO status_actions (osm_user_id, project_id, challenge_id, task_id, old_status, status)
+        VALUES (-1, (SELECT parent_id FROM challenges WHERE id = task_parent_id),
+                task_parent_id, update_id, update_status, new_status);;
+    END IF;;
+
+    --
+    -- Only update task_review table if we actually have a task_review_status otherwise we will
+    -- end up with weird empty rows. And if the new status is created we need to delete any requested review
+    --
+    IF task_review_status IS NOT NULL THEN
+      UPDATE task_review SET review_status = task_review_status, review_requested_by = task_review_requested_by,
+                             reviewed_by = task_reviewed_by, reviewed_at = task_reviewed_at WHERE task_review.task_id = update_id;;
+    ELSE IF new_status = 0 THEN
+        DELETE FROM task_review WHERE task_review.task_id = update_id;;
+      END IF;;
+    END IF;;
+
+    --
+    -- Only update a null mapped_on if we are resetting task status back to created
+    --
+    IF task_mapped_on IS NOT NULL THEN
+      UPDATE tasks SET mapped_on = task_mapped_on WHERE id = update_id;;
+    ELSE
+      IF new_status = 0 THEN
+        UPDATE tasks SET mapped_on = task_mapped_on WHERE id = update_id;;
+      END IF;;
+    END IF;;
+
+    RETURN update_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;
+
+# --- !Downs
+
+-- Creates or updates and task. Will also check if task status needs to be updated
+-- This change makes sure not to reset the task status if a task is disabled or declared a false positive
+DROP FUNCTION IF EXISTS update_task(text,bigint,text,integer,jsonb,jsonb,bigint,integer,bigint,text,timestamp without time zone,integer,integer,integer,timestamp without time zone);;
+CREATE OR REPLACE FUNCTION update_task(task_name text,
+                                        task_parent_id bigint,
+                                        task_instruction text,
+                                        task_status integer,
+                                        geo_json jsonb,
+                                        cooperative_work jsonb DEFAULT NULL,
+                                        task_id bigint DEFAULT -1,
+                                        task_priority integer DEFAULT 0,
+                                        task_changeset_id bigint DEFAULT -1,
+                                        reset_interval text DEFAULT '7 days',
+                                        task_mapped_on timestamp DEFAULT NULL,
+                                        task_review_status integer DEFAULT NULL,
+                                        task_review_requested_by integer DEFAULT NULL,
+                                        task_reviewed_by integer DEFAULT NULL,
+                                        task_reviewed_at timestamp DEFAULT NULL
+                                      ) RETURNS integer as $$
+  DECLARE
+    update_id integer;;
+    update_modified timestamp without time zone;;
+    update_status integer;;
+    new_status integer;;
+    geojson_geom geometry;;
+  BEGIN
+    IF (SELECT task_id) = -1 THEN
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE name = task_name AND parent_id = task_parent_id;;
+    ELSE
+      SELECT id, modified, status INTO update_id, update_modified, update_status FROM tasks WHERE id = task_id;;
+    END IF;;
+    -- Only if task status is not null set/update it to the new status
+    IF task_status IS NOT NULL THEN
+      new_status := task_status;;
+    ELSE
+      new_status := update_status;;
+    END IF;;
+    -- only reset the status if the task is not currently disabled or set as a false positive and all other criteria is met.
+    IF update_status = task_status AND NOT (update_status = 9 OR update_status = 2) AND (SELECT AGE(NOW(), update_modified)) > reset_interval::INTERVAL THEN
+      new_status := 0;;
+    END IF;;
+    SELECT ST_COLLECT(ST_SETSRID(ST_MAKEVALID(ST_GEOMFROMGEOJSON(jsonb_array_elements_Text::JSONB->>'geometry')), 4326)) INTO geojson_geom
+		FROM JSONB_ARRAY_ELEMENTS_TEXT(geo_json->'features');;
+    UPDATE tasks SET name = task_name, instruction = task_instruction, status = new_status, priority = task_priority,
+                     changeset_id = task_changeset_id, mapped_on = task_mapped_on, geojson = geo_json,
+                     cooperative_work_json = cooperative_work,
+                     location = ST_Centroid(geojson_geom),
+                     geom = geojson_geom
+                     WHERE id = update_id;;
+
+    -- Note in status actions if status has changed
+    -- Since only when someone with admin privileges to a challenge can call this update
+    -- to change the status we just set osm_user_id to -1 (thereby not impacting any user scores).
+    -- To determine who did the update check the actions table.
+    IF update_status != new_status THEN
+      INSERT INTO status_actions (osm_user_id, project_id, challenge_id, task_id, old_status, status)
+        VALUES (-1, (SELECT parent_id FROM challenges WHERE id = task_parent_id),
+                task_parent_id, update_id, update_status, new_status);;
+    END IF;;
+
+    --
+    -- Only update task_review table if we actually have a task_review_status otherwise we will
+    -- end up with weird empty rows. And if the new status is created we need to delete any requested review
+    --
+    IF task_review_status IS NOT NULL THEN
+      UPDATE task_review SET review_status = task_review_status, review_requested_by = task_review_requested_by,
+                             reviewed_by = task_reviewed_by, reviewed_at = task_reviewed_at WHERE task_review.task_id = update_id;;
+    ELSE IF new_status = 0 THEN
+        DELETE FROM task_review WHERE task_review.task_id = update_id;;
+      END IF;;
+    END IF;;
+    RETURN update_id;;
+  END
+  $$
+  LANGUAGE plpgsql VOLATILE;;

--- a/conf/evolutions/default/69.sql
+++ b/conf/evolutions/default/69.sql
@@ -75,12 +75,8 @@ CREATE OR REPLACE FUNCTION update_task(task_name text,
     --
     -- Only update a null mapped_on if we are resetting task status back to created
     --
-    IF task_mapped_on IS NOT NULL THEN
+    IF task_mapped_on IS NOT NULL OR new_status = 0 THEN
       UPDATE tasks SET mapped_on = task_mapped_on WHERE id = update_id;;
-    ELSE
-      IF new_status = 0 THEN
-        UPDATE tasks SET mapped_on = task_mapped_on WHERE id = update_id;;
-      END IF;;
     END IF;;
 
     RETURN update_id;;


### PR DESCRIPTION
* When tasks are being rebuilt if the task status and mapper are
  not changing then the mapped_on should not change also
    Add to the SQL stored procedure update_task:
```
    --
    -- Only update a null mapped_on if we are resetting task status back to created
    --
    IF task_mapped_on IS NOT NULL THEN
      UPDATE tasks SET mapped_on = task_mapped_on WHERE id = update_id;;
    ELSE
      IF new_status = 0 THEN
        UPDATE tasks SET mapped_on = task_mapped_on WHERE id = update_id;;
      END IF;;
    END IF;;
```

* When tasks are bulk updated, if the status is being set back to
  created we also need to clear the mapper, bundling, form data and review request.