### PR TITLE
Add capability to sort by challenge completion

### DIFF
--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -303,6 +303,10 @@ object Config {
     s"$SUB_GROUP_SCHEDULER.archiveChallenges.interval"
   val KEY_SCHEDULER_ARCHIVE_CHALLENGES_START =
     s"$SUB_GROUP_SCHEDULER.archiveChallenges.startTime"
+  val KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL =
+    s"$SUB_GROUP_SCHEDULER.updateChallengeCompletionMetrics.interval"
+  val KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_START =
+    s"$SUB_GROUP_SCHEDULER.updateChallengeCompletionMetrics.startTime"
   val KEY_SCHEDULER_NOTIFICATION_DIGEST_EMAIL_INTERVAL =
     s"$SUB_GROUP_SCHEDULER.notifications.digestEmail.interval"
   val KEY_SCHEDULER_NOTIFICATION_DIGEST_EMAIL_START =

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -169,7 +169,9 @@ case class Challenge(
     lastTaskRefresh: Option[DateTime] = None,
     dataOriginDate: Option[DateTime] = None,
     location: Option[String] = None,
-    bounding: Option[String] = None
+    bounding: Option[String] = None,
+    completionPercentage: Option[Int] = Some(0),
+    tasksRemaining: Option[Int] = Some(0),
 ) extends BaseObject[Long]
     with DefaultWrites
     with Identifiable {

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -335,5 +335,6 @@ case class ArchivableChallenge(
 
 case class ArchivableTask(
     val id: Long,
-    val modified: DateTime
+    val modified: DateTime,
+    val status: Long
   )

--- a/app/org/maproulette/framework/service/ChallengeService.scala
+++ b/app/org/maproulette/framework/service/ChallengeService.scala
@@ -85,11 +85,12 @@ class ChallengeService @Inject() (
   }
 
   /**
-    * Retrieve a list of challenges not yet archived
+    * Retrieve a list of active challenges
+    * @param archived: include archived if true
     * @return list of challenges
     */
-  def staleChallenges(): List[ArchivableChallenge] = {
-    this.repository.staleChallenges()
+  def activeChallenges(archived: Boolean = false): List[ArchivableChallenge] = {
+    this.repository.activeChallenges(archived);
   }
 
   /**
@@ -107,5 +108,15 @@ class ChallengeService @Inject() (
     */
   def archiveChallenge(challenge: ArchivableChallenge): Unit = {
     this.repository.archiveChallenge(challenge.id)
+  }
+
+  /**
+   * update challenge completion metrics
+   * @param challengeId
+   * @param tasksRemaining
+   * @param completionPercentage
+   */
+  def updateChallengeCompletionMetrics(challengeId: Long, tasksRemaining: Integer, completionPercentage: Integer): Unit = {
+    this.repository.updateChallengeCompletionMetrics(challengeId, tasksRemaining, completionPercentage);
   }
 }

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -111,6 +111,13 @@ class Scheduler @Inject() (
   )
 
   scheduleAtTime(
+    "updateChallengeCompletionMetrics",
+    "Updating Challenge Completion Metrics",
+    config.getValue(Config.KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_START),
+    Config.KEY_SCHEDULER_UPDATE_CHALLENGE_COMPLETION_INTERVAL
+  )
+
+  scheduleAtTime(
     "sendCountNotificationWeeklyEmails",
     "Sending Count Notification Weekly Emails",
     config.getValue(Config.KEY_SCHEDULER_COUNT_NOTIFICATION_WEEKLY_START),

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -121,15 +121,17 @@ class ChallengeDAL @Inject() (
       get[Boolean]("challenges.requires_local") ~
       get[Boolean]("deleted") ~
       get[Boolean]("challenges.is_archived") ~
-      get[Option[Boolean]]("challenges.changeset_url") map {
+      get[Option[Boolean]]("challenges.changeset_url") ~
+      get[Option[Int]]("challenges.completion_percentage") ~
+      get[Option[Int]]("challenges.tasks_remaining") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~ checkin_comment ~
             checkin_source ~ overpassql ~ remoteGeoJson ~ overpassTargetType ~ status ~ statusMessage ~
             defaultPriority ~ highPriorityRule ~ mediumPriorityRule ~ lowPriorityRule ~ defaultZoom ~
             minZoom ~ maxZoom ~ defaultBasemap ~ defaultBasemapId ~ customBasemap ~ updateTasks ~
             exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~ preferredReviewTags ~
-            limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
-            dataOriginDate ~ location ~ bounding ~ requiresLocal ~ deleted ~ isArchived ~ changesetUrl =>
+            limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~ dataOriginDate ~ location ~ bounding ~
+            requiresLocal ~ deleted ~ isArchived ~ changesetUrl ~ completionPercentage ~ tasksRemaining =>
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
           case r                                                                => r
@@ -191,7 +193,9 @@ class ChallengeDAL @Inject() (
           lastTaskRefresh,
           dataOriginDate,
           location,
-          bounding
+          bounding,
+          completionPercentage,
+          tasksRemaining
         )
     }
   }
@@ -251,7 +255,9 @@ class ChallengeDAL @Inject() (
       get[Option[List[Long]]]("virtual_parent_ids") ~
       get[Option[List[String]]]("presets") ~
       get[Boolean]("challenges.is_archived") ~
-      get[Boolean]("challenges.changeset_url") map {
+      get[Boolean]("challenges.changeset_url") ~
+      get[Option[Int]]("challenges.completion_percentage") ~
+      get[Option[Int]]("challenges.tasks_remaining") map {
       case id ~ name ~ created ~ modified ~ description ~ infoLink ~ ownerId ~ parentId ~ instruction ~
             difficulty ~ blurb ~ enabled ~ featured ~ cooperativeType ~ popularity ~
             checkin_comment ~ checkin_source ~ overpassql ~ remoteGeoJson ~ overpassTargetType ~
@@ -260,7 +266,7 @@ class ChallengeDAL @Inject() (
             customBasemap ~ updateTasks ~ exportableProperties ~ osmIdProperty ~ taskBundleIdProperty ~ preferredTags ~
             preferredReviewTags ~ limitTags ~ limitReviewTags ~ taskStyles ~ lastTaskRefresh ~
             dataOriginDate ~ location ~ bounding ~ requiresLocal ~ deleted ~ virtualParents ~
-            presets ~ isArchived ~ changesetUrl =>
+            presets ~ isArchived ~ changesetUrl ~ completionPercentage ~ tasksRemaining =>
         val hpr = highPriorityRule match {
           case Some(c) if StringUtils.isEmpty(c) || StringUtils.equals(c, "{}") => None
           case r                                                                => r
@@ -323,7 +329,9 @@ class ChallengeDAL @Inject() (
           lastTaskRefresh,
           dataOriginDate,
           location,
-          bounding
+          bounding,
+          completionPercentage,
+          tasksRemaining
         )
     }
   }

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -66,7 +66,9 @@ trait ChallengeWrites extends DefaultWrites {
       (JsPath \ "lastTaskRefresh").writeNullable[DateTime] and
       (JsPath \ "dataOriginDate").writeNullable[DateTime] and
       (JsPath \ "location").writeNullable[String](new jsonWrites("location")) and
-      (JsPath \ "bounding").writeNullable[String](new jsonWrites("bounding"))
+      (JsPath \ "bounding").writeNullable[String](new jsonWrites("bounding")) and
+      (JsPath \ "completionPercentage").writeNullable[Int] and
+      (JsPath \ "tasksRemaining").writeNullable[Int]
   )(unlift(Challenge.unapply))
 }
 
@@ -119,6 +121,8 @@ trait ChallengeReads extends DefaultReads {
       (JsPath \ "lastTaskRefresh").readNullable[DateTime] and
       (JsPath \ "dataOriginDate").readNullable[DateTime] and
       (JsPath \ "location").readNullable[String](new jsonReads("location")) and
-      (JsPath \ "bounding").readNullable[String](new jsonReads("bounding"))
+      (JsPath \ "bounding").readNullable[String](new jsonReads("bounding")) and
+      (JsPath \ "completionPercentage").readNullable[Int] and
+      (JsPath \ "tasksRemaining").readNullable[Int]
   )(Challenge.apply _)
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -203,8 +203,8 @@ maproulette {
     }
 
     updateChallengeCompletionMetrics {
-      startTime = "14:12:00"
-      interval = "1 minute"
+      startTime = "05:01:00"
+      interval = "10 minutes"
     }
 
     notifications {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -202,6 +202,11 @@ maproulette {
       interval = "24 hours"
     }
 
+    updateChallengeCompletionMetrics {
+      startTime = "14:12:00"
+      interval = "1 minute"
+    }
+
     notifications {
       immediateEmail {
         interval = "1 minute"

--- a/conf/evolutions/default/84.sql
+++ b/conf/evolutions/default/84.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+ALTER TABLE challenges ADD COLUMN completion_percentage INTEGER DEFAULT 0;;
+ALTER TABLE challenges ADD COLUMN tasks_remaining INTEGER DEFAULT 0;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS challenges DROP COLUMN completion_percentage;;
+ALTER TABLE IF EXISTS challenges DROP COLUMN tasks_remaining;;


### PR DESCRIPTION
Resolves https://github.com/osmlab/maproulette3/issues/686.

Added a scheduler to predetermine task completion percentage for challenges and the number of tasks remaining, and added these data-points to the challenge table.  This allows a challenge query to have context of its completion metrics in order to not have to drill down to the task table every query.

To be released with https://github.com/osmlab/maproulette3/pull/1642