### PR TITLE
Improve performance of next review task query

### DIFF
--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -165,7 +165,8 @@ class TaskReviewService @Inject() (
             false,
             excludeOtherReviewers,
             asMetaReview
-          )
+          ),
+          taskId
         )
         rowMap.get(taskId)
 


### PR DESCRIPTION
When fetching next task to review, a task id can provided
so that the task following (based on criteria) will be returned.
The query to determine the row number was pulling back the full
set of results when only the actual task needed to be returned.
Fixed query by wrapping in another select filtering by task id.