### PR TITLE
Support validating target type on overpass queries

### DIFF
--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -106,7 +106,8 @@ case class ChallengeGeneral(
 
 case class ChallengeCreation(
     overpassQL: Option[String] = None,
-    remoteGeoJson: Option[String] = None
+    remoteGeoJson: Option[String] = None,
+    overpassTargetType: Option[String] = None
 ) extends DefaultWrites
 
 case class ChallengePriority(

--- a/app/org/maproulette/framework/repository/ChallengeRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeRepository.scala
@@ -116,6 +116,7 @@ object ChallengeRepository {
       get[Option[String]]("challenges.checkin_comment") ~
       get[Option[String]]("challenges.checkin_source") ~
       get[Option[String]]("challenges.overpass_ql") ~
+      get[Option[String]]("challenges.overpass_target_type") ~
       get[Option[String]]("challenges.remote_geo_json") ~
       get[Option[Int]]("challenges.status") ~
       get[Option[String]]("challenges.status_message") ~
@@ -146,7 +147,7 @@ object ChallengeRepository {
       get[Option[List[Long]]]("virtual_parent_ids") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
-            checkin_source ~ overpassql ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
+            checkin_source ~ overpassql ~ overpassTargetType ~ remoteGeoJson ~ status ~ statusMessage ~ defaultPriority ~ highPriorityRule ~
             mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~ minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ preferredTags ~ preferredReviewTags ~
             limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
@@ -186,7 +187,7 @@ object ChallengeRepository {
             virtualParents,
             requiresLocal
           ),
-          ChallengeCreation(overpassql, remoteGeoJson),
+          ChallengeCreation(overpassql, remoteGeoJson, overpassTargetType),
           ChallengePriority(defaultPriority, hpr, mpr, lpr),
           ChallengeExtra(
             defaultZoom,

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -415,72 +415,107 @@ class ChallengeProvider @Inject() (
               this.db.withTransaction { implicit c =>
                 var partial = false
                 val payload = result.json
+                var targetTypeFailed = false
+
                 // parse the results. Overpass has its own format and is not geojson
                 val elements = (payload \ "elements").as[List[JsValue]]
-                elements.foreach { element =>
-                  try {
-                    val geometry = (element \ "center").asOpt[JsObject] match {
-                      case Some(center) =>
-                        Some(
-                          Json.obj(
-                            "type" -> "Point",
-                            "coordinates" -> List(
-                              (center \ "lon").as[Double],
-                              (center \ "lat").as[Double]
-                            )
-                          )
-                        )
-                      case None =>
+                try {
+                  elements.foreach { element =>
+                    // Verify target type if we are given one.
+                    challenge.creation.overpassTargetType match {
+                      case Some(targetType) if StringUtils.isNotEmpty(targetType) =>
                         (element \ "type").asOpt[String] match {
                           case Some("way") =>
-                            // TODO: ways do not have a "geometry" property, instead they have a list of "nodes"
-                            // referencing other elements in the array. So this code does not do the job.
-                            val points = (element \ "geometry").as[List[JsValue]].map { geom =>
-                              List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
+                            if (targetType != "way") {
+                              targetTypeFailed = true
+                              throw new InvalidException("Element type 'way' does not match target type of '" + targetType + "'")
                             }
-                            Some(Json.obj("type" -> "LineString", "coordinates" -> points))
                           case Some("node") =>
-                            Some(
-                              Json.obj(
-                                "type" -> "Point",
-                                "coordinates" -> List(
-                                  (element \ "lon").as[Double],
-                                  (element \ "lat").as[Double]
-                                )
-                              )
-                            )
-                          case _ => None
+                            if (targetType != "node") {
+                              targetTypeFailed = true
+                              throw new InvalidException("Element type 'node' does not match target type of '" + targetType + "'")
+                            }
+                          case x =>
+                            targetTypeFailed = true
+                            throw new InvalidException("Element type " + x + " does not match target type of '" + targetType + "'")
                         }
+                      case _ => // do not validate
                     }
 
-                    geometry match {
-                      case Some(geom) =>
-                        this.createNewTask(
-                          user,
-                          s"${(element \ "id").as[Long]}",
-                          challenge,
-                          geom,
-                          Utils.getProperties(element, "tags")
-                        )
-                      case None => None
+                    try {
+                        val geometry = (element \ "center").asOpt[JsObject] match {
+                        case Some(center) =>
+                          Some(
+                            Json.obj(
+                              "type" -> "Point",
+                              "coordinates" -> List(
+                                (center \ "lon").as[Double],
+                                (center \ "lat").as[Double]
+                              )
+                            )
+                          )
+                        case None =>
+                          (element \ "type").asOpt[String] match {
+                            case Some("way") =>
+                              // TODO: ways do not have a "geometry" property, instead they have a list of "nodes"
+                              // referencing other elements in the array. So this code does not do the job.
+                              val points = (element \ "geometry").as[List[JsValue]].map { geom =>
+                                List((geom \ "lon").as[Double], (geom \ "lat").as[Double])
+                              }
+                              Some(Json.obj("type" -> "LineString", "coordinates" -> points))
+                            case Some("node") =>
+                              Some(
+                                Json.obj(
+                                  "type" -> "Point",
+                                  "coordinates" -> List(
+                                    (element \ "lon").as[Double],
+                                    (element \ "lat").as[Double]
+                                  )
+                                )
+                              )
+                            case _ => None
+                          }
+                      }
+
+                      geometry match {
+                        case Some(geom) =>
+                          this.createNewTask(
+                            user,
+                            s"${(element \ "id").as[Long]}",
+                            challenge,
+                            geom,
+                            Utils.getProperties(element, "tags")
+                          )
+                        case None => None
+                      }
+                    } catch {
+                      case e: Exception =>
+                        partial = true
+                        logger.error(e.getMessage, e)
                     }
-                  } catch {
-                    case e: Exception =>
-                      partial = true
-                      logger.error(e.getMessage, e)
                   }
-                }
-                partial match {
-                  case true =>
+                  partial match {
+                    case true =>
+                      this.challengeDAL.update(
+                        Json.obj("status" -> Challenge.STATUS_PARTIALLY_LOADED),
+                        user
+                      )(challenge.id)
+                    case false =>
+                      this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(
+                        challenge.id
+                      )
+                      this.challengeDAL.markTasksRefreshed(true)(challenge.id)
+                  }
+                } catch {
+                  case e: Exception =>
                     this.challengeDAL.update(
-                      Json.obj("status" -> Challenge.STATUS_PARTIALLY_LOADED),
+                      Json.obj(
+                        "status"        -> Challenge.STATUS_FAILED,
+                        "statusMessage" -> s"${e.getMessage}"
+                      ),
                       user
                     )(challenge.id)
-                  case false =>
-                    this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(
-                      challenge.id
-                    )
-                    this.challengeDAL.markTasksRefreshed(true)(challenge.id)
+                    throw e
                 }
               }
             } else {

--- a/conf/evolutions/default/70.sql
+++ b/conf/evolutions/default/70.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+-- Add overpass_target_type to challenges
+ALTER TABLE IF EXISTS challenges
+  ADD COLUMN overpass_target_type VARCHAR;;
+
+# --- !Downs
+-- Remove added column overpass_target_type
+ALTER TABLE IF EXISTS challenges
+  DROP COLUMN overpass_target_type;;


### PR DESCRIPTION
* Add overpass_target_type to challenge

* When processing an overpass query during challenge creationg,
  if provided an overpass_target_type then verify that all the
  overpass elements are of that type - otherwise set the
  challenge has failed and report an error message.