### PR TITLE
Improve performance of review queries

### DIFF
--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -134,7 +134,8 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
     this.repository.queryTasksInBoundingBox(
       query,
       this.getOrder(sort, orderDirection),
-      paging
+      paging,
+      params.challengeParams.challengeIds
     )
   }
 }

--- a/app/org/maproulette/framework/service/TaskReviewMetricsService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewMetricsService.scala
@@ -55,7 +55,9 @@ class TaskReviewMetricsService @Inject() (
       excludeOtherReviewers
     )
 
-    this.repository.executeReviewMetricsQuery(query).head
+    this.repository.executeReviewMetricsQuery(query,
+      projectIds = params.projectIds,
+      challengeIds = params.challengeParams.challengeIds).head
   }
 
   /**

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -22,7 +22,7 @@ import org.maproulette.exception.InvalidException
 import org.maproulette.session.{SearchParameters, SearchReviewParameters}
 import org.maproulette.permissions.Permission
 import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
-import org.maproulette.data.ChallengeType
+import org.maproulette.data.{ChallengeType, Actions}
 
 /**
   * Service layer for TaskReview
@@ -885,11 +885,23 @@ class TaskReviewService @Inject() (
     query.addFilterGroup(
       FilterGroup(
         List(
-          BaseParameter(
-            "id",
-            "",
-            Operator.NULL,
-            table = Some("l")
+          SubQueryFilter(
+            Task.FIELD_ID,
+            Query.simple(
+              List(
+                BaseParameter(
+                  "item_type",
+                  Actions.ITEM_TYPE_TASK,
+                  Operator.EQ,
+                  useValueDirectly = true,
+                  table = None
+                )
+              ),
+              s"SELECT item_id from locked"
+            ),
+            negate = true,
+            Operator.IN,
+            Some("tasks")
           )
         )
       )


### PR DESCRIPTION
* Include only 'row_num' from select when needed (in nextTaskReview only)
  and exclude from all other review queries to improve performance

* Use subselect to determine if tasks are locked instead of LEFT JOIN

* Improve query when getting challenge summary by using a WITH clause
  to narrow tasks table to only tasks in relevant challenge

* Improve fetching tasks in bounding box query by usign a WITH clause
  to narrows tasks table to only tasks in challenge

* Improve review metrics queries by using challenge ids to limit
  tasks in a WITH clause when possible.