### PR TITLE
add updateTaskPriorities method at end of remoteJson flow

### DIFF
--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -261,6 +261,11 @@ class ChallengeProvider @Inject() (
         } else {
           this.challengeDAL.update(Json.obj("status" -> Challenge.STATUS_READY), user)(challenge.id)
           this.challengeDAL.markTasksRefreshed()(challenge.id)
+
+          //we need to reapply task priority rules since task locations were updated
+          Future {
+            this.challengeDAL.updateTaskPriorities(user)(challenge.id)
+          }
         }
       case Failure(f) =>
         if (fileNumber > 1) {


### PR DESCRIPTION
Challenges submitted via remoteJson don't assign priority rules correctly because an updatePriorities method was missing after the creation process is complete.  Creation and Edit flows should be resolved with this implementation.