### PR TITLE
Use build.sbt 'version' for swagger api version

### DIFF
--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -3,7 +3,6 @@ swagger: "2.0"
 info:
   title: "MapRoulette API"
   description: "API for MapRoulette enabling the creation and maintenance of MapRoulette challenges"
-  version: "4.0"
   contact:
     name: "maproulette@maproulette.org"
   license:


### PR DESCRIPTION
Remove unnecessary `info.version` from swagger.yml and allow the
play-swagger plugin to use the build's version (from build.sbt).

This has no visual change as both versions (build.sbt and swagger.yml)
were both 4.0.0, and in the future deployments can set a version.

See here for reference https://github.com/iheartradio/play-swagger#step-2

> Note that info.version is intentionally left out, playSwagger will automatically fillin the build version of the project. However if the version is set here it will be honored. You can also dynamically generate the version string in build file using the swaggerAPIVersion setting.
