### PR TITLE
add migration to drop update_challenge_modified trigger

### DIFF
--- a/conf/evolutions/default/90.sql
+++ b/conf/evolutions/default/90.sql
@@ -1,0 +1,7 @@
+# --- !Ups
+DROP TRIGGER IF EXISTS update_challenges_modified ON challenges;;
+
+# --- !Downs
+DROP TRIGGER IF EXISTS update_challenges_modified ON challenges;;
+CREATE TRIGGER update_challenges_modified BEFORE UPDATE ON challenges
+  FOR EACH ROW EXECUTE PROCEDURE update_modified();;


### PR DESCRIPTION
Challenge modified dates have utility in the frontend to indicate to users when the challenge and/or its associated tasks were last interacted with.  At this stage of the system, it no longer seems responsible to include the update_challenge_modified trigger, since jobs update active challenges regularly, making the modified dates not useful for end users.  Dropping the trigger will allow background processes to run without affecting said dates, and will allow us to only update the dates in a more purposeful manner.

There are no indications of regression, through manual testing and studying the code.  There appears to be no dependency on the trigger for user interactions (meaning modified dates still get updated thanks to challenge/task update services).  And there's no conditions that check for challenge modified dates.  Any conditions that depend on challenge modified dates would be useless anyway if the dates are being updated via daily jobs.  dropping the trigger ensures this won't happen anymore.

Reference: https://github.com/osmlab/maproulette3/issues/1733
