### PR TITLE
Akka Settings from Environment

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -45,6 +45,14 @@ akka {
   actor {
     provider = "cluster"
   }
+  remote.artery {
+    canonical {
+      hostname = "127.0.0.1"
+      hostname = ${?MR_AKKA_HOST}
+      port = 25520
+      port = ${?MR_AKKA_PORT}
+    }
+  }
 }
 play {
   evolutions.db.default {


### PR DESCRIPTION
* Allows customization of Akka's listening via `MR_AKKA_{HOST,PORT}` environment variables.  This is convenient for running tests at the same time as a running development instance.
* Default Akka to safely listen only on 127.0.0.1 instead of all bound addresses.  Cluster advertisement should be opt-in, not opt-out -- otherwise it's a potential security issue (I wish malicious cluster joining wasn't a thing).