### PR TITLE
Update many runtime dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,27 +43,36 @@ libraryDependencies ++= Seq(
   specs2 % Test,
   filters,
   guice,
+
+  // NOTE: Be careful upgrading sangria and play-json as binary incompatiblities can break graphql and the entire UI.
+  //       See the compatibility matrix here https://github.com/sangria-graphql/sangria-play-json
   "org.sangria-graphql"     %% "sangria-play-json"  % "2.0.1",
-  "org.sangria-graphql"     %% "sangria"            % "2.0.0-M1",
-  "com.typesafe.play"       %% "play-json-joda"     % "2.8.1",
-  "com.typesafe.play"       %% "play-json"          % "2.8.1",
-  "org.scalatestplus.play"  %% "scalatestplus-play" % "5.0.0" % Test,
-  "org.webjars"             % "swagger-ui"          % "3.25.0",
-  "org.playframework.anorm" %% "anorm"              % "2.6.5",
-  "org.playframework.anorm" %% "anorm-postgres"     % "2.6.5",
-  "org.postgresql"          % "postgresql"          % "42.2.10",
-  "net.postgis"             % "postgis-jdbc"        % "2.3.0",
-  "joda-time"               % "joda-time"           % "2.10.5",
+  "org.sangria-graphql"     %% "sangria"            % "2.0.1",
+  "com.typesafe.play"       %% "play-json-joda"     % "2.8.2",
+  "com.typesafe.play"       %% "play-json"          % "2.8.2",
+  "org.scalatestplus.play"  %% "scalatestplus-play" % "5.1.0" % Test,
+  "org.scalatestplus"       %% "mockito-4-5"        % "3.2.12.0" % Test,
+
+  // NOTE: There is a breaking change with swagger-ui starting at v4.1.3 where the 'url'
+  //       parameter is disabled for security reasons.
+  //       See https://github.com/swagger-api/swagger-ui/issues/4872
+  "org.webjars"             % "swagger-ui"          % "4.1.2",
+
+  "org.playframework.anorm" %% "anorm"              % "2.6.10",
+  "org.playframework.anorm" %% "anorm-postgres"     % "2.6.10",
+  "org.postgresql"          % "postgresql"          % "42.3.4",
+  "net.postgis"             % "postgis-jdbc"        % "2021.1.0",
+  "joda-time"               % "joda-time"           % "2.10.14",
   "com.vividsolutions"      % "jts"                 % "1.13",
   "org.wololo"              % "jts2geojson"         % "0.14.3",
-  "org.apache.commons"      % "commons-lang3"       % "3.9",
+  "org.apache.commons"      % "commons-lang3"       % "3.12.0",
   "commons-codec"           % "commons-codec"       % "1.14",
-  "com.typesafe.play"       %% "play-mailer"        % "8.0.0",
-  "com.typesafe.play"       %% "play-mailer-guice"  % "8.0.0",
+  "com.typesafe.play"       %% "play-mailer"        % "8.0.1",
+  "com.typesafe.play"       %% "play-mailer-guice"  % "8.0.1",
   "com.typesafe.akka"       %% "akka-cluster-tools" % "2.6.19",
   "com.typesafe.akka"       %% "akka-cluster-typed" % "2.6.19",
   "com.typesafe.akka"       %% "akka-slf4j"         % "2.6.19",
-  "net.debasishg"           %% "redisclient"        % "3.20"
+  "net.debasishg"           %% "redisclient"        % "3.42"
 )
 
 resolvers ++= Seq(

--- a/test/org/maproulette/framework/service/FollowServiceSpec.scala
+++ b/test/org/maproulette/framework/service/FollowServiceSpec.scala
@@ -8,7 +8,7 @@ package org.maproulette.framework.service
 import org.maproulette.framework.model._
 import org.maproulette.framework.util.{FrameworkHelper, UserTag}
 import org.maproulette.exception.{InvalidException}
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import play.api.libs.json.Json
 import play.api.Application
 

--- a/test/org/maproulette/framework/service/UserServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserServiceSpec.scala
@@ -14,7 +14,7 @@ import org.maproulette.exception.{InvalidException}
 import org.maproulette.session.{SearchParameters, SearchTaskParameters}
 import org.maproulette.data.{ProjectType}
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import play.api.Application
 
 /**


### PR DESCRIPTION
The updates will resolve these issues (identified by snyk docker scan)

```

Issues to fix by upgrading:

  Upgrade com.fasterxml.jackson.core:jackson-databind@2.11.4 to com.fasterxml.jackson.core:jackson-databind@2.12.6.1 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698] in com.fasterxml.jackson.core:jackson-databind@2.11.4
    introduced by com.fasterxml.jackson.core:jackson-databind@2.11.4 and 1 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244] in com.fasterxml.jackson.core:jackson-databind@2.11.4
    introduced by com.fasterxml.jackson.core:jackson-databind@2.11.4 and 1 other path(s)

  Upgrade org.postgresql:postgresql@42.2.10 to org.postgresql:postgresql@42.3.3 to fix
  ✗ Arbitrary Code Injection [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2401816] in org.postgresql:postgresql@42.2.10
    introduced by org.postgresql:postgresql@42.2.10
  ✗ Remote Code Execution (RCE) [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2390459] in org.postgresql:postgresql@42.2.10
    introduced by org.postgresql:postgresql@42.2.10
  ✗ XML External Entity (XXE) Injection [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-571481] in org.postgresql:postgresql@42.2.10
    introduced by org.postgresql:postgresql@42.2.10

  Upgrade org.webjars:swagger-ui@3.25.0 to org.webjars:swagger-ui@4.1.3 to fix
  ✗ User Interface (UI) Misrepresentation of Critical Information [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-2314887] in org.webjars:swagger-ui@3.25.0
    introduced by org.webjars:swagger-ui@3.25.0
  ✗ Insecure Defaults [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-575003] in org.webjars:swagger-ui@3.25.0
    introduced by org.webjars:swagger-ui@3.25.0


Issues with no direct upgrade or patch:
  ✗ Information Exposure [Low Severity][https://snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-1313686] in org.eclipse.jetty:jetty-server@9.4.39.v20210325
    introduced by net.sf.ehcache:sizeof-agent@1.0.1 > org.eclipse.jetty:jetty-server@9.4.39.v20210325
  This issue was fixed in versions: 11.0.3, 10.0.3, 9.4.41
  ✗ Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637] in org.glassfish.jersey.core:jersey-common@2.31
    introduced by net.sf.ehcache:sizeof-agent@1.0.1 > org.glassfish.jersey.core:jersey-common@2.31
  This issue was fixed in versions: 3.0.2, 2.34


```