### PR TITLE
Fix bug where reviewer cannot re-review a task

### DIFF
--- a/app/org/maproulette/models/dal/TaskReviewDAL.scala
+++ b/app/org/maproulette/models/dal/TaskReviewDAL.scala
@@ -809,16 +809,19 @@ class TaskReviewDAL @Inject() (
 
       // If we are changing the status back to "needsReview" then this task
       // has been fixed by the mapper and the mapper is requesting review again
-      if (needsReReview) {
-        fetchBy = "review_requested_by"
-        reviewRequestedBy = Some(user.id)
-      } else {
-        reviewedBy = Some(user.id)
-      }
+      val fetchByUser =
+        if (needsReReview) {
+          fetchBy = "review_requested_by"
+          reviewRequestedBy = Some(user.id)
+          user.id
+        } else {
+          reviewedBy = Some(user.id)
+          originalReviewer.get
+        }
 
       val updatedRows =
         SQL"""UPDATE task_review SET review_status = $reviewStatus,
-                                 #${fetchBy} = ${originalReviewer.get},
+                                 #${fetchBy} = ${fetchByUser},
                                  reviewed_at = NOW(),
                                  review_started_at = task_review.review_claimed_at,
                                  review_claimed_at = NULL,

--- a/conf/evolutions/default/72.sql
+++ b/conf/evolutions/default/72.sql
@@ -1,0 +1,21 @@
+# --- !Ups
+-- Due to a bug where mapper was being set as reviewer during a review revision,
+-- we need to fix these task reviews by pulling the correct requested_by from
+-- the most recent task_review_history entry.
+
+WITH wrong_reviews AS (
+  SELECT tr.id AS reviewId, tr.task_id AS taskId, th.requested_by AS requestedBy
+  FROM task_review tr
+  JOIN task_review_history th ON (tr.task_id = th.task_id)
+  LEFT OUTER JOIN task_review_history th2 ON (tr.task_id = th2.task_id AND
+      (th.reviewed_at < th2.reviewed_at OR (th.reviewed_at = th2.reviewed_at AND
+       th.id < th2.id)))
+  WHERE th2.task_id IS NULL AND tr.reviewed_by = tr.review_requested_by AND
+        tr.review_requested_by NOT IN
+          (SELECT th.requested_by FROM task_review_history th
+           WHERE th.task_id = tr.task_id)
+)
+UPDATE task_review
+SET review_requested_by = requestedBy
+FROM wrong_reviews
+WHERE id = wrong_reviews.reviewId AND task_id = wrong_reviews.taskId;


### PR DESCRIPTION
* Fix case where reviewer was being assigned as mapper in case
  of re-review in the task_review table

* Fix any data messed up by this bug by referencing task_review_history