### PR TITLE
See Tag Fix Suggestions User Setting

### DIFF
--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -180,7 +180,8 @@ case class UserSettings(
     isReviewer: Option[Boolean] = None,
     allowFollowing: Option[Boolean] = None,
     theme: Option[Int] = None,
-    customBasemaps: Option[List[CustomBasemap]] = None
+    customBasemaps: Option[List[CustomBasemap]] = None,
+    seeTagFixSuggestions: Option[Boolean] = None,
 ) {
   def getTheme: String = theme match {
     case Some(t) =>

--- a/app/org/maproulette/framework/service/UserService.scala
+++ b/app/org/maproulette/framework/service/UserService.scala
@@ -352,6 +352,9 @@ class UserService @Inject() (
       val allowFollowing = (value \ "settings" \ "allowFollowing")
         .asOpt[Boolean]
         .getOrElse(cachedItem.settings.allowFollowing.getOrElse(true))
+      val seeTagFixSuggestions = (value \ "settings" \ "seeTagFixSuggestions")
+        .asOpt[Boolean]
+        .getOrElse(cachedItem.settings.seeTagFixSuggestions.getOrElse(true))
       val theme = (value \ "settings" \ "theme")
         .asOpt[Int]
         .getOrElse(cachedItem.settings.theme.getOrElse(-1))
@@ -394,7 +397,8 @@ class UserService @Inject() (
               Some(isReviewer),
               Some(allowFollowing),
               Some(theme),
-              customBasemaps
+              customBasemaps,
+              Some(seeTagFixSuggestions)
             ),
             properties = Some(properties)
           ),

--- a/conf/evolutions/default/86.sql
+++ b/conf/evolutions/default/86.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE users ADD COLUMN see_tag_fix_suggestions BOOLEAN DEFAULT true;;
+
+# --- !Downs
+ALTER TABLE IF EXISTS users DROP COLUMN see_tag_fix_suggestions;;


### PR DESCRIPTION
This will add a "See Tag Fix Suggestions" user setting, allowing tag fix widgets to be disabled so user only sees a normal task edit interface.

Resolves https://github.com/osmlab/maproulette3/issues/1650
To be released with https://github.com/osmlab/maproulette3/pull/1667