### PR TITLE
add markTasksRefreshed to taskUpload flow

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -191,6 +191,10 @@ class TaskController @Inject() (
     //priority based on location and parent priority rules.
     updatePriority(createdObject);
 
+    //https://github.com/osmlab/maproulette3/issues/1733
+    //User request to have taskUploads update taskRefresh for challenge
+    this.dalManager.challenge.markTasksRefreshed()(createdObject.parent);
+
     // If we have added a new task to a 'finished' challenge, we need to make
     // sure to set challenge back to 'ready'
     this.dalManager.challenge.updateReadyStatus()(createdObject.parent)


### PR DESCRIPTION
Assists with resolving https://github.com/osmlab/maproulette3/issues/1733.  A challenge's `last_task_refresh` should update when new tasks are being uploaded or updated via the API.

To be released with https://github.com/osmlab/maproulette3/pull/1742