### PR TITLE
Fix build: Update to sbt-play-swagger 0.10.6

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,6 +12,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.9.1-PLAY2.8")
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.6-PLAY2.8")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.1")


### PR DESCRIPTION
The sbt plugin "com.iheart:sbt-play-swagger" plugin dependency needs to be updated since the 0.9.1 versions have been removed from maven, likely due to a long outstanding CVE <https://nvd.nist.gov/vuln/detail/CVE-2017-18640>.

We know that the (unpatched) build worked Jan 11 and failed Jan 12. 

The build error message:
```
[error] sbt.librarymanagement.ResolveException: Error downloading com.iheart:play-swagger_2.13:0.9.1-PLAY2.8
[error]   Not found
[error]   Not found
[error]   not found: /root/.ivy2/local/com.iheart/play-swagger_2.13/0.9.1-PLAY2.8/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/com/iheart/play-swagger_2.13/0.9.1-PLAY2.8/play-swagger_2.13-0.9.1-PLAY2.8.pom
```

