### PR TITLE
revise behavior of review_started_at

### DIFF
--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -83,7 +83,7 @@ class TaskReviewRepository @Inject() (
         Query
           .simple(List())
           .build(
-            """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW()
+            """UPDATE task_review SET review_claimed_by = {userId}, review_claimed_at = NOW(), review_started_at = NOW()
                     WHERE task_id = {taskId} AND review_claimed_at IS NULL"""
           )
           .on(Symbol("taskId") -> task.id, Symbol("userId") -> user.id)
@@ -308,7 +308,7 @@ class TaskReviewRepository @Inject() (
         )
         .executeUpdate()
 
-      // Update task review status on old task reviews to "unecessary"
+      // Update task review status on old task reviews to "unnecessary"
       query
         .build(s"""UPDATE task_review tr
                 SET review_status = ${Task.REVIEW_STATUS_UNNECESSARY},
@@ -348,7 +348,7 @@ class TaskReviewRepository @Inject() (
           s"meta_review_status = ${mr}, reviewed_at = NOW(), meta_review_started_at = task_review.review_claimed_at, "
         case Some(mr) =>
           s"meta_review_status = ${mr}, meta_reviewed_at = NOW(), meta_review_started_at = task_review.review_claimed_at, "
-        case None => "reviewed_at = NOW(), review_started_at = task_review.review_claimed_at,"
+        case None => "reviewed_at = NOW(), "
       }
       val updatedRows =
         SQL(s"""UPDATE task_review SET review_status = $reviewStatus,


### PR DESCRIPTION
In some scenarios, review duration is broken because review_started_at is being unknowingly nullified.  By setting review_started_at during claimTaskReview, this should prevent a race condition between two endpoints that is un-claiming the task review before the task is actually reviewed.

This bug fix is preferential to swapping the order of the two endpoints (`/next` and `/task/review`) due to a comment found in the frontend code (https://github.com/osmlab/maproulette3/blob/main/src/components/HOCs/WithTaskReview/WithTaskReview.js#L56).

