### PR TITLE
Revert some overly optimistic optimizations

### DIFF
--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -368,25 +368,10 @@ class DataManager @Inject() (
         }
       )
 
-      var challenges = challengeId match {
-        case Some(id) if id != -1 => Some(List(id))
-        case _ =>
-          // Let's determine all the challenges that are in these projects
-          // to make our query faster.
-          if (projectList != None) {
-            findRelevantChallenges(projectList)
-          }
-          else {
-            None
-          }
+      val challengeFilter = challengeId match {
+        case Some(id) if id != -1 => s"AND tasks.parent_id = $id"
+        case _                    => buildProjectSearch(projectList, "c.parent_id", "c.id")
       }
-
-      val withTable = challenges match {
-        case Some(ids) if (!ids.isEmpty) =>
-          s"WITH tasks AS (SELECT * FROM tasks WHERE tasks.parent_id IN (${ids.mkString(",")}))"
-        case _ => ""
-      }
-
       val priorityFilter = priority match {
         case Some(p) =>
           val invert =
@@ -396,7 +381,7 @@ class DataManager @Inject() (
       }
 
       val searchFilters = new StringBuilder(
-        s"1=1 $priorityFilter ${if (searchString != "") searchField("c.name")
+        s"1=1 $challengeFilter $priorityFilter ${if (searchString != "") searchField("c.name")
         else ""}"
       )
 
@@ -411,9 +396,7 @@ class DataManager @Inject() (
       // It won't decrease performance as this is simple basic math calculations, but it certainly
       // isn't pretty
       val query =
-        s"""
-          ${withTable}
-          SELECT tasks.parent_id, c.name,
+        s"""SELECT tasks.parent_id, c.name,
               COUNT(tasks.completed_time_spent) as tasksWithTime,
               COALESCE(SUM(tasks.completed_time_spent), 0) as totalTimeSpent,
               SUM(CASE WHEN tasks.status != 4 THEN 1 ELSE 0 END) as total,

--- a/app/org/maproulette/framework/mixins/TaskFilterMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskFilterMixin.scala
@@ -10,6 +10,7 @@ import org.maproulette.framework.service.ServiceManager
 import org.maproulette.framework.model.{Task, User, Challenge, Project}
 import org.maproulette.framework.psql.{Query, _}
 import org.maproulette.framework.psql.filter._
+import org.maproulette.data.Actions
 
 import org.maproulette.utils.Utils
 
@@ -75,22 +76,12 @@ trait TaskFilterMixin {
         query.addFilterGroup(
           FilterGroup(
             List(
-              BaseParameter(
-                "id",
-                None,
-                Operator.NULL,
-                useValueDirectly = true,
-                table = Some("l")
-              ),
-              BaseParameter(
-                "user_id",
-                user.id,
-                Operator.EQ,
-                useValueDirectly = true,
-                table = Some("l")
+              CustomParameter(
+                s"""tasks.id NOT IN (select item_id from locked WHERE
+                  item_id = tasks.id AND item_type = ${Actions.ITEM_TYPE_TASK}
+                  AND user_id != ${user.id})"""
               )
-            ),
-            OR()
+            )
           )
         )
     }

--- a/app/org/maproulette/framework/repository/TaskReviewMetricsRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewMetricsRepository.scala
@@ -200,19 +200,9 @@ class TaskReviewMetricsRepository @Inject() (override val db: Database) extends 
             }
         }
 
-      // Try limiting tasks table to just the challenges we are interested in
-      val withTable =
-        challengeList match {
-          case Some(ids) if (!ids.isEmpty) =>
-            s"WITH tasks AS (SELECT * FROM tasks WHERE tasks.parent_id " +
-            s"IN (${ids.mkString(",")}))"
-          case _ => ""
-        }
-
       query
         .build(
           s"""
-         ${withTable}
          SELECT COUNT(*) AS total,
          COUNT(tasks.completed_time_spent) as tasksWithReviewTime,
          COALESCE(SUM(EXTRACT(EPOCH FROM (task_review.reviewed_at - task_review.review_started_at)) * 1000),0) as totalReviewTime,

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -155,52 +155,7 @@ class TaskReviewRepository @Inject() (
   // 3. ReviewStatus
   // 4. Default to ReviewStatus != 5 (unnecessary)
   private def buildWithTable(params: SearchParameters): String = {
-    val defaultWith =
-      s"""
-        WITH task_review AS (
-          SELECT * FROM task_review WHERE review_status <> ${Task.REVIEW_STATUS_UNNECESSARY}
-        )
-      """
-    params.owner match {
-      case Some(owner) =>
-        params.invertFields.getOrElse(List()).contains("o") match {
-          case true => defaultWith
-          case false =>
-            s"""
-              WITH task_review AS (
-              SELECT * FROM task_review tr INNER JOIN users u
-              ON u.id = tr.review_requested_by WHERE u.name ILIKE '%${owner}%'
-            )
-            """
-        }
-      case None =>
-        params.reviewer match {
-          case Some(reviewer) =>
-            params.invertFields.getOrElse(List()).contains("r") match {
-              case true => defaultWith
-              case false =>
-                s"""
-                  WITH task_review AS (
-                  SELECT * FROM task_review tr INNER JOIN users u
-                  ON u.id = tr.reviewed_by WHERE u.name ILIKE '%${reviewer}%'
-                )"""
-            }
-          case None =>
-            params.taskParams.taskReviewStatus match {
-              case Some(rs) =>
-                params.invertFields.getOrElse(List()).contains("trStatus") match {
-                  case true => defaultWith
-                  case false =>
-                    s"""
-                      WITH task_review AS (
-                        SELECT * FROM task_review WHERE review_status IN (${rs.mkString(",")})
-                      )
-                    """
-                }
-              case None => defaultWith
-            }
-        }
-    }
+    return ""
   }
 
   private def buildTaskQuery(query: Query, includeRowNumber: Boolean = false,

--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -134,8 +134,7 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
     this.repository.queryTasksInBoundingBox(
       query,
       this.getOrder(sort, orderDirection),
-      paging,
-      params.challengeParams.challengeIds
+      paging
     )
   }
 }

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -827,7 +827,10 @@ class TaskReviewService @Inject() (
       case sortColumn if sortColumn.nonEmpty =>
         // We have two "id" columns: one for Tasks and one for taskReview. So
         // we need to specify which one to sort by for the SQL query.
-        val table     = if (sortColumn == "id" || sortColumn == "status") Some("tasks") else Some("")
+        val table     =
+          if (sortColumn == "id" || sortColumn == "status") Some("tasks")
+          else if (sortColumn == "reviewed_at") Some("task_review")
+          else Some("")
         val direction = if (order == "DESC") Order.DESC else Order.ASC
 
         Order(

--- a/conf/evolutions/default/77.sql
+++ b/conf/evolutions/default/77.sql
@@ -1,0 +1,15 @@
+# --- !Ups
+-- Add indexes for mapped_on
+DROP index "idx_tasks_tasks_mapped_on";
+DROP index "idx_tasks_tasks_mapped_on_status";
+
+CREATE INDEX "idx_tasks_tasks_mapped_on_status_asc" on tasks (status, mapped_on asc);;
+CREATE INDEX "idx_tasks_tasks_mapped_on_status_desc" on tasks (status, mapped_on desc);;
+
+# --- !Downs
+-- Remove indexes
+DROP index "idx_tasks_tasks_mapped_on_status_asc";
+DROP index "idx_tasks_tasks_mapped_on_status_desc";
+
+SELECT create_index_if_not_exists('tasks', 'tasks_mapped_on', '(mapped_on)');;
+SELECT create_index_if_not_exists('tasks', 'tasks_mapped_on_status', '(mapped_on, status)');;


### PR DESCRIPTION
* Revert DataManager to no longer have "with"

* Fix ambigious 'reviewed_at' sort in review queries

* Remove 'with' in TaskClusterRepository and remove inner join on locked

* Remove 'with' in TaskReviewRepository

* Change TaskFilterMixin.add filter locked to use subselect instead of
  join on locked table (as query does not always needed to join on locked)