### PR TITLE
improve user-friendliness of lock error messages

### DIFF
--- a/app/org/maproulette/framework/mixins/Locking.scala
+++ b/app/org/maproulette/framework/mixins/Locking.scala
@@ -49,11 +49,11 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
               .executeUpdate()
           } else {
             throw new LockedException(
-              s"Item [${item.id}] currently locked by different user. [${user.id}"
+              s"Item ${item.id} currently locked by user ${user.id}"
             )
           }
         case None =>
-          throw new LockedException(s"Item [${item.id}] trying to unlock does not exist.")
+          throw new LockedException(s"Item ${item.id} trying to unlock does not exist.")
       }
     }
 
@@ -83,10 +83,10 @@ trait Locking[T <: BaseObject[_]] extends TransactionManager {
               .executeUpdate()
           } else {
             throw new LockedException(
-              s"Item [${item.id}] currently locked by different user. [${user.id}]"
+              s"Item ${item.id} currently locked by user ${user.id}"
             )
           }
-        case None => throw new LockedException(s"Lock on item [${item.id}] does not exist.")
+        case None => throw new LockedException(s"Lock on item ${item.id} does not exist.")
       }
     }
 

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -130,7 +130,7 @@ class TaskReviewRepository @Inject() (
       // if returning 0, then this is because the item is locked by a different user
       if (updatedRows == 0) {
         throw new IllegalAccessException(
-          s"Current task [${task.id} is locked by another user, cannot cancel review at this time."
+          s"This task is locked by another user, cannot cancel review at this time."
         )
       }
 
@@ -368,7 +368,7 @@ class TaskReviewRepository @Inject() (
       // if returning 0, then this is because the item is locked by a different user
       if (updatedRows == 0) {
         throw new IllegalAccessException(
-          s"Current task [${task.id} is locked by another user, cannot update review status at this time."
+          s"This task is locked by another user, cannot update review status at this time."
         )
       }
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -618,7 +618,7 @@ class TaskDAL @Inject() (
           // if returning 0, then this is because the item is locked by a  different user
           if (updatedRows == 0) {
             throw new IllegalAccessException(
-              s"Current task [${task.id} is locked by another user, cannot update status at this time."
+              s"This task is locked by another user, cannot update status at this time."
             )
           }
         }


### PR DESCRIPTION
As a result of https://github.com/osmlab/maproulette3/pull/1631, this PR improves the user-friendliness of the lock messages for task status update services.  I also removed the task ids from the messages for a couple of the services since some tasks are in bundles and don't match up with the task id in the URL, potentially confusing the user.