### PR TITLE
distinguish page from offset for /challenge "listChildren" services

### DIFF
--- a/app/org/maproulette/controllers/ParentController.scala
+++ b/app/org/maproulette/controllers/ParentController.scala
@@ -158,14 +158,14 @@ trait ParentController[T <: BaseObject[Long], C <: BaseObject[Long]] extends CRU
     *
     * @param id     The parent id
     * @param limit  The limit of how many objects to be returned
-    * @param offset For paging
+    * @param page   for paging
     * @return 200 OK with json array of children objects
     */
-  def listChildren(id: Long, limit: Int, offset: Int): Action[AnyContent] = Action.async {
+  def listChildren(id: Long, limit: Int, page: Int): Action[AnyContent] = Action.async {
     implicit request =>
       implicit val writes: Writes[C] = this.cWrites
       this.sessionManager.userAwareRequest { implicit user =>
-        Ok(Json.toJson(this.dal.listChildren(limit, offset)(id).map(this.childController.inject)))
+        Ok(Json.toJson(this.dal.listChildren(limit, page)(id).map(this.childController.inject)))
       }
   }
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -800,7 +800,7 @@ class ChallengeDAL @Inject() (
     */
   override def listChildren(
       limit: Int = Config.DEFAULT_LIST_SIZE,
-      offset: Int = 0,
+      page: Int = 0,
       onlyEnabled: Boolean = false,
       searchString: String = "",
       orderColumn: String = "id",
@@ -809,6 +809,7 @@ class ChallengeDAL @Inject() (
     // add a child caching option that will keep a list of children for the parent
     this.withMRConnection { implicit c =>
       val geometryParser = this.taskRepository.getTaskParser(this.taskRepository.updateAndRetrieve)
+      val offset = page * limit;
       val query =
         s"""SELECT ${taskDAL.retrieveColumns}
                       FROM tasks


### PR DESCRIPTION
This is a continuance of https://github.com/maproulette/maproulette2/pull/897 where we need to distinguish page from offset for our API users.  The terminology seems to change between our routes and controllers/services.

I verified that this change does not break any frontend usages.