### PR TITLE
add changesetUrl to challenge formatters

### DIFF
--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1064,6 +1064,7 @@ class ChallengeController @Inject() (
     jsonBody = Utils.insertIntoJson(jsonBody, "minZoom", Challenge.MIN_ZOOM)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "maxZoom", Challenge.MAX_ZOOM)(IntWrites)
     jsonBody = Utils.insertIntoJson(jsonBody, "updateTasks", false)(BooleanWrites)
+    jsonBody = Utils.insertIntoJson(jsonBody, "changesetUrl", false)(BooleanWrites)
     // if we can't find the parent ID, just use the user's default project instead
     (jsonBody \ "parent").asOpt[Long] match {
       case Some(v) => jsonBody

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -71,20 +71,9 @@ trait ChallengeWrites extends DefaultWrites {
 }
 
 trait ChallengeReads extends DefaultReads {
+  implicit val challengeGeneralReads: Reads[ChallengeGeneral]   = Json.reads[ChallengeGeneral]
   implicit val challengeCreationReads: Reads[ChallengeCreation] = Json.reads[ChallengeCreation]
   implicit val challengePriorityReads: Reads[ChallengePriority] = Json.reads[ChallengePriority]
-
-  implicit val challengeGeneralReads = new Reads[ChallengeGeneral] {
-    def reads(json: JsValue): JsResult[ChallengeGeneral] = {
-      val jsonWithExtras =
-        (json \ "changesetUrl").asOpt[JsValue] match {
-          case Some(value) => json
-          case None        => Utils.insertIntoJson(json, "changesetUrl", false, false)
-        }
-
-      Json.fromJson[ChallengeGeneral](jsonWithExtras)(Json.reads[ChallengeGeneral])
-    }
-  }
 
   implicit val challengeExtraReads = new Reads[ChallengeExtra] {
     def reads(json: JsValue): JsResult[ChallengeExtra] = {

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -71,9 +71,20 @@ trait ChallengeWrites extends DefaultWrites {
 }
 
 trait ChallengeReads extends DefaultReads {
-  implicit val challengeGeneralReads: Reads[ChallengeGeneral]   = Json.reads[ChallengeGeneral]
   implicit val challengeCreationReads: Reads[ChallengeCreation] = Json.reads[ChallengeCreation]
   implicit val challengePriorityReads: Reads[ChallengePriority] = Json.reads[ChallengePriority]
+
+  implicit val challengeGeneralReads = new Reads[ChallengeGeneral] {
+    def reads(json: JsValue): JsResult[ChallengeGeneral] = {
+      val jsonWithExtras =
+        (json \ "changesetUrl").asOpt[JsValue] match {
+          case Some(value) => json
+          case None        => Utils.insertIntoJson(json, "changesetUrl", false, false)
+        }
+
+      Json.fromJson[ChallengeGeneral](jsonWithExtras)(Json.reads[ChallengeGeneral])
+    }
+  }
 
   implicit val challengeExtraReads = new Reads[ChallengeExtra] {
     def reads(json: JsValue): JsResult[ChallengeExtra] = {


### PR DESCRIPTION
In some challenge creation user flows, the frontend is not providing a changesetUrl value of true or false, so we need to add the changesetUrl to the challengeFormatters