### PR TITLE
Fix search by challenge tags in task cluster search

### DIFF
--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -65,7 +65,7 @@ trait SearchParametersMixin {
         })
         .mkString(",")
 
-      val invert = params.invertFields.getOrElse(List()).contains("tc")
+      val invert = params.invertFields.getOrElse(List()).contains("ct")
       FilterGroup(
         List(
           SubQueryFilter(
@@ -80,7 +80,7 @@ trait SearchParametersMixin {
                   table = Some("tags")
                 )
               ),
-              "SELECT task_id from tags_on_challenges tc INNER JOIN tags ON tags.id = tc.tag_id"
+              "SELECT challenge_id from tags_on_challenges tc INNER JOIN tags ON tags.id = tc.tag_id"
             ),
             invert,
             Operator.IN,

--- a/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
+++ b/test/org/maproulette/framework/mixins/SearchParametersMixinSpec.scala
@@ -24,7 +24,7 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
           SearchChallengeParameters(challengeTags = Some(List("my_tag", "tag2")))
         )
       this.filterChallengeTags(params).sql() mustEqual
-        "c.id IN (SELECT task_id from tags_on_challenges tc " +
+        "c.id IN (SELECT challenge_id from tags_on_challenges tc " +
           "INNER JOIN tags ON tags.id = tc.tag_id WHERE tags.name IN ('my_tag','tag2'))"
     }
 
@@ -35,10 +35,10 @@ class SearchParametersMixinSpec() extends PlaySpec with SearchParametersMixin {
     "be inverted" in {
       val params = SearchParameters(
         challengeParams = SearchChallengeParameters(challengeTags = Some(List("my_tag", "tag2"))),
-        invertFields = Some(List("tc"))
+        invertFields = Some(List("ct"))
       )
       this.filterChallengeTags(params).sql() mustEqual
-        "NOT c.id IN (SELECT task_id from tags_on_challenges tc " +
+        "NOT c.id IN (SELECT challenge_id from tags_on_challenges tc " +
           "INNER JOIN tags ON tags.id = tc.tag_id WHERE tags.name IN ('my_tag','tag2'))"
     }
   }


### PR DESCRIPTION
* SearchParamtersMixin was pulling back wrong field when applying
  filters for challenge tags

Fixes issue osmlab/maproulette3#1514