### PR TITLE
relocate isArchived JSON insert to ChallengeReads

### DIFF
--- a/app/org/maproulette/controllers/CRUDController.scala
+++ b/app/org/maproulette/controllers/CRUDController.scala
@@ -91,7 +91,6 @@ trait CRUDController[T <: BaseObject[Long]] extends SessionController {
     jsonBody =
       Utils.insertIntoJson(jsonBody, "created", DateTime.now())(JodaWrites.JodaDateTimeNumberWrites)
     Utils.insertIntoJson(jsonBody, "modified", DateTime.now())(JodaWrites.JodaDateTimeNumberWrites)
-    Utils.insertIntoJson(jsonBody, "isArchived", false)
   }
 
   /**

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -93,6 +93,11 @@ trait ChallengeReads extends DefaultReads {
         case None        => Utils.insertIntoJson(jsonWithExtras, "limitReviewTags", false, true)
       }
 
+      jsonWithExtras = (jsonWithExtras \ "isArchived").asOpt[JsValue] match {
+        case Some(value) => jsonWithExtras
+        case None        => Utils.insertIntoJson(jsonWithExtras, "isArchived", false, false)
+      }
+
       Json.fromJson[ChallengeExtra](jsonWithExtras)(Json.reads[ChallengeExtra])
     }
   }


### PR DESCRIPTION
My original implementation of the "isArchived" json insert in the CRUDController was incorrect.  Knowing about the Challenge Formatter now, I relocated the "isArchived" parameter to the Challenge specific formatters so that Tasks are not affected, since they also use the CRUDController.  Projects require "isArchived" as well but this logic is located elsewhere, and is unaffected.

Refactors https://github.com/maproulette/maproulette2/pull/890/files#diff-de464fb49f0929f7f712b05119d821bad5535eec31cd3305ec03f6fdd5bbb831R94

Resolves https://github.com/maproulette/maproulette2/issues/895