### PR TITLE
set play idle timeout in conf to 1 hour

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,6 +74,7 @@ play {
         noCaVerification = false
       }
     }
+    ws.timeout.idle=3600s
   }
   # This is the max memory for post body data
   http {


### PR DESCRIPTION
When doing an overpass query we let the user override the timeout
in their query. This timeout only overrides the request timeout
and will still be restricted by the idle timeout. By changing the idle timeout
to an hour in the conf, it will allow longer overpass queries to
run with overridden timeouts but as the default request timeout
in play is 2 minutes it will still enforce that restriction
normally.

See "configuring timeouts" in: https://www.playframework.com/documentation/2.6.x/ScalaWS

Closes #842 