### PR TITLE
disable HttpLoggingFilter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -98,7 +98,6 @@ play {
   modules.enabled += "org.maproulette.jobs.JobModule"
   filters {
     enabled += "play.filters.gzip.GzipFilter"
-    enabled += "org.maproulette.filters.HttpLoggingFilter"
     gzip {
       whiteList = []
     }


### PR DESCRIPTION
this feature needs additional checks for OPTION calls.  disabling for now.