### PR TITLE
Fix when retrieving a tag by name it needs a tag type

### DIFF
--- a/app/org/maproulette/framework/graphql/schemas/TagSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/TagSchema.scala
@@ -54,7 +54,10 @@ class TagSchema @Inject() (override val service: TagService)
       fieldType = OptionType(TagType),
       arguments = MRSchema.nameArg :: TagSchema.parentArg :: Nil,
       resolve = context =>
-        this.service.retrieveByName(context.arg(MRSchema.nameArg), context.arg(TagSchema.parentArg))
+        this.service.retrieveByName(
+          context.arg(MRSchema.nameArg),
+          context.arg(TagSchema.tagTypeArg),
+          context.arg(TagSchema.parentArg))
     ),
     Field(
       name = "keywordsByTask",

--- a/app/org/maproulette/framework/mixins/TagsControllerMixin.scala
+++ b/app/org/maproulette/framework/mixins/TagsControllerMixin.scala
@@ -175,7 +175,7 @@ trait TagsControllerMixin[T <: BaseObject[Long]] {
                 case e: NumberFormatException =>
                   // this is the case where a name is supplied, so we will either search for a tag with
                   // the same name or create a new tag with the current name
-                  this.tagService.retrieveByName(tag) match {
+                  this.tagService.retrieveByName(tag, this.tagType) match {
                     case Some(t) => t.asInstanceOf[Tag]
                     case None =>
                       Tag(-1, tag, tagType = this.tagType)

--- a/app/org/maproulette/framework/service/TagService.scala
+++ b/app/org/maproulette/framework/service/TagService.scala
@@ -134,12 +134,13 @@ class TagService @Inject() (
     * @param parentId The parent identifier of the tag, set to -1 if you don't want to filter by it's parent
     * @return The tag, None if not found
     */
-  def retrieveByName(name: String, parentId: Long = -1): Option[Tag] = {
+  def retrieveByName(name: String, tagType: String, parentId: Long = -1): Option[Tag] = {
     this
       .query(
         Query.simple(
           List(
             BaseParameter(Tag.FIELD_NAME, name.toLowerCase),
+            BaseParameter(Tag.FIELD_TAG_TYPE, tagType),
             FilterParameter
               .conditional(Tag.FIELD_PARENT_ID, parentId, includeOnlyIfTrue = parentId != -1)
           )

--- a/app/org/maproulette/models/dal/mixin/TagDALMixin.scala
+++ b/app/org/maproulette/models/dal/mixin/TagDALMixin.scala
@@ -90,7 +90,7 @@ trait TagDALMixin[T <: BaseObject[Long]] {
   ): Unit = {
     val tagIds = tags.filter(_.nonEmpty).flatMap { tag =>
       {
-        this.tagService.retrieveByName(tag) match {
+        this.tagService.retrieveByName(tag, this.tableName) match {
           case Some(t) => Some(t.id)
           case None    => Some(this.tagService.create(Tag(-1, tag), user).id)
         }


### PR DESCRIPTION
When retrieving a tag by name it must have a tag type as there
can be multiple tags of the same name but of different types (challenges/tasks)