### PR TITLE
distinguish page from offset

### DIFF
--- a/app/org/maproulette/controllers/ParentController.scala
+++ b/app/org/maproulette/controllers/ParentController.scala
@@ -186,10 +186,7 @@ trait ParentController[T <: BaseObject[Long], C <: BaseObject[Long]] extends CRU
       this.sessionManager.userAwareRequest { implicit user =>
         // now replace the parent field in the parent with a children array
 
-        var offset = 0
-        if (page > 0) {
-          offset = limit * page
-        }
+        var offset = limit * page
 
         Json
           .toJson(this.dal.retrieveById(id))

--- a/app/org/maproulette/controllers/ParentController.scala
+++ b/app/org/maproulette/controllers/ParentController.scala
@@ -177,14 +177,20 @@ trait ParentController[T <: BaseObject[Long], C <: BaseObject[Long]] extends CRU
     *
     * @param id     The parent id
     * @param limit  The limit of how many objects to be returned
-    * @param offset For paging
+    * @param page   page number starting at 0, used to determine offset
     * @return 200 Ok with parent json object containing children objects
     */
-  def expandedList(id: Long, limit: Int, offset: Int): Action[AnyContent] = Action.async {
+  def expandedList(id: Long, limit: Int, page: Int): Action[AnyContent] = Action.async {
     implicit request =>
       implicit val writes: Writes[C] = cWrites
       this.sessionManager.userAwareRequest { implicit user =>
         // now replace the parent field in the parent with a children array
+
+        var offset = 0
+        if (page > 0) {
+          offset = limit * page
+        }
+
         Json
           .toJson(this.dal.retrieveById(id))
           .transform(this.childrenAddition(this.dal.listChildren(limit, offset)(id))) match {

--- a/app/org/maproulette/controllers/ParentController.scala
+++ b/app/org/maproulette/controllers/ParentController.scala
@@ -184,10 +184,9 @@ trait ParentController[T <: BaseObject[Long], C <: BaseObject[Long]] extends CRU
     implicit request =>
       implicit val writes: Writes[C] = cWrites
       this.sessionManager.userAwareRequest { implicit user =>
+        val offset = limit * page
+
         // now replace the parent field in the parent with a children array
-
-        var offset = limit * page
-
         Json
           .toJson(this.dal.retrieveById(id))
           .transform(this.childrenAddition(this.dal.listChildren(limit, offset)(id))) match {


### PR DESCRIPTION
The `api/v2/challenge/3684/children?limit=#&page=#` endpoint was using the `page` parameter as an `offset` in the service, instead of converting the page number to the proper offset value.