### PR TITLE
fix id reference in setBundleTaskReviewStatus

### DIFF
--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -174,7 +174,7 @@ class TaskBundleController @Inject() (
         if (tags.nonEmpty) {
           val tagList = tags.split(",").toList
           if (tagList.nonEmpty) {
-            this.addTagstoItem(id, tagList.map(new Tag(-1, _, tagType = this.tagType)), user)
+            this.addTagstoItem(task.id, tagList.map(new Tag(-1, _, tagType = this.tagType)), user)
           }
         }
       }


### PR DESCRIPTION
For bundled task reviews, tags need to be applied to tasks instead of the bundle id.