### PR TITLE
Add support for Achievements/Badges

### DIFF
--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -226,7 +226,8 @@ case class User(
     properties: Option[String] = None,
     score: Option[Int] = None,
     followingGroupId: Option[Long] = None,
-    followersGroupId: Option[Long] = None
+    followersGroupId: Option[Long] = None,
+    achievements: Option[List[Int]] = None,
 ) extends CacheObject[Long]
     with Identifiable {
   // for users the display name is always retrieved from OSM
@@ -415,18 +416,7 @@ object User extends CommonField {
       case Some(key) if key.nonEmpty =>
         try {
           val decryptedAPIKey = Some(s"${user.id}|${crypto.decrypt(key)}")
-          new User(
-            user.id,
-            user.created,
-            user.modified,
-            user.osmProfile,
-            user.grants,
-            decryptedAPIKey,
-            user.guest,
-            user.settings,
-            user.properties,
-            user.score
-          )
+          user.copy(apiKey = decryptedAPIKey)
         } catch {
           case _: BadPaddingException | _: IllegalBlockSizeException =>
             LoggerFactory

--- a/app/org/maproulette/framework/model/UserMetrics.scala
+++ b/app/org/maproulette/framework/model/UserMetrics.scala
@@ -30,4 +30,30 @@ object UserMetrics {
   val FIELD_TASKS_WITH_TIME            = "tasks_with_time"
   val FIELD_TOTAL_REVIEW_TIME          = "total_review_time"
   val FIELD_TASKS_WITH_REVIEW_TIME     = "tasks_with_review_time"
+  val FIELD_ACHIEVEMENTS               = "achievements"
+}
+
+trait Achievement {}
+object Achievement {
+  val MAPPED_ROADS = 1
+  val MAPPED_WATER = 2
+  val MAPPED_TRANSIT = 3
+  val MAPPED_LANDUSE = 4
+  val MAPPED_BUILDINGS = 5
+  val MAPPED_POI = 6
+  val POINTS_100 = 7
+  val POINTS_500 = 8
+  val POINTS_1000 = 9
+  val POINTS_5000 = 10
+  val POINTS_10000 = 11
+  val POINTS_50000 = 12
+  val POINTS_100000 = 13
+  val POINTS_500000 = 14
+  val POINTS_1000000 = 15
+  val FIXED_TASK = 16
+  val REVIEWED_TASK = 17
+  val CREATED_CHALLENGE = 18
+  val FIXED_FINAL_TASK = 19
+  val FIXED_COOP_TASK = 20
+  val CHALLENGE_COMPLETED = 21
 }

--- a/app/org/maproulette/framework/service/AchievementService.scala
+++ b/app/org/maproulette/framework/service/AchievementService.scala
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import javax.inject.{Inject, Singleton}
+import scala.collection.mutable.ListBuffer
+import org.maproulette.framework.model.{Task, Challenge, User, Tag, Achievement}
+import org.maproulette.framework.repository.{UserRepository}
+import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
+
+/**
+  * @author nrotstan
+  */
+@Singleton
+class AchievementService @Inject() (
+    repository: UserRepository,
+    serviceManager: ServiceManager,
+    webSocketProvider: WebSocketProvider,
+) {
+  /**
+    * Award any appropriate achievements based on completion of a task
+    */
+  def awardTaskCompletionAchievements(user: User, task: Task, newStatus: Int): Option[User] = {
+    // Achievements are only awarded if the task was fixed
+    if (newStatus == Task.STATUS_FIXED) {
+      // We build up a list of all potential achievements. When we add them to the user,
+      // only the new ones (not already possessed by the user) will be actually be added
+      val achievements = ListBuffer[Int]()
+      achievements += Achievement.FIXED_TASK
+      if (task.cooperativeWork != None) {
+        achievements += Achievement.FIXED_COOP_TASK
+      }
+
+      this.serviceManager.challenge.retrieve(task.parent) match {
+        case Some(challenge) =>
+          if (challenge.status.getOrElse(Challenge.STATUS_NA) == Challenge.STATUS_FINISHED) {
+            achievements += Achievement.FIXED_FINAL_TASK
+          }
+          val challengeTags = this.serviceManager.tag.listByChallenge(task.parent)
+          this.appendTaskCompletionCategoryAchievements(challengeTags, achievements)
+        case None =>
+      }
+
+      this.appendPointBasedAchievements(user, achievements)
+      this.addAchievementsToUser(user, achievements.toList)
+    }
+    else {
+      Some(user)
+    }
+  }
+
+  /**
+    * Award any appropriate achievements based on review of a task
+    */
+  def awardTaskReviewAchievements(user: User, task: Task, newReviewStatus: Int): Option[User] = {
+    // Achievements are only awarded if the review was completed
+    if (newReviewStatus != Task.REVIEW_STATUS_APPROVED &&
+        newReviewStatus != Task.REVIEW_STATUS_REJECTED &&
+        newReviewStatus != Task.REVIEW_STATUS_ASSISTED) {
+      return Some(user)
+    }
+
+    this.addAchievementsToUser(user, List(Achievement.REVIEWED_TASK))
+  }
+
+  /**
+    * Award any appropriate achievements based on completion of a challenge
+    */
+  def awardChallengeCompletionAchievements(challenge: Challenge) = {
+    // Achievements are only awarded if the challenge is finished
+    if (challenge.status.getOrElse(Challenge.STATUS_NA) == Challenge.STATUS_FINISHED) {
+      // Retrieve mappers as User instances, as getChallengeMappers gives back
+      // UserSearchResult instances
+      val mappers = this.serviceManager.user.retrieveListById(
+        this.serviceManager.user.getChallengeMappers(challenge.id).map(m => m.id)
+      )
+
+      mappers.foreach { mapper =>
+        this.addAchievementsToUser(mapper, List(Achievement.CHALLENGE_COMPLETED))
+      }
+    }
+  }
+
+  /**
+    * Award any appropriate achievements based on creation of a new challenge
+    */
+  def awardChallengeCreationAchievements(challenge: Challenge): Option[User] = {
+        // Achievements are only awarded if the challenge is ready and public
+    if (challenge.status.getOrElse(Challenge.STATUS_NA) != Challenge.STATUS_READY ||
+        !challenge.general.enabled) {
+      return None
+    }
+
+    this.serviceManager.project.retrieve(challenge.general.parent) match {
+      case Some(project) if project.enabled =>
+        this.serviceManager.user.retrieveByOSMId(challenge.general.owner) match {
+          case Some(user) =>
+            this.addAchievementsToUser(user, List(Achievement.CREATED_CHALLENGE))
+          case None => None
+        }
+      case _ => None
+    }
+  }
+
+  /**
+    * Add achievements to user (only new achievements will be added)
+    */
+  def addAchievementsToUser(user: User, achievements: List[Int]): Option[User] = {
+    if (achievements.filterNot(user.achievements.getOrElse(List.empty).toSet).isEmpty) {
+      // User already has all of these achievements. Nothing to do
+      return Some(user)
+    }
+
+    // We need to invalidate the user in the cache
+    this.serviceManager.user.cacheManager.withDeletingCache(id => this.serviceManager.user.retrieve(id)) {
+      implicit cachedItem =>
+        this.repository.addAchievements(user.id, achievements)
+        Some(cachedItem)
+    }(id = user.id)
+
+    // Notify websocket clients of any new awards
+    val latestUser = this.serviceManager.user.retrieve(user.id)
+    latestUser match {
+      case Some(latest) =>
+        val justAwarded = latest.achievements.getOrElse(List.empty).filterNot(
+          user.achievements.getOrElse(List.empty).toSet
+        )
+        if (!justAwarded.isEmpty) {
+          webSocketProvider.sendMessage(
+            WebSocketMessages.achievementAwarded(
+              WebSocketMessages.AchievementData(user.id, justAwarded)
+            )
+          )
+        }
+      case None => // nothing to do
+    }
+
+    latestUser
+  }
+
+  /**
+   * Appends achievements related to completing a task in a specific category
+   * as determined by the tags on the parent challenge
+   */
+  private def appendTaskCompletionCategoryAchievements(challengeTags: List[Tag], achievements: ListBuffer[Int]) = {
+    if (challengeTags.exists(t => t.name == "highway")) {
+      achievements += Achievement.MAPPED_ROADS
+    }
+    if (challengeTags.exists(t => t.name == "building")) {
+      achievements += Achievement.MAPPED_BUILDINGS
+    }
+    if (challengeTags.exists(t => t.name == "natural" || t.name == "water")) {
+      achievements += Achievement.MAPPED_WATER
+    }
+    if (challengeTags.exists(t => t.name == "amenity" || t.name == "leisure")) {
+      achievements += Achievement.MAPPED_POI
+    }
+    if (challengeTags.exists(t => t.name == "landuse" || t.name == "boundary")) {
+      achievements += Achievement.MAPPED_LANDUSE
+    }
+    if (challengeTags.exists(t => t.name == "public_transport" || t.name == "railway")) {
+      achievements += Achievement.MAPPED_TRANSIT
+    }
+  }
+
+  private def appendPointBasedAchievements(user: User, achievements: ListBuffer[Int]) = {
+    if (user.score.getOrElse(0) >= 100) {
+      achievements += Achievement.POINTS_100
+    }
+    if (user.score.getOrElse(0) >= 500) {
+      achievements += Achievement.POINTS_500
+    }
+    if (user.score.getOrElse(0) >= 1000) {
+      achievements += Achievement.POINTS_1000
+    }
+    if (user.score.getOrElse(0) >= 5000) {
+      achievements += Achievement.POINTS_5000
+    }
+    if (user.score.getOrElse(0) >= 10000) {
+      achievements += Achievement.POINTS_10000
+    }
+    if (user.score.getOrElse(0) >= 50000) {
+      achievements += Achievement.POINTS_50000
+    }
+    if (user.score.getOrElse(0) >= 100000) {
+      achievements += Achievement.POINTS_100000
+    }
+    if (user.score.getOrElse(0) >= 500000) {
+      achievements += Achievement.POINTS_500000
+    }
+    if (user.score.getOrElse(0) >= 1000000) {
+      achievements += Achievement.POINTS_1000000
+    }
+  }
+}

--- a/app/org/maproulette/framework/service/ServiceManager.scala
+++ b/app/org/maproulette/framework/service/ServiceManager.scala
@@ -28,6 +28,7 @@ class ServiceManager @Inject() (
     challengeListingService: Provider[ChallengeListingService],
     challengeSnapshotService: Provider[ChallengeSnapshotService],
     userMetricService: Provider[UserMetricService],
+    achievementService: Provider[AchievementService],
     virtualProjectService: Provider[VirtualProjectService],
     taskClusterService: Provider[TaskClusterService],
     taskReviewService: Provider[TaskReviewService],
@@ -42,6 +43,8 @@ class ServiceManager @Inject() (
   def tag: TagService = tagService.get()
 
   def userMetrics: UserMetricService = userMetricService.get()
+
+  def achievement: AchievementService = achievementService.get()
 
   def virtualProject: VirtualProjectService = virtualProjectService.get()
 

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -655,6 +655,12 @@ class TaskReviewService @Inject() (
       }
     }
 
+    if (reviewStatus == Task.REVIEW_STATUS_APPROVED ||
+        reviewStatus == Task.REVIEW_STATUS_REJECTED ||
+        reviewStatus == Task.REVIEW_STATUS_ASSISTED) {
+      this.serviceManager.achievement.awardTaskReviewAchievements(user, task, reviewStatus)
+    }
+
     updatedRows
   }
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -18,7 +18,7 @@ import org.maproulette.Config
 import org.maproulette.cache.CacheManager
 import org.maproulette.data._
 import org.maproulette.exception.{InvalidException, NotFoundException}
-import org.maproulette.framework.model.{Challenge, Project, StatusActions, User, GrantTarget, Task}
+import org.maproulette.framework.model.{Challenge, Project, StatusActions, User, GrantTarget, Task, Achievement}
 import org.maproulette.framework.psql.filter.{BaseParameter, SubQueryFilter}
 import org.maproulette.framework.psql.{Order, Paging, Query}
 import org.maproulette.framework.repository.{ProjectRepository, TaskRepository}
@@ -792,6 +792,10 @@ class TaskDAL @Inject() (
     }
 
     this.manager.challenge.updateFinishedStatus()(primaryTask.parent)
+
+    Future {
+      this.serviceManager.achievement.awardTaskCompletionAchievements(user, primaryTask, status)
+    }
 
     if (reviewNeeded) {
       webSocketProvider.sendMessage(

--- a/app/org/maproulette/provider/websockets/WebSocketActor.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketActor.scala
@@ -43,6 +43,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
   implicit val pongMessageWrites                  = WebSocketMessages.pongMessageWrites
   implicit val notificationDataWrites             = WebSocketMessages.notificationDataWrites
   implicit val notificationMessageWrites          = WebSocketMessages.notificationMessageWrites
+  implicit val achievementDataWrites              = WebSocketMessages.achievementDataWrites
+  implicit val achievementMessageWrites           = WebSocketMessages.achievementMessageWrites
   implicit val reviewDataWrites                   = WebSocketMessages.reviewDataWrites
   implicit val reviewMessageWrites                = WebSocketMessages.reviewMessageWrites
   implicit val taskWithReviewWrites               = TaskWithReview.taskWithReviewWrites
@@ -56,6 +58,8 @@ class WebSocketActor(out: ActorRef) extends Actor {
 
   def receive = {
     case serverMessage: WebSocketMessages.NotificationMessage =>
+      out ! Json.toJson(serverMessage)
+    case serverMessage: WebSocketMessages.AchievementMessage =>
       out ! Json.toJson(serverMessage)
     case serverMessage: WebSocketMessages.ReviewMessage =>
       out ! Json.toJson(serverMessage)

--- a/app/org/maproulette/provider/websockets/WebSocketMessages.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketMessages.scala
@@ -76,6 +76,11 @@ object WebSocketMessages {
   case class FollowMessage(messageType: String, data: FollowUpdateData, meta: ServerMeta)
       extends ServerMessage
 
+  case class AchievementData(userId: Long, achievement: List[Int])
+
+  case class AchievementMessage(messageType: String, data: AchievementData, meta: ServerMeta)
+      extends ServerMessage
+
   // Public helper methods for creation of individual messages and data objects
   def pong(): PongMessage = PongMessage("pong", ServerMeta(None))
 
@@ -127,6 +132,9 @@ object WebSocketMessages {
   def followUpdate(data: FollowUpdateData): FollowMessage =
     createFollowMessage("follow-update", data)
 
+  def achievementAwarded(data: AchievementData): AchievementMessage =
+    createAchievementMessage("achievement-awarded", data)
+
   def userSummary(user: User): UserSummary =
     UserSummary(user.id, user.osmProfile.id, user.osmProfile.displayName, user.osmProfile.avatarURL)
 
@@ -147,6 +155,17 @@ object WebSocketMessages {
       data: NotificationData
   ): NotificationMessage = {
     NotificationMessage(
+      messageType,
+      data,
+      ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_USER + s"_${data.userId}"))
+    )
+  }
+
+  private def createAchievementMessage(
+    messageType: String,
+    data: AchievementData
+  ): AchievementMessage = {
+    AchievementMessage(
       messageType,
       data,
       ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_USER + s"_${data.userId}"))
@@ -194,6 +213,10 @@ object WebSocketMessages {
     FollowMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_FOLLOWING)))
   }
 
+  private def createAchievementMessage(messageType: String, data: FollowUpdateData): FollowMessage = {
+    FollowMessage(messageType, data, ServerMeta(Some(WebSocketMessages.SUBSCRIPTION_FOLLOWING)))
+  }
+
   // Reads for client messages
   implicit val clientMessageReads: Reads[ClientMessage]       = Json.reads[ClientMessage]
   implicit val subscriptionDataReads: Reads[SubscriptionData] = Json.reads[SubscriptionData]
@@ -208,6 +231,9 @@ object WebSocketMessages {
   implicit val notificationDataWrites: Writes[NotificationData] = Json.writes[NotificationData]
   implicit val notificationMessageWrites: Writes[NotificationMessage] =
     Json.writes[NotificationMessage]
+  implicit val achievementDataWrites: Writes[AchievementData]   = Json.writes[AchievementData]
+  implicit val achievementMessageWrites: Writes[AchievementMessage] =
+    Json.writes[AchievementMessage]
   implicit val reviewDataWrites: Writes[ReviewData]             = Json.writes[ReviewData]
   implicit val reviewMessageWrites: Writes[ReviewMessage]       = Json.writes[ReviewMessage]
   implicit val taskActionWrites: Writes[TaskAction]             = Json.writes[TaskAction]

--- a/conf/evolutions/default/75.sql
+++ b/conf/evolutions/default/75.sql
@@ -1,0 +1,140 @@
+# --- !Ups
+-- Add array_distinct function for removing dups
+DROP FUNCTION IF EXISTS array_distinct(arr anyarray);;
+CREATE FUNCTION array_distinct(arr anyarray) RETURNS anyarray AS $$
+  SELECT array_agg(elem order by ord)
+    from (
+      SELECT DISTINCT on(elem) elem, ord
+      FROM unnest(arr) WITH ordinality AS arr(elem, ord)
+      ORDER BY elem, ord
+    ) s
+$$
+LANGUAGE SQL IMMUTABLE;;
+
+-- Add achievements array column to user_metrics
+ALTER TABLE IF EXISTS user_metrics
+  ADD COLUMN achievements INTEGER[] NOT NULL DEFAULT '{}';;
+
+-- Retroactively add some basic achievements to users who earned them:
+-- FIXED_TASK
+UPDATE user_metrics SET achievements = array_distinct(achievements || 16)
+WHERE total_fixed > 0;;
+
+-- FIXED_COOP_TASK
+UPDATE user_metrics set achievements=array_distinct(achievements || 20)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select id from challenges where cooperative_type > 0
+  )
+);;
+
+-- MAPPED_ROADS
+UPDATE user_metrics set achievements=array_distinct(achievements || 1)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select distinct(challenge_id) from tags_on_challenges
+    INNER JOIN tags ON tags.id = tags_on_challenges.tag_id
+    WHERE tags.name = 'highway'
+  )
+);;
+
+-- MAPPED_WATER
+UPDATE user_metrics set achievements=array_distinct(achievements || 2)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select distinct(challenge_id) from tags_on_challenges
+    INNER JOIN tags ON tags.id = tags_on_challenges.tag_id
+    WHERE tags.name IN ('natural', 'water')
+  )
+);;
+
+-- MAPPED_TRANSIT
+UPDATE user_metrics set achievements=array_distinct(achievements || 3)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select distinct(challenge_id) from tags_on_challenges
+    INNER JOIN tags ON tags.id = tags_on_challenges.tag_id
+    WHERE tags.name IN ('railway', 'public_transport')
+  )
+);;
+
+-- MAPPED_LANDUSE
+UPDATE user_metrics set achievements=array_distinct(achievements || 4)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select distinct(challenge_id) from tags_on_challenges
+    INNER JOIN tags ON tags.id = tags_on_challenges.tag_id
+    WHERE tags.name IN ('landuse', 'boundary')
+  )
+);;
+
+-- MAPPED_BUILDINGS
+UPDATE user_metrics set achievements=array_distinct(achievements || 5)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select distinct(challenge_id) from tags_on_challenges
+    INNER JOIN tags ON tags.id = tags_on_challenges.tag_id
+    WHERE tags.name = 'building'
+  )
+);;
+
+-- MAPPED_POI
+UPDATE user_metrics set achievements=array_distinct(achievements || 6)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) from users u
+  INNER JOIN status_actions sa ON sa.osm_user_id = u.osm_id
+  WHERE sa.status = 1 AND sa.old_status != 1 AND challenge_id IN (
+    select distinct(challenge_id) from tags_on_challenges
+    INNER JOIN tags ON tags.id = tags_on_challenges.tag_id
+    WHERE tags.name IN ('amenity', 'leisure')
+  )
+);;
+
+-- REVIEWED_TASK
+UPDATE user_metrics SET achievements = array_distinct(achievements || 17)
+WHERE total_approved > 0 OR total_rejected > 0 OR total_assisted > 0;;
+
+-- CREATED_CHALLENGE
+UPDATE user_metrics SET achievements = array_distinct(achievements || 18)
+WHERE user_metrics.user_id IN (
+  SELECT DISTINCT(u.id) FROM USERS u
+  INNER JOIN challenges c ON c.owner_id = u.osm_id
+  INNER JOIN projects p ON c.parent_id = p.id
+  WHERE (c.enabled = true and p.enabled = true) OR c.status = 5 -- enabled or finished
+);;
+
+-- POINTS_100 through POINTS_1000000
+UPDATE user_metrics set achievements =
+  CASE
+    WHEN score >= 1000000 THEN array_distinct(achievements || '{7, 8, 9, 10, 11, 12, 13, 14, 15}'::int[])
+    WHEN score >= 500000 THEN array_distinct(achievements || '{7, 8, 9, 10, 11, 12, 13, 14}'::int[])
+    WHEN score >= 100000 THEN array_distinct(achievements || '{7, 8, 9, 10, 11, 12, 13}'::int[])
+    WHEN score >= 50000 THEN array_distinct(achievements || '{7, 8, 9, 10, 11, 12}'::int[])
+    WHEN score >= 10000 THEN array_distinct(achievements || '{7, 8, 9, 10, 11}'::int[])
+    WHEN score >= 5000 THEN array_distinct(achievements || '{7, 8, 9, 10}'::int[])
+    WHEN score >= 1000 THEN array_distinct(achievements || '{7, 8, 9}'::int[])
+    WHEN score >= 500 THEN array_distinct(achievements || '{7, 8}'::int[])
+    WHEN score >= 100 THEN array_distinct(achievements || 7)
+  END
+WHERE score >= 100;;
+
+
+# --- !Downs
+-- Remove achievements from user_metrics
+ALTER TABLE IF EXISTS user_metrics
+  DROP COLUMN achievements;;
+
+-- Remove array_distinct function
+DROP FUNCTION IF EXISTS array_distinct;;

--- a/test/org/maproulette/framework/FrameworkMasterSuite.scala
+++ b/test/org/maproulette/framework/FrameworkMasterSuite.scala
@@ -15,6 +15,7 @@ import org.scalatest.{BeforeAndAfterAll, Suite, Suites, Tag}
   */
 class FrameworkMasterSuite extends Suites with BeforeAndAfterAll with TestDatabase {
   private val suites = IndexedSeq(
+    new AchievementServiceSpec,
     new NotificationRepositorySpec,
     new NotificationSubscriptionRepositorySpec,
     new NotificationServiceSpec,

--- a/test/org/maproulette/framework/repository/UserRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/UserRepositorySpec.scala
@@ -208,6 +208,23 @@ class UserRepositorySpec(implicit val application: Application) extends Framewor
           )
         )
       )
+      this.userRepository.deleteByOSMID(61)
+    }
+
+    "add user achievements" taggedAs UserRepoTag in {
+      val insertedUser = this.userRepository
+        .upsert(this.getTestUser(62, "AddAchievementsTest"), "TestAPIKey", "POINT (20 40)")
+
+      // Brand-new users have no achievements
+      insertedUser.achievements.getOrElse(List.empty).length mustEqual 0
+
+      this.userRepository.addAchievements(insertedUser.id, List(1, 2, 3))
+      this.repositoryGet(insertedUser.id).get.achievements.getOrElse(List.empty).length mustEqual 3
+
+      // Make sure dup achievements don't get added
+      this.userRepository.addAchievements(insertedUser.id, List(3, 4, 5))
+      this.repositoryGet(insertedUser.id).get.achievements.getOrElse(List.empty).length mustEqual 5
+      this.userRepository.deleteByOSMID(62)
     }
   }
 

--- a/test/org/maproulette/framework/service/AchievementServiceSpec.scala
+++ b/test/org/maproulette/framework/service/AchievementServiceSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 MapRoulette contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ */
+
+package org.maproulette.framework.service
+
+import org.maproulette.framework.model.{Achievement, User, Task, Challenge}
+import org.maproulette.data.{UserType, ProjectType}
+import org.maproulette.framework.util.{FrameworkHelper, UserTag}
+import play.api.Application
+import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.Mockito._
+
+/**
+  * @author nrotstan
+  */
+class AchievementServiceSpec(implicit val application: Application) extends FrameworkHelper with MockitoSugar {
+  val service: AchievementService = this.serviceManager.achievement
+
+  var randomUser: User   = null
+  var anotherUser: User  = null
+
+  "AchievementService" should {
+    "award an achievement if user fixes their first task" taggedAs UserTag in {
+      val task = this.serviceManager.task.retrieve(defaultTask.id).get
+      val updatedUser =
+        this.service.awardTaskCompletionAchievements(this.defaultUser, task, Task.STATUS_FIXED)
+
+      updatedUser.get.achievements.getOrElse(List.empty).contains(Achievement.FIXED_TASK) mustEqual true
+    }
+
+    "does not award an achievement if the task isn't fixed" taggedAs UserTag in {
+      val task = this.serviceManager.task.retrieve(defaultTask.id).get
+      val updatedUser =
+        this.service.awardTaskCompletionAchievements(this.anotherUser, task, Task.STATUS_FALSE_POSITIVE)
+      
+      updatedUser.get.achievements.getOrElse(List.empty).contains(Achievement.FIXED_TASK) mustEqual false
+    }
+
+    "award an achievement if user crosses points threshold" taggedAs UserTag in {
+      val task = this.serviceManager.task.retrieve(defaultTask.id).get
+      val user = this.defaultUser.copy(score = Some(100))
+      val updatedUser =
+        this.service.awardTaskCompletionAchievements(user, task, Task.STATUS_FIXED)
+
+      updatedUser.get.achievements.getOrElse(List.empty).contains(Achievement.POINTS_100) mustEqual true
+    }
+
+    "award an achievement if user reviews their first task" taggedAs UserTag in {
+      val task = this.serviceManager.task.retrieve(defaultTask.id).get
+      val updatedUser =
+        this.service.awardTaskReviewAchievements(this.defaultUser, task, Task.REVIEW_STATUS_APPROVED)
+
+      updatedUser.get.achievements.getOrElse(List.empty).contains(Achievement.REVIEWED_TASK) mustEqual true
+    }
+
+    "does not award an achievement if the task isn't completed" taggedAs UserTag in {
+      val task = this.serviceManager.task.retrieve(defaultTask.id).get
+      val updatedUser =
+        this.service.awardTaskCompletionAchievements(this.anotherUser, task, Task.REVIEW_STATUS_DISPUTED)
+      
+      updatedUser.get.achievements.getOrElse(List.empty).contains(Achievement.REVIEWED_TASK) mustEqual false
+    }
+  }
+
+  override implicit val projectTestName: String = "AchievementServiceSpecProject"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    anotherUser = this.serviceManager.user.create(
+      this.getTestUser(22398765, "AnotherUser"),
+      User.superUser
+    )
+  }
+}

--- a/test/org/maproulette/framework/service/TaskClusterServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskClusterServiceSpec.scala
@@ -86,7 +86,7 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
             challengeIds = Some(List(randomChallenge.id))
           )
         ),
-        excludeLocked = true
+        ignoreLocked = true
       )
       count mustEqual 3
       response.length mustEqual 3
@@ -102,7 +102,7 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
           )
         ),
         Paging(1, 0),
-        excludeLocked = true
+        ignoreLocked = true
       )
       count mustEqual 3
       response.length mustEqual 1
@@ -117,7 +117,7 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
             challengeIds = Some(List(randomChallenge.id))
           )
         ),
-        excludeLocked = true,
+        ignoreLocked = true,
         sort = "id",
         orderDirection = "DESC"
       )
@@ -138,7 +138,7 @@ class TaskClusterServiceSpec(implicit val application: Application) extends Fram
           excludeTaskIds = Some(List(randomTask.id))
         )
       ),
-      excludeLocked = true
+      ignoreLocked = true
     )
     count mustEqual 2
     response.length mustEqual 2

--- a/test/org/maproulette/utils/TestSpec.scala
+++ b/test/org/maproulette/utils/TestSpec.scala
@@ -133,6 +133,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
   val challengeSnapshotService = mock[ChallengeSnapshotService]
   val dataService              = mock[DataService]
   val userMetricService        = mock[UserMetricService]
+  val achievementService       = mock[AchievementService]
   val virtualProjectService    = mock[VirtualProjectService]
   val tagService               = mock[TagService]
   val taskClusterService       = mock[TaskClusterService]
@@ -156,6 +157,7 @@ trait TestSpec extends PlaySpec with MockitoSugar {
     Providers.of[ChallengeListingService](challengeListingService),
     Providers.of[ChallengeSnapshotService](challengeSnapshotService),
     Providers.of[UserMetricService](userMetricService),
+    Providers.of[AchievementService](achievementService),
     Providers.of[VirtualProjectService](virtualProjectService),
     Providers.of[TaskClusterService](taskClusterService),
     Providers.of[TaskReviewService](taskReviewService),


### PR DESCRIPTION
- Add support for Achievements, which are awarded to users for various
notable actions/events, such as fixing their first task or crossing a
major points threshold

- Add migration that retroactively awards (most) achievements that would
have been earned in the past

- Achievements are simply represented as an array of int constants on
the user_metrics table, and are pulled into the User object for easy
reference by clients

- A new AchievementService manages the awarding of achievements as
appropriate when certain major events occur, such as task completion,
task review, challenge completion, etc.

- Websocket messages are transmitted to subscribed clients when users
earn new achievements