### PR TITLE
Allow custom filename for challenge GeoJSON export

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -144,7 +144,8 @@ class ChallengeController @Inject() (
       statusFilter: String,
       reviewStatusFilter: String,
       priorityFilter: String,
-      timezone: String
+      timezone: String,
+      filename: String
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.userAwareRequest { implicit user =>
       SearchParameters.withSearch { implicit params =>
@@ -165,11 +166,16 @@ class ChallengeController @Inject() (
             } else {
               Some(Utils.split(priorityFilter).map(_.toInt))
             }
+            val attachmentFilename = if (StringUtils.isEmpty(filename)) {
+              "challenge_geojson.json"
+            } else {
+              filename
+            }
 
             Result(
               header = ResponseHeader(
                 OK,
-                Map(CONTENT_DISPOSITION -> s"attachment; filename=challenge_geojson.json")
+                Map(CONTENT_DISPOSITION -> s"attachment; filename=${attachmentFilename}")
               ),
               body = HttpEntity.Strict(
                 ByteString(

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -867,8 +867,12 @@ GET     /challenge/:cid/previousTask/:id            @org.maproulette.controllers
 #     in: query
 #     description: A timezone offset to apply to time fields. Format should be like '+HH:MM'. Default is GMT (+00:00)
 #     required: optional
+#   - name: filename
+#     in: query
+#     description: Optional filename to be used for the export
+#     default: challenge_geojson.json
 ###
-GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "")
+GET     /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "", filename:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves Challenge GeoJSON
@@ -892,11 +896,15 @@ GET     /challenge/view/:id                         @org.maproulette.controllers
 #   - name: reviewStatus
 #     in: query
 #     description: Can filter the Tasks returned by the reviewStatus of the Task. 0 - Requested, 1 - Approved, 2 - Rejected, 3 - Assisted, 4 - Disputed
+#   - name: filename
+#     in: query
+#     description: Optional filename to be used for the export
+#     default: challenge_geojson.json
 #   - name: taskPropertySearch
 #     in: POST form data
 #     description: Can filter by specific task properties.
 ###
-POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "")
+POST    /challenge/view/:id                         @org.maproulette.controllers.api.ChallengeController.getChallengeGeoJSON(id:Long, status:String ?= "", reviewStatus:String ?= "", priority:String ?= "", timezone:String ?= "", filename:String ?= "")
 ###
 # tags: [ Challenge ]
 # summary: Retrieves clustered Task points


### PR DESCRIPTION
- Add support for optional filename to be specified when exporting
challenge GeoJSON via API