### PR TITLE
Fix searching challenges with apostrophe causes SQL error

### DIFF
--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -102,7 +102,7 @@ trait SearchParametersMixin {
       List(
         FilterParameter.conditional(
           Project.FIELD_DISPLAY_NAME,
-          s"'${SQLUtils.search(params.projectSearch.getOrElse("").replace("'", "''"))}'",
+          s"'${SQLUtils.search(params.projectSearch.getOrElse(""))}'",
           Operator.ILIKE,
           params.invertFields.getOrElse(List()).contains("ps"),
           true,
@@ -184,7 +184,7 @@ trait SearchParametersMixin {
                   List(
                     FilterParameter.conditional(
                       Project.FIELD_DISPLAY_NAME,
-                      s"'${SQLUtils.search(params.projectSearch.getOrElse("").replace("'", "''"))}'",
+                      s"'${SQLUtils.search(params.projectSearch.getOrElse(""))}'",
                       Operator.ILIKE,
                       params.invertFields.getOrElse(List()).contains("ps"),
                       true,
@@ -195,7 +195,7 @@ trait SearchParametersMixin {
                       s"(c.id IN " +
                         s"(SELECT vp2.challenge_id FROM virtual_project_challenges vp2 " +
                         s" INNER JOIN projects p2 ON p2.id = vp2.project_id WHERE " +
-                        s" LOWER(p2.display_name) LIKE LOWER('%${ps.replace("'", "''")}%') AND p2.enabled=true))"
+                        s" LOWER(p2.display_name) LIKE LOWER('${SQLUtils.search(ps)}') AND p2.enabled=true))"
                     )
                   ),
                   OR()
@@ -627,7 +627,7 @@ trait SearchParametersMixin {
                   List(
                     BaseParameter(
                       Challenge.FIELD_NAME,
-                      s"'%${cs}%'",
+                      s"'${SQLUtils.search(cs)}'",
                       Operator.ILIKE,
                       useValueDirectly = true,
                       negate = params.invertFields.getOrElse(List()).contains("cs"),
@@ -785,7 +785,7 @@ trait SearchParametersMixin {
                     case SearchParameters.TASK_PROP_SEARCH_TYPE_NOT_EQUAL =>
                       query ++= s" AND features->'properties'->>'${k}' != '${v}' "
                     case SearchParameters.TASK_PROP_SEARCH_TYPE_CONTAINS =>
-                      query ++= s" AND features->'properties'->>'${k}' LIKE '%${v}%' "
+                      query ++= s" AND features->'properties'->>'${k}' LIKE '${SQLUtils.search(v)}' "
                     case SearchParameters.TASK_PROP_SEARCH_TYPE_EXISTS =>
                       query ++= s" AND features->'properties'->>'${k}' IS NOT NULL "
                     case SearchParameters.TASK_PROP_SEARCH_TYPE_MISSING =>
@@ -856,7 +856,7 @@ trait SearchParametersMixin {
                     s"${Task.TABLE}.${Task.FIELD_ID}",
                     useValueDirectly = true
                   ),
-                  BaseParameter("u.name", s"'%${m}%'", Operator.ILIKE, useValueDirectly = true)
+                  BaseParameter("u.name", s"'${SQLUtils.search(m)}'", Operator.ILIKE, useValueDirectly = true)
                 ),
                 "SELECT t2.id FROM tasks t2 INNER JOIN users u ON u.id = t2.completed_by"
               ),
@@ -1018,7 +1018,7 @@ trait SearchParametersMixin {
                 s"${Task.TABLE}.${Task.FIELD_ID}",
                 useValueDirectly = true
               ),
-              BaseParameter("u.name", s"'%${value}%'", Operator.ILIKE, useValueDirectly = true)
+              BaseParameter("u.name", s"'${SQLUtils.search(value)}'", Operator.ILIKE, useValueDirectly = true)
             ),
             s"SELECT task_id FROM task_review tr INNER JOIN users u ON u.id = tr.${column}"
           ),

--- a/app/org/maproulette/framework/psql/SQLUtils.scala
+++ b/app/org/maproulette/framework/psql/SQLUtils.scala
@@ -47,9 +47,15 @@ object SQLUtils {
     * @param value The search string that you are using to match with
     * @return
     */
-  def search(value: String, usePrefix: Boolean = false): String = {
+  def search(value: String, usePrefix: Boolean = false, escapeSingleQuote: Boolean = true): String = {
     val firstChar = if (usePrefix) "" else "%"
-    if (value.nonEmpty) s"$firstChar$value%" else "%"
+    val searchString = escapeSingleQuote match {
+      case true => 
+        if (value.nonEmpty) value.replace("'", "''")
+        else value
+      case false => value
+    }
+    if (value.nonEmpty) s"$firstChar$searchString%" else "%"
   }
 
   def toParameterValue[T](value: T): ParameterValue =

--- a/test/org/maproulette/framework/service/TagServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TagServiceSpec.scala
@@ -72,7 +72,7 @@ class TagServiceSpec(implicit val application: Application) extends FrameworkHel
 
     "retrieve a tag by name" taggedAs KeywordTag in {
       val createdTag   = this.service.create(Tag(-1, "RetrieveServiceTagTest"), User.superUser)
-      val retrievedTag = this.service.retrieveByName("RetrieveServiceTagTest")
+      val retrievedTag = this.service.retrieveByName("RetrieveServiceTagTest", "challenges")
       retrievedTag.get.id mustEqual createdTag.id
       retrievedTag.get.name mustEqual createdTag.name
       retrievedTag.get.description mustEqual createdTag.description


### PR DESCRIPTION
When searching challenges/mappers/reviewers/projects and
using an apostrophe, the single quote needs to be escaped