### PR TITLE
Fix challenge-level comment notifications

### DIFF
--- a/app/org/maproulette/framework/service/NotificationService.scala
+++ b/app/org/maproulette/framework/service/NotificationService.scala
@@ -205,8 +205,8 @@ class NotificationService @Inject() (
               userId = mentionedUser.id,
               notificationType = UserNotification.NOTIFICATION_TYPE_MENTION,
               fromUsername = Some(fromUser.osmProfile.displayName),
-              taskId = Some(challenge.id),
-              challengeId = Some(challenge.general.parent),
+              taskId = None,
+              challengeId = Some(challenge.id),
               targetId = Some(comment.id),
               extra = Some(comment.comment)
             ),


### PR DESCRIPTION
Resolves https://github.com/osmlab/maproulette3/issues/1630
To be released with https://github.com/osmlab/maproulette3/pull/1643

The issue pertains to challenge-level comments, which were mistakenly populating the taskId column with the challengeId.  This column should instead just be nullified.