### PR TITLE
Remove the API_HOST var from swagger.yml

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -53,7 +53,6 @@ jobs:
     - name: Run the integration tests
       env:
         SBT_OPTS: "-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M"
-        API_HOST: 127.0.0.1:9000
         host: 127.0.0.1
         scheme: http
         apiKey: 1234

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ For more details on the app registration process, see the [OSM OAuth wiki page](
     * `mapillary.clientId`: a [Mapillary Client ID](https://www.mapillary.com/dashboard/developers), needed if you want to use any of the Mapillary integrations.
     * `osm.consumerKey` and `osm.consumerSecret`: the OAuth keys from your OSM OAuth app you created earlier.
 * Save `dev.conf`
-* Create an environment variable for the Swagger API documentation: `export API_HOST=localhost:9000`
 
 Now you're ready to run the MapRoulette backend.
 

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -9,7 +9,6 @@ info:
     name: "Apache License version 2.0"
     url: "http://www.apache.org/licenses/"
 basePath: "/api/v2"
-host: ${API_HOST}
 consumes:
   - application/json
 produces:


### PR DESCRIPTION
Since the scala API is what provides the swagger docs there is no need to allow swagger to send requests to a different backend. This patch purges the API_HOST variable and the swagger docs will now, by default, send the request to the host where it (the API serving swagger) is running.

If the API and Docs are separated into different hosts in the future, use this approach https://github.com/iheartradio/play-swagger#how-do-i-use-a-different-host-for-different-environment