### PR TITLE
add more restriction to updateLocations

### DIFF
--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -151,8 +151,9 @@ class SchedulerActor @Inject() (
     logger.info(action)
     val start       = System.currentTimeMillis
     val currentTime = DateTime.now()
+    val challengeFilter = "deleted = false AND is_archived = false AND enabled = true";
     val staleChallengeIds = db.withTransaction { implicit c =>
-      SQL("SELECT id FROM challenges WHERE modified > last_updated OR last_updated IS NULL")
+      SQL(s"SELECT id FROM challenges WHERE ${challengeFilter} AND (modified > last_updated OR last_updated IS NULL)")
         .as(SqlParser.long("id").*)
     }
 
@@ -180,7 +181,7 @@ class SchedulerActor @Inject() (
     })
 
     db.withTransaction { implicit c =>
-      SQL("SELECT id FROM challenges WHERE last_updated > {currentTime}")
+      SQL(s"SELECT id FROM challenges WHERE ${challengeFilter} AND (last_updated > {currentTime})")
         .on(Symbol("currentTime") -> ToParameterValue.apply[DateTime].apply(currentTime))
         .as(SqlParser.long("id").*)
         .foreach(id => {


### PR DESCRIPTION
adding additional filtering to updateLocations to speed up the service.  Challenges outside of discoverability shouldn't need this update.