### PR TITLE
fix taskCluster archive filtering

### DIFF
--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -46,7 +46,8 @@ trait SearchParametersMixin {
       this.filterTaskProps(params),
       this.filterChallenges(params),
       this.filterChallengeTags(params),
-      this.filterChallengeEnabled(params)
+      this.filterChallengeEnabled(params),
+      this.filterChallengeArchived(params),
     )
 
     if (projectSearch) {
@@ -658,6 +659,25 @@ trait SearchParametersMixin {
         )
       )
     )
+  }
+
+  /**
+   * Filters by c.is_archived. Will only include if
+   * challengeParams.archived value is true
+   */
+  def filterChallengeArchived(params: SearchParameters): FilterGroup = {
+      FilterGroup(
+        List(
+          FilterParameter.conditional(
+            Challenge.FIELD_ARCHIVED,
+            value = params.challengeParams.archived,
+            Operator.EQ,
+            useValueDirectly = true,
+            includeOnlyIfTrue = true,
+            table = Some("c")
+          )
+        )
+      )
   }
 
   /**

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -275,6 +275,7 @@ object Challenge extends CommonField {
   val TABLE           = "challenges"
   val FIELD_PARENT_ID = "parent_id"
   val FIELD_ENABLED   = "enabled"
+  val FIELD_ARCHIVED  = "is_archived"
   val FIELD_STATUS    = "status"
   val FIELD_DELETED   = "deleted"
 

--- a/app/org/maproulette/session/SearchParameters.scala
+++ b/app/org/maproulette/session/SearchParameters.scala
@@ -357,7 +357,7 @@ object SearchParameters {
       case None => params.challengeParams.challengeIds
     }
 
-    val archived = request.getQueryString("archived") match {
+    val archived = request.getQueryString("ca") match {
       case Some(q) => {
         if (q == "true") {
           true


### PR DESCRIPTION
The taskCluster services need to filter out archived challenges' task nodes appropriately.

To be released with: https://github.com/osmlab/maproulette3/pull/1646