### PR TITLE
Mark challenge finished when overpass query returns no tasks

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -510,6 +510,9 @@ class ChallengeProvider @Inject() (
                         challenge.id
                       )
                       this.challengeDAL.markTasksRefreshed(true)(challenge.id)
+                      // If no tasks were created by this overpass query or all tasks are
+                      // fixed, then we need to update the status to finished.
+                      this.challengeDAL.updateFinishedStatus(true)(challenge.id)
                   }
                 } catch {
                   case e: Exception =>


### PR DESCRIPTION
 If after building/rebuilding challenge from an overpass query, mark as finished if there are no incomplete tasks.

Closes osmlab/maproulette3#986