### PR TITLE
Add support for returning additional reviewers

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -841,6 +841,7 @@ class ChallengeController @Inject() (
             s"""${task.completedTimeSpent.getOrElse("")},"${mapper}",""" +
             s"""${Task.reviewStatusMap.get(task.reviewStatus.getOrElse(-1)).get},""" +
             s""""${task.reviewedBy.getOrElse("")}",${reviewedAt},"${reviewTimeSeconds}",""" +
+            s""""${task.additionalReviewers.getOrElse(List()).mkString(", ")}",""" +
             s""""${comments}","${task.bundleId.getOrElse("")}","${task.isBundlePrimary
               .getOrElse("")}",""" +
             s""""${task.tags.getOrElse("")}"${propData}${responseData}""".stripMargin
@@ -855,7 +856,7 @@ class ChallengeController @Inject() (
             ResponseHeader(OK, Map(CONTENT_DISPOSITION -> s"attachment; filename=${filename}")),
           body = HttpEntity.Strict(
             ByteString(
-              s"""TaskID,TaskLink,ChallengeID,ChallengeLink,TaskName,TaskStatus,TaskPriority,MappedOn,CompletionTime,Mapper,ReviewStatus,Reviewer,ReviewedAt,ReviewTimeSeconds,Comments,BundleId,IsBundlePrimary,Tags${propsToExportHeaderString}${responseHeaders}\n"""
+              s"""TaskID,TaskLink,ChallengeID,ChallengeLink,TaskName,TaskStatus,TaskPriority,MappedOn,CompletionTime,Mapper,ReviewStatus,Reviewer,ReviewedAt,ReviewTimeSeconds,AdditionalReviewers,Comments,BundleId,IsBundlePrimary,Tags${propsToExportHeaderString}${responseHeaders}\n"""
             ).concat(ByteString(seqString.mkString("\n"))),
             Some("text/csv; header=present")
           )

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -505,9 +505,15 @@ class TaskController @Inject() (
           .toMap
       )
 
+      val allReviewers = new scala.collection.mutable.ListBuffer[Long]()
+      tasks.foreach(t => {
+        allReviewers += t.pointReview.reviewedBy.getOrElse(0L)
+        t.pointReview.additionalReviewers.getOrElse(List()).foreach(r => allReviewers += r)
+      })
+
       val reviewers = Some(
         this.serviceManager.user
-          .retrieveListById(tasks.map(t => t.pointReview.reviewedBy.getOrElse(0L)))
+          .retrieveListById(allReviewers.toList)
           .map(u => u.id -> Json.obj("username" -> u.name, "id" -> u.id))
           .toMap
       )
@@ -548,6 +554,26 @@ class TaskController @Inject() (
             Json.toJson(reviewers.get(task.pointReview.reviewedBy.get)).as[JsObject]
           reviewPointJson =
             Utils.insertIntoJson(reviewPointJson, "reviewedBy", reviewerJson, true).as[JsObject]
+          updated = Utils.insertIntoJson(updated, "pointReview", reviewPointJson, true)
+        }
+
+        if (task.pointReview.additionalReviewers != None) {
+          val additionalReviewerJson = Json
+            .toJson(
+              Map(
+                "additionalReviewers" ->
+                  task.pointReview.additionalReviewers.getOrElse(List()).map(r => reviewers.get(r))
+              )
+            )
+            .as[JsObject]
+          reviewPointJson = Utils
+            .insertIntoJson(
+              reviewPointJson,
+              "additionalReviewers",
+              (additionalReviewerJson \ "additionalReviewers").get,
+              true
+            )
+            .as[JsObject]
           updated = Utils.insertIntoJson(updated, "pointReview", reviewPointJson, true)
         }
 

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -505,10 +505,9 @@ class TaskController @Inject() (
           .toMap
       )
 
-      val allReviewers = new scala.collection.mutable.ListBuffer[Long]()
-      tasks.foreach(t => {
-        allReviewers += t.pointReview.reviewedBy.getOrElse(0L)
-        t.pointReview.additionalReviewers.getOrElse(List()).foreach(r => allReviewers += r)
+      val allReviewers = tasks.flatMap(t => {
+        List(t.pointReview.reviewedBy.map(r => r)).flatMap(r => r) ++
+          t.pointReview.additionalReviewers.getOrElse(List())
       })
 
       val reviewers = Some(

--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -246,9 +246,15 @@ class TaskReviewController @Inject() (
           .toMap
       )
 
+      val allReviewers = new scala.collection.mutable.ListBuffer[Long]()
+      tasks.foreach(t => {
+        allReviewers += t.review.reviewedBy.getOrElse(0L)
+        t.review.additionalReviewers.getOrElse(List()).foreach(r => allReviewers += r)
+      })
+
       val reviewers = Some(
         this.serviceManager.user
-          .retrieveListById(tasks.map(t => t.review.reviewedBy.getOrElse(0L)))
+          .retrieveListById(allReviewers.toList)
           .map(u => u.id -> Json.obj("username" -> u.name, "id" -> u.id))
           .toMap
       )
@@ -269,6 +275,23 @@ class TaskReviewController @Inject() (
         if (task.review.reviewedBy.getOrElse(0) != 0) {
           val reviewerJson = Json.toJson(reviewers.get(task.review.reviewedBy.get)).as[JsObject]
           updated = Utils.insertIntoJson(updated, "reviewedBy", reviewerJson, true)
+        }
+        if (task.review.additionalReviewers != None) {
+          val additionalReviewerJson = Json
+            .toJson(
+              Map(
+                "additionalReviewers" ->
+                  task.review.additionalReviewers.getOrElse(List()).map(r => reviewers.get(r))
+              )
+            )
+            .as[JsObject]
+
+          updated = Utils.insertIntoJson(
+            updated,
+            "additionalReviewers",
+            (additionalReviewerJson \ "additionalReviewers").get,
+            true
+          )
         }
         if (includeTags && tagsMap.contains(task.id)) {
           val tagsJson = Json.toJson(tagsMap(task.id))

--- a/app/org/maproulette/controllers/api/TaskReviewController.scala
+++ b/app/org/maproulette/controllers/api/TaskReviewController.scala
@@ -246,10 +246,9 @@ class TaskReviewController @Inject() (
           .toMap
       )
 
-      val allReviewers = new scala.collection.mutable.ListBuffer[Long]()
-      tasks.foreach(t => {
-        allReviewers += t.review.reviewedBy.getOrElse(0L)
-        t.review.additionalReviewers.getOrElse(List()).foreach(r => allReviewers += r)
+      val allReviewers = tasks.flatMap(t => {
+        List(t.review.reviewedBy.map(r => r)).flatMap(r => r) ++
+          t.review.additionalReviewers.getOrElse(List())
       })
 
       val reviewers = Some(

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -319,19 +319,21 @@ class TaskReviewController @Inject() (
           params.getProjectIds match {
             case Some(pId) =>
               // Searching by project, just fetch name
-              pId.map(
-                 this.projectService.retrieve(_) match {
-                  case Some(p) => p.displayName.get
-                  case None => ""
-                }
-              ).mkString("|")
+              pId
+                .map(
+                  this.projectService.retrieve(_) match {
+                    case Some(p) => p.displayName.get
+                    case None    => ""
+                  }
+                )
+                .mkString("|")
             case None =>
               params.getChallengeIds match {
                 case Some(cId) =>
                   // We have a list of challenges. If these challenges all belong
                   // to the same project we can use the parent project name.
                   val challengeList = this.challengeService.list(cId)
-                  val parentProject:Option[Long] =
+                  val parentProject: Option[Long] =
                     if (challengeList.forall(_.general.parent == challengeList.head.general.parent))
                       Some(challengeList.head.general.parent)
                     else None
@@ -339,7 +341,7 @@ class TaskReviewController @Inject() (
                     case Some(pp) =>
                       this.projectService.retrieve(pp) match {
                         case Some(p) => p.displayName.get
-                        case None => ""
+                        case None    => ""
                       }
                     case None => ""
                   }
@@ -394,7 +396,8 @@ class TaskReviewController @Inject() (
               val rsTimeSeconds = Math.round(rsRow.avgReviewTime / 1000)
               val rsPercent     = Math.round(rsRow.total * 100 / row.total)
               result ++=
-                s"\n${mapper.get},${projectName},${if (challengeName == "") "" else s"${challengeName},"}" +
+                s"\n${mapper.get},${projectName},${if (challengeName == "") ""
+                else s"${challengeName},"}" +
                   s"${Task.reviewStatusMap.get(rs).get},${rsRow.total}," +
                   s"${rsPercent},${rsTimeSeconds},,,,," +
                   s",${rsRow.fixed},${rsRow.falsePositive},${rsRow.alreadyFixed}," +

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -129,8 +129,7 @@ trait SearchParametersMixin {
               )
             )
           )
-        }
-        else {
+        } else {
           FilterGroup(
             List(
               BaseParameter(

--- a/app/org/maproulette/framework/model/Leaderboard.scala
+++ b/app/org/maproulette/framework/model/Leaderboard.scala
@@ -24,7 +24,12 @@ case class LeaderboardUser(
     completedTasks: Int,
     avgTimeSpent: Long,
     created: DateTime = new DateTime(),
-    topChallenges: List[LeaderboardChallenge]
+    topChallenges: List[LeaderboardChallenge],
+    reviewsApproved: Option[Int],
+    reviewsAssisted: Option[Int],
+    reviewsRejected: Option[Int],
+    reviewsDisputed: Option[Int],
+    additionalReviews: Option[Int]
 )
 object LeaderboardUser extends CommonField {
   implicit val writes: Writes[LeaderboardUser] = Json.writes[LeaderboardUser]

--- a/app/org/maproulette/framework/model/TaskReview.scala
+++ b/app/org/maproulette/framework/model/TaskReview.scala
@@ -22,6 +22,7 @@ case class TaskReview(
     reviewedByUsername: Option[String],
     reviewedAt: Option[DateTime],
     reviewStartedAt: Option[DateTime],
+    additionalReviewers: Option[List[Long]],
     reviewClaimedBy: Option[Long],
     reviewClaimedByUsername: Option[String],
     reviewClaimedAt: Option[DateTime]

--- a/app/org/maproulette/framework/repository/LeaderboardRepository.scala
+++ b/app/org/maproulette/framework/repository/LeaderboardRepository.scala
@@ -50,9 +50,15 @@ class LeaderboardRepository @Inject() (override val db: Database) extends Reposi
       get[Int]("user_ranking") ~
       get[DateTime]("created").? ~
       get[Int]("completed_tasks") ~
-      get[Long]("avg_time_spent") map {
+      get[Long]("avg_time_spent") ~
+      get[Int]("reviews_approved").? ~
+      get[Int]("reviews_assisted").? ~
+      get[Int]("reviews_rejected").? ~
+      get[Int]("reviews_disputed").? ~
+      get[Int]("additional_reviews").? map {
       case userId ~ name ~ avatarURL ~ score ~ rank ~ created ~
-            completedTasks ~ avgTimeSpent => {
+            completedTasks ~ avgTimeSpent ~ reviewsApproved ~ reviewsAssisted ~
+            reviewsRejected ~ reviewsDisputed ~ additional_reviews => {
         new LeaderboardUser(
           userId,
           name,
@@ -65,7 +71,12 @@ class LeaderboardRepository @Inject() (override val db: Database) extends Reposi
             case Some(c) => c
             case _       => new DateTime()
           },
-          getTopChallengesBlock(userId)
+          getTopChallengesBlock(userId),
+          reviewsApproved,
+          reviewsAssisted,
+          reviewsRejected,
+          reviewsDisputed,
+          additional_reviews
         )
       }
     }

--- a/app/org/maproulette/framework/repository/ProjectRepository.scala
+++ b/app/org/maproulette/framework/repository/ProjectRepository.scala
@@ -180,10 +180,10 @@ class ProjectRepository @Inject() (override val db: Database, grantService: Gran
 
       val baseQuery =
         s"""
-          SELECT challenges.id, users.osm_id, users.name, challenges.name, challenges.parent_id, 
-                  |projects.name, challenges.blurb, ST_AsGeoJSON(challenges.location) AS location, 
-                  |ST_AsGeoJSON(challenges.bounding) AS bounding, challenges.difficulty, 
-                  |challenges.last_updated 
+          SELECT challenges.id, users.osm_id, users.name, challenges.name, challenges.parent_id,
+                  |projects.name, challenges.blurb, ST_AsGeoJSON(challenges.location) AS location,
+                  |ST_AsGeoJSON(challenges.bounding) AS bounding, challenges.difficulty,
+                  |challenges.last_updated
           |FROM challenges
           |INNER JOIN projects ON projects.id = challenges.parent_id
           |INNER JOIN users ON users.osm_id = challenges.owner_id
@@ -358,7 +358,7 @@ object ProjectRepository extends Readers {
         val locationJSON = Json.parse(location)
         val coordinates  = (locationJSON \ "coordinates").as[List[Double]]
         val point        = Point(coordinates(1), coordinates.head)
-        val pointReview  = PointReview(None, None, None, None, None)
+        val pointReview  = PointReview(None, None, None, None, None, None)
         val boundingJSON = Json.parse(bounding)
         ClusteredPoint(
           id,

--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -115,7 +115,8 @@ class UserMetricService @Inject() (
             )
           )
         )
-      )
+      ),
+      false
     )
 
     if (isReviewer) {
@@ -135,12 +136,13 @@ class UserMetricService @Inject() (
             reviewerTimeClause,
             BaseParameter(
               TaskReview.FIELD_REVIEW_STATUS,
-              Task.REVIEW_STATUS_UNNECESSARY,
-              Operator.EQ,
+              List(Task.REVIEW_STATUS_UNNECESSARY),
+              Operator.IN,
               true
             )
           )
-        )
+        ),
+        true
       )
       Map(
         "tasks"           -> taskCounts,

--- a/app/org/maproulette/framework/service/UserService.scala
+++ b/app/org/maproulette/framework/service/UserService.scala
@@ -169,7 +169,6 @@ class UserService @Inject() (
           )
         case None => query
       }
-
     )
   }
 

--- a/app/org/maproulette/models/ClusteredPoint.scala
+++ b/app/org/maproulette/models/ClusteredPoint.scala
@@ -19,7 +19,8 @@ case class PointReview(
     reviewRequestedBy: Option[Long],
     reviewedBy: Option[Long],
     reviewedAt: Option[DateTime],
-    reviewStartedAt: Option[DateTime]
+    reviewStartedAt: Option[DateTime],
+    additionalReviewers: Option[List[Long]]
 )
 
 /**

--- a/app/org/maproulette/models/Task.scala
+++ b/app/org/maproulette/models/Task.scala
@@ -22,7 +22,8 @@ case class TaskReviewFields(
     reviewedAt: Option[DateTime] = None,
     reviewStartedAt: Option[DateTime] = None,
     reviewClaimedBy: Option[Long] = None,
-    reviewClaimedAt: Option[DateTime] = None
+    reviewClaimedAt: Option[DateTime] = None,
+    additionalReviewers: Option[List[Long]] = None
 ) extends DefaultWrites
 
 /**
@@ -163,6 +164,10 @@ object Task extends CommonField {
       }
       updated = o.review.reviewClaimedBy match {
         case Some(r) => Utils.insertIntoJson(updated, "reviewClaimedBy", r, true)
+        case None    => updated
+      }
+      updated = o.review.additionalReviewers match {
+        case Some(r) => Utils.insertIntoJson(updated, "additionalReviewers", r, true)
         case None    => updated
       }
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1357,6 +1357,7 @@ class TaskDAL @Inject() (
         reviewedBy         <- get[Option[String]]("reviewedBy")
         reviewedAt         <- get[Option[DateTime]]("task_review.reviewed_at")
         reviewStartedAt    <- get[Option[DateTime]]("task_review.review_started_at")
+        additionalReviewers<- get[Option[List[String]]]("additionalReviewers")
         tags               <- get[Option[String]]("tags")
         responses          <- get[Option[String]]("responses")
         bundleId           <- get[Option[Long]]("bundle_id")
@@ -1376,6 +1377,7 @@ class TaskDAL @Inject() (
         reviewedBy,
         reviewedAt,
         reviewStartedAt,
+        additionalReviewers,
         tags,
         responses,
         geojson,
@@ -1408,6 +1410,7 @@ class TaskDAL @Inject() (
                    (SELECT name as reviewRequestedBy FROM users WHERE users.id = task_review.review_requested_by),
                    (SELECT name as reviewedBy FROM users WHERE users.id = task_review.reviewed_by),
                    task_review.reviewed_at, task_review.review_started_at,
+                   (ARRAY(SELECT name FROM users WHERE id IN (SELECT UNNEST(additional_reviewers)))) AS additionalReviewers,
                    (SELECT STRING_AGG(tg.name, ',') AS tags FROM tags_on_tasks tot, tags tg where tot.task_id = tasks.id AND tg.id = tot.tag_id),
                    tasks.completion_responses::TEXT AS responses
             FROM tasks LEFT OUTER JOIN (
@@ -1510,6 +1513,7 @@ class TaskDAL @Inject() (
       reviewedBy: Option[String],
       reviewedAt: Option[DateTime],
       reviewStartedAt: Option[DateTime],
+      additionalReviewers: Option[List[String]],
       tags: Option[String],
       completionResponses: Option[String],
       geojson: Option[String],

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -77,7 +77,7 @@ class TaskDAL @Inject() (
   val retrieveColumnsWithReview: String = this.retrieveColumns +
     ", task_review.review_status, task_review.review_requested_by, " +
     "task_review.reviewed_by, task_review.reviewed_at, task_review.review_started_at, " +
-    "task_review.review_claimed_by, task_review.review_claimed_at "
+    "task_review.review_claimed_by, task_review.review_claimed_at, task_review.additional_reviewers "
 
   /**
     * Retrieves the object based on the name, this function is somewhat weak as there could be
@@ -126,6 +126,7 @@ class TaskDAL @Inject() (
       get[Option[DateTime]]("task_review.review_started_at") ~
       get[Option[Long]]("task_review.review_claimed_by") ~
       get[Option[DateTime]]("task_review.review_claimed_at") ~
+      get[Option[List[Long]]]("task_review.additional_reviewers") ~
       get[Int]("tasks.priority") ~
       get[Option[Long]]("tasks.changeset_id") ~
       get[Option[String]]("responses") ~
@@ -134,7 +135,7 @@ class TaskDAL @Inject() (
       case id ~ name ~ created ~ modified ~ parent_id ~ instruction ~ location ~ status ~ geojson ~
             cooperativeWork ~ mappedOn ~ completedTimeSpent ~ completedBy ~ reviewStatus ~
             reviewRequestedBy ~ reviewedBy ~ reviewedAt ~ reviewStartedAt ~ reviewClaimedBy ~
-            reviewClaimedAt ~ priority ~ changesetId ~ responses ~ bundleId ~ isBundlePrimary =>
+            reviewClaimedAt ~ additionalReviewers ~ priority ~ changesetId ~ responses ~ bundleId ~ isBundlePrimary =>
         val values = this.updateAndRetrieve(id, geojson, location, cooperativeWork)
         Task(
           id,
@@ -157,7 +158,8 @@ class TaskDAL @Inject() (
             reviewedAt,
             reviewStartedAt,
             reviewClaimedBy,
-            reviewClaimedAt
+            reviewClaimedAt,
+            additionalReviewers
           ),
           priority,
           changesetId,

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -413,8 +413,8 @@ class ChallengeProvider @Inject() (
           case Success(result) =>
             if (result.status == Status.OK) {
               this.db.withTransaction { implicit c =>
-                var partial = false
-                val payload = result.json
+                var partial          = false
+                val payload          = result.json
                 var targetTypeFailed = false
 
                 // parse the results. Overpass has its own format and is not geojson
@@ -428,22 +428,28 @@ class ChallengeProvider @Inject() (
                           case Some("way") =>
                             if (targetType != "way") {
                               targetTypeFailed = true
-                              throw new InvalidException("Element type 'way' does not match target type of '" + targetType + "'")
+                              throw new InvalidException(
+                                "Element type 'way' does not match target type of '" + targetType + "'"
+                              )
                             }
                           case Some("node") =>
                             if (targetType != "node") {
                               targetTypeFailed = true
-                              throw new InvalidException("Element type 'node' does not match target type of '" + targetType + "'")
+                              throw new InvalidException(
+                                "Element type 'node' does not match target type of '" + targetType + "'"
+                              )
                             }
                           case x =>
                             targetTypeFailed = true
-                            throw new InvalidException("Element type " + x + " does not match target type of '" + targetType + "'")
+                            throw new InvalidException(
+                              "Element type " + x + " does not match target type of '" + targetType + "'"
+                            )
                         }
                       case _ => // do not validate
                     }
 
                     try {
-                        val geometry = (element \ "center").asOpt[JsObject] match {
+                      val geometry = (element \ "center").asOpt[JsObject] match {
                         case Some(center) =>
                           Some(
                             Json.obj(

--- a/conf/evolutions/default/70.sql
+++ b/conf/evolutions/default/70.sql
@@ -3,7 +3,47 @@
 ALTER TABLE IF EXISTS challenges
   ADD COLUMN overpass_target_type VARCHAR;;
 
+-- Add additional_reviewer to task_review
+ALTER TABLE IF EXISTS task_review
+  ADD COLUMN additional_reviewers INTEGER[];;
+
+-- Add original_reviewer to task_review_history
+ALTER TABLE IF EXISTS task_review_history
+  ADD COLUMN original_reviewer INTEGER;;
+
+
+-- Fix task_review_history review_started_at column
+-- This column was being set with the last time this
+-- task was reviewed, it's started at time when it should
+-- be set with when the review was claimed at. We can fix
+-- all the latest entries in the task_review_history table
+-- by looking at the task_review table.
+UPDATE task_review_history SET review_started_at = NULL;;
+
+WITH last_entry AS (
+  SELECT tr.*, ROW_NUMBER() OVER (PARTITION BY task_id ORDER BY id DESC) AS entry
+  from task_review_history tr where review_status = 1 OR review_status = 2 or review_status = 3
+), new_entry AS (
+  SELECT last_entry.id as row_id, tr.review_started_at as new_started_at, tr.task_id as new_task_id
+  FROM last_entry
+  INNER JOIN task_review tr ON tr.task_id = last_entry.task_id
+  WHERE entry = 1 and last_entry.review_status = tr.review_status
+)
+UPDATE task_review_history
+SET review_started_at = new_started_at
+FROM new_entry
+WHERE id = new_entry.row_id
+
+
 # --- !Downs
 -- Remove added column overpass_target_type
 ALTER TABLE IF EXISTS challenges
   DROP COLUMN overpass_target_type;;
+
+-- Remove added column additional_reviewer
+ALTER TABLE IF EXISTS task_review
+  DROP COLUMN additional_reviewers;;
+
+-- Remove column original_reviewer
+ALTER TABLE IF EXISTS task_review_history
+  DROP COLUMN original_reviewer;;

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -619,7 +619,7 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
       val params = SearchParameters(projectIds = Some(List(123, 456)))
       this.filterProjects(params, true).sql() mustEqual
         "(p.id IN (123,456) OR c.id IN (SELECT challenge_id from virtual_project_challenges " +
-        "WHERE project_id IN (123,456)))"
+          "WHERE project_id IN (123,456)))"
     }
 
     "invert search project Ids including virtual" in {
@@ -627,7 +627,7 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
         SearchParameters(projectIds = Some(List(123, 456)), invertFields = Some(List("pid")))
       this.filterProjects(params, true).sql() mustEqual
         "NOT p.id IN (123,456) AND NOT c.id IN (SELECT challenge_id " +
-        "from virtual_project_challenges WHERE project_id IN (123,456))"
+          "from virtual_project_challenges WHERE project_id IN (123,456))"
     }
 
     "does fuzzy search" in {


### PR DESCRIPTION
* Add to database task_review: 'additional_reviewers' and
  to task_review_history: 'original_reviewer'

* Support 'additionalReviewers' to be returned when fetching
  any task data that includes review data.

* Convert review metrics to fetch from task_review_history to
  better match expected metrics and include metric for
  'additionalReviews'

* Convert reviewer 'leaderboard' to fetch review counts from
  task_review_history and also include how many reviews were
  'additionalReviews'

* When returning review metrics also include breakdown by review status

* Fix bug around updating task_review_history: In setTaskReviewStatus
  the 'started_at' time for the task_review_history should be the
  task's review current 'claimed_at' time. Also include db evolution
  to fix the latest entries for a task in task_review_history by
  populating the started_at from the task_review table.