### PR TITLE
change sort of challenge tasks extract

### DIFF
--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -1284,7 +1284,7 @@ class TaskDAL @Inject() (
   def retrieveTaskSummaries(
       challengeIds: List[Long],
       limit: Int = Config.DEFAULT_LIST_SIZE,
-      offset: Int = 0,
+      page: Int = 0,
       params: SearchParameters
   ): (List[TaskSummary], Map[Long, String]) =
     db.withConnection { implicit c =>
@@ -1375,8 +1375,8 @@ class TaskDAL @Inject() (
             LEFT OUTER JOIN task_review ON task_review.task_id = tasks.id
             #${joinClause.toString}
             WHERE tasks.parent_id IN (#${challengeIds.mkString(",")}) AND #${filters.toString}
-            ORDER BY tasks.parent_Id
-            LIMIT #${this.sqlLimit(limit)} OFFSET #${offset}
+            ORDER BY tasks.id
+            LIMIT #${this.sqlLimit(limit)} OFFSET #${page * limit}
       """
       (query.as(parser.*), allComments)
     }

--- a/conf/v2_route/challenge.api
+++ b/conf/v2_route/challenge.api
@@ -1111,9 +1111,14 @@ GET     /challenge/:id/extractReviewHistory             @org.maproulette.control
 #     in: path
 #     description: The ID of the challenge
 #     required: true
+#   - name: apiKey
+#     in: header
+#     description: The user's apiKey to authorize the request
+#     required: true
+#     type: string
 #   - name: limit
 #     in: query
-#     description: Limit the number of results returned in the response. Default value is 10.
+#     description: Limit the number of results returned in the response. Default value is -1 (no limit).
 #   - name: page
 #     in: query
 #     description: Used in conjunction with the limit parameter to page through X number of responses. Default value is 0, ie. first page.


### PR DESCRIPTION
Since all tasks in a challenge have the same parent id, sorting by parent id is unreliable when using page/limit parameters of the extract endpoint.  Also, offset is properly converted from page now.

To be released with https://github.com/osmlab/maproulette3/pull/1714