### PR TITLE
filter out deleted tasks in taskCluster

### DIFF
--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -39,7 +39,9 @@ class TaskClusterService @Inject() (repository: TaskClusterRepository)
       params: SearchParameters,
       numberOfPoints: Int = this.repository.DEFAULT_NUMBER_OF_POINTS
   ): List[TaskCluster] = {
-    val query = this.filterOutDeletedParents(this.filterOnSearchParameters(params)(false))
+    val filtered = this.filterOnSearchParameters(params)(false)
+    val query = this.filterOutDeletedParents(filtered)
+
     this.repository.queryTaskClusters(query, numberOfPoints, params)
   }
 


### PR DESCRIPTION
taskCluster endpoint filtering isn't properly checking for deleted task parents.

Resolves https://github.com/osmlab/maproulette3/issues/1663