### PR TITLE
Create HttpLoggingFilter to log http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Now you're ready to run the MapRoulette backend.
 
 You run the MapRoulette backend in development mode like this:
 
-`sbt run -Dconfig.resource=dev.conf`
+`sbt run -Dconfig.resource=./conf/dev.conf -Dlogger.resource=logback-dev.xml`
 
 > This will take some time the first run as dependencies are downloaded.
 
@@ -68,6 +68,15 @@ Confirm that it's all working by getting `http://localhost:9000/api/v2/challenge
 > This will take some time on first run as artifacts are compiled.
 
 ## Notes
+
+### Logging Levels
+
+During development, please set `-Dlogger.resource=logback-dev.xml` to have the best experience. The logback dev file sets
+many items to the devel level and logs all HTTP request paths and response times.
+
+Any changes to the `conf/logback-dev.xml` will be loaded within about 5 seconds and a service restart is not needed.
+
+To have all request _headers_ sent by the client logged, update the `conf/logback-dev.xml` "org.maproulette.filters" entry to TRACE.
 
 ### Deploying on Windows
 

--- a/app/org/maproulette/filters/Filters.scala
+++ b/app/org/maproulette/filters/Filters.scala
@@ -6,11 +6,13 @@ package org.maproulette.filters
 
 import javax.inject.Inject
 import play.api.http.DefaultHttpFilters
+import play.api.http.EnabledFilters
 import play.filters.cors.CORSFilter
 import play.filters.gzip.GzipFilter
 
 /**
+ * See https://www.playframework.com/documentation/2.8.x/ScalaHttpFilters#Using-filters
   * @author cuthbertm
   */
-class Filters @Inject() (corsFilter: CORSFilter, gzipFilter: GzipFilter)
-    extends DefaultHttpFilters(corsFilter, gzipFilter)
+class Filters @Inject() (defaultFilters: EnabledFilters, corsFilter: CORSFilter, gzipFilter: GzipFilter)
+    extends DefaultHttpFilters(defaultFilters.filters :+ corsFilter :+ gzipFilter: _*)

--- a/app/org/maproulette/filters/HttpLoggingFilter.scala
+++ b/app/org/maproulette/filters/HttpLoggingFilter.scala
@@ -1,0 +1,57 @@
+package org.maproulette.filters
+
+import javax.inject.Inject
+import akka.stream.Materializer
+import org.maproulette.filters.HttpLoggingFilter.logger
+import org.slf4j.LoggerFactory
+import play.api.mvc.Result
+import play.api.mvc.RequestHeader
+import play.api.mvc.Filter
+import play.api.routing.HandlerDef
+import play.api.routing.Router
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+
+/**
+ * Filter to provide an http request log at the service side. The HttpLoggingFilter is enabled by default within
+ * application.conf but will create no output until logback is set to the debug or trace levels.
+ */
+class HttpLoggingFilter @Inject() (implicit val mat: Materializer, ec: ExecutionContext)
+    extends Filter {
+  def apply(
+      nextFilter: RequestHeader => Future[Result]
+  )(requestHeader: RequestHeader): Future[Result] = {
+    val startTime = System.currentTimeMillis
+
+    nextFilter(requestHeader).map { result =>
+      val handlerDef: HandlerDef = requestHeader.attrs(Router.Attrs.HandlerDef)
+      val action                 = handlerDef.controller + "." + handlerDef.method
+      val endTime                = System.currentTimeMillis
+      val requestTime            = endTime - startTime
+
+      logger.debug(
+        "id={} {}: '{}' took {}ms and returned {}",
+        requestHeader.id,
+        action,
+        requestHeader.toString(),
+        requestTime,
+        result.header.status
+      )
+
+      logger.trace(
+        "id={} Request Headers: {}",
+        requestHeader.id,
+        requestHeader.headers.headers
+          .map({ case (k, v) => s"${k}=${v}" })
+          .mkString("  ;; ")
+      )
+
+      result
+    }
+  }
+}
+
+object HttpLoggingFilter {
+  private val logger = LoggerFactory.getLogger(getClass.getName)
+}

--- a/app/org/maproulette/metrics/Metrics.scala
+++ b/app/org/maproulette/metrics/Metrics.scala
@@ -4,30 +4,24 @@
  */
 package org.maproulette.metrics
 
-import java.util.concurrent.TimeUnit
-
-import org.joda.time.DateTime
+import java.time.Duration
+import java.time.Instant
 import org.slf4j.LoggerFactory
-import play.api.Logger
 
 /**
   * @author cuthbertm
   */
 object Metrics {
+  private val logger = LoggerFactory.getLogger(getClass.getName)
+
   def timer[T](name: String, suppress: Boolean = false)(block: () => T): T = {
-    val start   = DateTime.now()
-    val result  = block()
-    val end     = DateTime.now()
-    val diff    = end.minus(start.getMillis).getMillis
-    val minutes = TimeUnit.MILLISECONDS.toMinutes(diff)
-    val seconds = TimeUnit.MILLISECONDS.toSeconds(diff) - TimeUnit.MINUTES.toSeconds(
-      TimeUnit.MILLISECONDS.toMinutes(diff)
-    )
-    val milliseconds = TimeUnit.MILLISECONDS.toMillis(diff) - TimeUnit.SECONDS.toMillis(
-      TimeUnit.MILLISECONDS.toSeconds(diff)
-    )
+    val start  = Instant.now()
+    val result = block()
+    val end    = Instant.now()
+
+    val duration = Duration.between(start, end)
     if (!suppress) {
-      LoggerFactory.getLogger(this.getClass).info(s"$name took $minutes:$seconds.$milliseconds")
+      logger.info("{} block took {}ms", name, duration.toMillis)
     }
     result
   }

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"       %% "play-mailer-guice"  % "8.0.0",
   "com.typesafe.akka"       %% "akka-cluster-tools" % "2.6.1",
   "com.typesafe.akka"       %% "akka-cluster-typed" % "2.6.1",
+  "com.typesafe.akka"       %% "akka-slf4j"         % "2.6.1",
   "net.debasishg"           %% "redisclient"        % "3.20"
 )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -98,6 +98,7 @@ play {
   modules.enabled += "org.maproulette.jobs.JobModule"
   filters {
     enabled += "play.filters.gzip.GzipFilter"
+    enabled += "org.maproulette.filters.HttpLoggingFilter"
     gzip {
       whiteList = []
     }

--- a/conf/dev.conf.example
+++ b/conf/dev.conf.example
@@ -5,6 +5,22 @@ db.default {
   username="osm"
   password="osm"
 }
+
+akka {
+  # Refer to the manual for akka logging options
+  # https://doc.akka.io/docs/akka/current/logging.html
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "WARN"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  actor {
+    debug {
+      # receive = on
+      # autoreceive = on
+      # lifecycle = on
+    }
+  }
+}
+
 maproulette {
   debug=true
   bootstrap=true

--- a/conf/logback-dev.xml
+++ b/conf/logback-dev.xml
@@ -1,0 +1,32 @@
+<configuration debug="true" scan="true" scanPeriod="5 seconds">
+    <conversionRule conversionWord="coloredLevel" converterClass="play.api.libs.logback.ColoredLevel" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>%date{"HH:mm:ss,SSS"} %coloredLevel [%thread] %class{15}.%M\(%file:%line\) - %message%n%xException</Pattern>
+        </encoder>
+        <includeCallerData>true</includeCallerData>
+    </appender>
+
+    <logger name="org.maproulette" level="DEBUG" />
+
+    <!-- Set this to TRACE to see the client's provided HTTP request headers -->
+    <!-- Do not use TRACE in a production environment since requests with apiKey header will have the key written to the log -->
+    <logger name="org.maproulette.filters" level="DEBUG" />
+
+    <!-- Set psql to DEBUG to see the sql statements sent to the db -->
+    <logger name="org.maproulette.framework.psql" level="INFO" />
+
+    <logger name="play" level="INFO" />
+
+    <!-- More akka logging tweaks can be made in the dev.conf, akka.actor.debug -->
+    <logger name="akka" level="INFO" />
+
+    <!-- Unknown if these actually do anything -->
+    <logger name="application" level="TRACE" />
+    <logger name="controllers" level="TRACE" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Create HttpLoggingFilter logging filter to provide an http request log at the service side. The HttpLoggingFilter is enabled by default within application.conf but will create no output until logback is set to the debug or trace levels.

Verified that the gh action logs don't print anything different than before (the http log filter is noop at info level)
This is what the trace log looks like this in the intellij console:

> 21:13:41,477 [debug] [application-akka.actor.default-dispatcher-19] o.m.f.HttpLoggingFilter.$anonfun$apply$1(HttpLoggingFilter.scala:39) - id=161 org.maproulette.controllers.api.ChallengeController.listChildren: 'GET /api/v2/challenge/1139/tasks?limit=10&page=0' took 17ms and returned 200
> 21:13:41,478 [trace] [application-akka.actor.default-dispatcher-19] o.m.f.HttpLoggingFilter.$anonfun$apply$1(HttpLoggingFilter.scala:47) - id=161 Request Headers: Timeout-Access=<function1>  ;; Remote-Address=127.0.0.1:47750  ;; Raw-Request-URI=/api/v2/challenge/1139/tasks?limit=10&page=0  ;; Tls-Session-Info=Session(11112|SSL_NULL_WITH_NULL_NULL)  ;; apiKey= xyzsomevalue  ;; Host=127.0.0.1:9000  ;; Connection=Keep-Alive  ;; User-Agent=Apache-HttpClient/4.5.1 (Java/11.0.14.1)  ;; Accept-Encoding=gzip,deflate

