### PR TITLE
add bulk archive api

### DIFF
--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -1282,6 +1282,33 @@ class ChallengeDAL @Inject() (
   }
 
   /**
+   * Archive or unarchive a list of challenges
+   *
+   * @param challengeIds  The list of challengeIds
+   * @param archive  boolean determining if challenges should be archived(true) or unarchived(false)
+   * @return
+   */
+  def bulkArchive(challengeIds: List[Long], archive: Boolean)(implicit c: Option[Connection] = None): List[Long] = {
+    this.withMRConnection { implicit c =>
+      try {
+        val ids = challengeIds.mkString(",")
+        val query =
+          s"""UPDATE challenges
+             |	SET is_archived = ${archive}
+             |	WHERE id IN (${ids});""".stripMargin
+        SQL(query).executeUpdate()
+
+        challengeIds
+      } catch {
+        case e: Exception =>
+          logger.error(e.getMessage, e)
+          throw e
+      }
+
+    }
+  }
+
+  /**
     * The summary for a challenge is the status with the number of tasks associated with each status
     * underneath the given challenge
     *

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -454,6 +454,29 @@ GET     /challenges/preferred                             @org.maproulette.contr
 GET     /challenges                                 @org.maproulette.controllers.api.ChallengeController.list(limit:Int ?= 10, page:Int ?= 0, onlyEnabled:Boolean ?= false)
 ###
 # tags: [ Challenge ]
+# summary: Bulk Archive Challenges.
+# produces: [ application/json ]
+# description: Archive or unarchive a list of challenges
+# responses:
+#   '200':
+#     description: A success message
+# parameters:
+#   - name: ids
+#     in: body
+#     description: A JSON array of challenge IDs
+#     required: true
+#     schema:
+#       type: array
+#       items:
+#         type: integer
+#   - name: isArchived
+#     in: body
+#     description: a boolean indicating if challenges should be archived (true) or unarchived (false)
+#     required: true
+###
+POST     /challenges/bulkArchive                    @org.maproulette.controllers.api.ChallengeController.bulkArchive()
+###
+# tags: [ Challenge ]
 # summary: List all the Challenges with review tasks.
 # produces: [ application/json ]
 # description: Lists all the Challenges in the system with review tasks.


### PR DESCRIPTION
This new endpoint allows multiple challenges to be archived or unarchived simultaneously