### PR TITLE
Code quality: scalafix: Fail the build if there are unused imports

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -19,6 +19,11 @@ jobs:
           CI: true
         run: |
           sbt -Dsbt.log.format=false 'set asciiGraphWidth := 10000' 'dependencyTree'
+      - name: Verify scalafix passes
+        env:
+          CI: true
+        run: |
+          sbt -Dsbt.log.format=false 'generateRoutesFile' 'scalafixAll --check'
 
   sbt_tests_jacoco:
     runs-on: ubuntu-latest

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,6 @@
+rules = [
+  RemoveUnused,
+]
+
+triggered.rules = [
+]

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -9,7 +9,7 @@ import java.util.Calendar
 import akka.actor.ActorRef
 import javax.inject.{Inject, Named}
 import org.maproulette.exception.{StatusMessage, StatusMessages}
-import org.maproulette.framework.service.{ServiceManager, UserService}
+import org.maproulette.framework.service.ServiceManager
 import org.maproulette.jobs.SchedulerActor.RunJob
 import org.maproulette.models.dal._
 import org.maproulette.session.SessionManager

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -25,7 +25,6 @@ import org.maproulette.framework.model._
 import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.service.{ServiceManager, TagService}
 import org.maproulette.framework.mixins.{ParentMixin, TagsControllerMixin}
-import org.maproulette.models._
 import org.maproulette.models.dal._
 import org.maproulette.models.dal.mixin.TagDALMixin
 import org.maproulette.permissions.Permission

--- a/app/org/maproulette/controllers/api/DataController.scala
+++ b/app/org/maproulette/controllers/api/DataController.scala
@@ -17,7 +17,6 @@ import play.api.libs.json._
 import play.api.mvc._
 
 import scala.collection.mutable
-import scala.util.Try
 
 /**
   * @author cuthbertm

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -6,8 +6,6 @@ package org.maproulette.controllers.api
 
 import java.sql.Connection
 import akka.util.ByteString
-import anorm.SQL
-import org.joda.time.DateTime
 
 import javax.inject.Inject
 import org.locationtech.jts.geom.Envelope
@@ -26,7 +24,6 @@ import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.service.{ServiceManager, TagService, TaskClusterService}
 import org.maproulette.framework.mixins.TagsControllerMixin
 import org.maproulette.framework.repository.TaskRepository
-import org.maproulette.models._
 import org.maproulette.models.dal.mixin.TagDALMixin
 import org.maproulette.models.dal.{DALManager, TaskDAL}
 import org.maproulette.provider.osm._

--- a/app/org/maproulette/controllers/api/VirtualChallengeController.scala
+++ b/app/org/maproulette/controllers/api/VirtualChallengeController.scala
@@ -11,7 +11,7 @@ import org.maproulette.Config
 import org.maproulette.controllers.CRUDController
 import org.maproulette.data.{ActionManager, TaskViewed, VirtualChallengeType}
 import org.maproulette.exception.NotFoundException
-import org.maproulette.framework.model.{User, ClusteredPoint, Point, PointReview, Task}
+import org.maproulette.framework.model.{User, ClusteredPoint, Task}
 import org.maproulette.models.dal.{TaskDAL, VirtualChallengeDAL}
 import org.maproulette.models.VirtualChallenge
 import org.maproulette.session.{

--- a/app/org/maproulette/data/DataManager.scala
+++ b/app/org/maproulette/data/DataManager.scala
@@ -11,15 +11,14 @@ import anorm._
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.Config
-import org.maproulette.framework.model.{ReviewMetrics, Task}
+import org.maproulette.framework.model.Task
 import org.maproulette.framework.service.ServiceManager
 import org.maproulette.models.utils.{AND, DALHelper, WHERE}
 import org.maproulette.models.dal.mixin.SearchParametersMixin
-import org.maproulette.session.{SearchParameters, SearchTaskParameters}
+import org.maproulette.session.SearchParameters
 import org.maproulette.utils.BoundingBoxFinder
 import play.api.Application
 import play.api.db.Database
-import scala.collection.mutable.ListBuffer
 
 case class ActionSummary(
     total: Int,

--- a/app/org/maproulette/data/SnapshotManager.scala
+++ b/app/org/maproulette/data/SnapshotManager.scala
@@ -4,19 +4,16 @@
  */
 package org.maproulette.data
 
-import java.sql.Connection
 
 import anorm.SqlParser._
 import anorm._
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.Config
-import org.maproulette.models.utils.WHERE
 import org.maproulette.models.dal.{ChallengeDAL}
-import org.maproulette.session.SearchParameters
 import org.maproulette.utils.BoundingBoxFinder
 import org.maproulette.exception.NotFoundException
-import org.maproulette.framework.model.{Challenge, Task}
+import org.maproulette.framework.model.Challenge
 import org.maproulette.framework.service.ServiceManager
 import play.api.Application
 import play.api.db.Database

--- a/app/org/maproulette/framework/controller/ChallengeSnapshotController.scala
+++ b/app/org/maproulette/framework/controller/ChallengeSnapshotController.scala
@@ -9,15 +9,12 @@ import javax.inject.Inject
 import org.maproulette.data.ActionManager
 import org.maproulette.data._
 import org.maproulette.framework.service.ChallengeSnapshotService
-import org.maproulette.framework.psql.Paging
-import org.maproulette.framework.model.{User, Challenge, Task}
+import org.maproulette.framework.model.{Challenge, Task}
 import org.maproulette.session.SessionManager
-import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.http.HttpEntity
-import org.maproulette.exception.NotFoundException
 
 /**
   * SnapshotController is responsible for handling functionality related to

--- a/app/org/maproulette/framework/controller/DataController.scala
+++ b/app/org/maproulette/framework/controller/DataController.scala
@@ -6,13 +6,9 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import org.apache.commons.lang3.StringUtils
-import org.maproulette.data.{Created => ActionCreated, _}
-import org.maproulette.exception.{MPExceptionUtil, NotFoundException, StatusMessage}
-import org.maproulette.framework.model.{User}
+import org.maproulette.data.{Created => _, _}
 import org.maproulette.framework.service.{DataService}
 import org.maproulette.session.{SearchParameters, SessionManager}
-import org.maproulette.utils.Utils
 import play.api.libs.json._
 import play.api.mvc._
 

--- a/app/org/maproulette/framework/controller/FollowController.scala
+++ b/app/org/maproulette/framework/controller/FollowController.scala
@@ -5,7 +5,6 @@
 
 package org.maproulette.framework.controller
 
-import java.net.URLDecoder
 
 import javax.inject.Inject
 import org.maproulette.data.ActionManager

--- a/app/org/maproulette/framework/controller/LeaderboardController.scala
+++ b/app/org/maproulette/framework/controller/LeaderboardController.scala
@@ -6,16 +6,11 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import org.apache.commons.lang3.StringUtils
-import org.maproulette.data.{Created => ActionCreated, _}
-import org.maproulette.exception.{MPExceptionUtil, NotFoundException, StatusMessage}
+import org.maproulette.data.{Created => _, _}
 import org.maproulette.framework.service.{LeaderboardService}
-import org.maproulette.framework.model.{User, LeaderboardUser, LeaderboardChallenge}
 import org.maproulette.session.{SessionManager, SearchParameters}
-import org.maproulette.utils.Utils
 import play.api.libs.json._
 import play.api.mvc._
-import scala.util.Try
 
 /**
   * @author krotstan

--- a/app/org/maproulette/framework/controller/NotificationController.scala
+++ b/app/org/maproulette/framework/controller/NotificationController.scala
@@ -6,7 +6,7 @@ package org.maproulette.framework.controller
 
 import javax.inject.Inject
 import org.apache.commons.lang3.StringUtils
-import org.maproulette.exception.{InvalidException, NotFoundException, StatusMessage}
+import org.maproulette.exception.StatusMessage
 import org.maproulette.framework.service.{NotificationService}
 import org.maproulette.framework.model.{NotificationSubscriptions}
 import org.maproulette.framework.psql.{Order, OrderField, Paging}
@@ -15,8 +15,6 @@ import org.maproulette.utils.{Crypto, Utils}
 import play.api.libs.json._
 import play.api.mvc._
 
-import scala.concurrent.Promise
-import scala.util.{Failure, Success}
 
 /**
   * @author nrotstan
@@ -30,7 +28,6 @@ class NotificationController @Inject() (
 ) extends AbstractController(components)
     with DefaultWrites {
 
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   implicit val notificationSubscriptionReads =
     NotificationSubscriptions.notificationSubscriptionReads

--- a/app/org/maproulette/framework/controller/TaskBundleController.scala
+++ b/app/org/maproulette/framework/controller/TaskBundleController.scala
@@ -5,10 +5,9 @@
 
 package org.maproulette.framework.controller
 
-import java.net.URLDecoder
 
 import javax.inject.Inject
-import org.maproulette.exception.{NotFoundException, InvalidException}
+import org.maproulette.exception.InvalidException
 import org.maproulette.data._
 import org.maproulette.framework.model.{Task, Tag}
 import org.maproulette.framework.service.{TaskBundleService, ServiceManager, TagService}

--- a/app/org/maproulette/framework/controller/TaskController.scala
+++ b/app/org/maproulette/framework/controller/TaskController.scala
@@ -12,7 +12,6 @@ import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.model.User
 import org.maproulette.framework.mixins.TaskJSONMixin
 import org.maproulette.session.{SessionManager, SearchParameters, SearchLocation}
-import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
 import play.api.http.HttpEntity

--- a/app/org/maproulette/framework/controller/TaskHistoryController.scala
+++ b/app/org/maproulette/framework/controller/TaskHistoryController.scala
@@ -5,16 +5,13 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import akka.util.ByteString
 import org.maproulette.data.ActionManager
-import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.service.{ServiceManager, TaskHistoryService}
-import org.maproulette.framework.model.{User, TaskLogEntry}
+import org.maproulette.framework.model.TaskLogEntry
 import org.maproulette.session.SessionManager
 import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
-import play.api.http.HttpEntity
 
 /**
   * TaskHistoryController is responsible for fetching the history of a task.

--- a/app/org/maproulette/framework/controller/TaskReviewController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewController.scala
@@ -5,7 +5,6 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import akka.util.ByteString
 import org.maproulette.data.ActionManager
 import org.maproulette.exception.NotFoundException
 import org.maproulette.framework.service.{TaskReviewService, TagService, ServiceManager}
@@ -16,13 +15,11 @@ import org.maproulette.framework.repository.TaskRepository
 import org.maproulette.session.{
   SessionManager,
   SearchParameters,
-  SearchTaskParameters,
   SearchLocation
 }
 import org.maproulette.utils.Utils
 import play.api.mvc._
 import play.api.libs.json._
-import play.api.http.HttpEntity
 
 import org.maproulette.data.{
   TaskItem,

--- a/app/org/maproulette/framework/controller/TaskReviewMetricsController.scala
+++ b/app/org/maproulette/framework/controller/TaskReviewMetricsController.scala
@@ -16,8 +16,6 @@ import org.maproulette.framework.service.{
 import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.model.{
   Challenge,
-  ChallengeListing,
-  Project,
   User,
   ReviewMetrics,
   Task

--- a/app/org/maproulette/framework/controller/TeamController.scala
+++ b/app/org/maproulette/framework/controller/TeamController.scala
@@ -5,13 +5,12 @@
 
 package org.maproulette.framework.controller
 
-import java.net.URLDecoder
 
 import javax.inject.Inject
 import org.maproulette.data.ActionManager
-import org.maproulette.exception.{MPExceptionUtil, NotFoundException, StatusMessage}
+import org.maproulette.exception.{MPExceptionUtil, StatusMessage}
 import org.maproulette.framework.service.TeamService
-import org.maproulette.framework.model.{User, TeamMember, TeamUser, MemberObject, Group}
+import org.maproulette.framework.model.{User, MemberObject, Group}
 import org.maproulette.framework.psql.{Paging}
 import org.maproulette.session.SessionManager
 import play.api.libs.json._

--- a/app/org/maproulette/framework/controller/UserController.scala
+++ b/app/org/maproulette/framework/controller/UserController.scala
@@ -5,13 +5,11 @@
 package org.maproulette.framework.controller
 
 import javax.inject.Inject
-import org.apache.commons.lang3.StringUtils
 import org.maproulette.exception.{InvalidException, NotFoundException, StatusMessage}
 import org.maproulette.framework.model.{
   Challenge,
   User,
   UserSettings,
-  ProjectManager,
   GrantTarget,
   Task
 }
@@ -20,7 +18,6 @@ import org.maproulette.framework.service.ServiceManager
 import org.maproulette.framework.mixins.ParentMixin
 import org.maproulette.permissions.Permission
 import org.maproulette.session.{SessionManager, SearchParameters}
-import org.maproulette.data.{UserType}
 import org.maproulette.utils.{Crypto, Utils}
 import play.api.libs.json._
 import play.api.mvc._

--- a/app/org/maproulette/framework/graphql/GraphQL.scala
+++ b/app/org/maproulette/framework/graphql/GraphQL.scala
@@ -9,7 +9,7 @@ import javax.inject.Inject
 import org.maproulette.framework.graphql.schemas._
 import org.maproulette.framework.graphql.fetchers._
 import sangria.schema.{ObjectType, fields}
-import sangria.execution.deferred.{Fetcher, DeferredResolver}
+import sangria.execution.deferred.DeferredResolver
 
 /**
   * @author mcuthbert

--- a/app/org/maproulette/framework/graphql/fetchers/ChallengeFetchers.scala
+++ b/app/org/maproulette/framework/graphql/fetchers/ChallengeFetchers.scala
@@ -7,7 +7,6 @@ package org.maproulette.framework.graphql.fetchers
 
 import org.maproulette.framework.graphql.UserContext
 import sangria.execution.deferred.{Fetcher}
-import org.maproulette.framework.psql.Paging
 import scala.concurrent.{Future}
 
 /**

--- a/app/org/maproulette/framework/graphql/fetchers/ProjectFetchers.scala
+++ b/app/org/maproulette/framework/graphql/fetchers/ProjectFetchers.scala
@@ -6,9 +6,7 @@
 package org.maproulette.framework.graphql.fetchers
 
 import org.maproulette.framework.graphql.UserContext
-import org.maproulette.framework.model.Challenge
-import sangria.execution.deferred.{Fetcher, Relation, RelationIds}
-import org.maproulette.framework.psql.Paging
+import sangria.execution.deferred.Fetcher
 import scala.concurrent.{Future}
 
 /**

--- a/app/org/maproulette/framework/graphql/fetchers/TaskFetchers.scala
+++ b/app/org/maproulette/framework/graphql/fetchers/TaskFetchers.scala
@@ -6,8 +6,7 @@
 package org.maproulette.framework.graphql.fetchers
 
 import org.maproulette.framework.graphql.UserContext
-import sangria.execution.deferred.{Fetcher, HasId}
-import org.maproulette.framework.psql.Paging
+import sangria.execution.deferred.Fetcher
 import scala.concurrent.{Future}
 
 /**

--- a/app/org/maproulette/framework/graphql/fetchers/UserFetchers.scala
+++ b/app/org/maproulette/framework/graphql/fetchers/UserFetchers.scala
@@ -7,7 +7,6 @@ package org.maproulette.framework.graphql.fetchers
 
 import org.maproulette.framework.graphql.UserContext
 import sangria.execution.deferred.{Fetcher, HasId}
-import org.maproulette.framework.psql.Paging
 import scala.concurrent.{Future}
 
 /**

--- a/app/org/maproulette/framework/graphql/schemas/ActionItemSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/ActionItemSchema.scala
@@ -7,10 +7,8 @@ package org.maproulette.framework.graphql.schemas
 
 import javax.inject.Inject
 import org.maproulette.Config
-import org.maproulette.exception.NotFoundException
 import org.maproulette.framework.graphql.UserContext
-import org.maproulette.framework.service.UserService
-import org.maproulette.data.{ActionManager, ActionItem}
+import org.maproulette.data.ActionManager
 import sangria.schema._
 
 /**

--- a/app/org/maproulette/framework/graphql/schemas/TaskSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/TaskSchema.scala
@@ -5,8 +5,6 @@
 
 package org.maproulette.framework.graphql.schemas
 
-import org.maproulette.framework.model.{Task, TaskReviewFields, MapillaryImage}
-import sangria.macros.derive.{ObjectTypeName, deriveObjectType}
 import sangria.schema._
 
 /**

--- a/app/org/maproulette/framework/graphql/schemas/TeamSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/TeamSchema.scala
@@ -11,8 +11,7 @@ import org.maproulette.framework.graphql.fetchers.TeamFetchers
 import org.maproulette.framework.graphql.UserContext
 import org.maproulette.framework.model._
 import org.maproulette.framework.service.TeamService
-import play.api.libs.json.{DefaultWrites, Json, Reads, Writes}
-import sangria.macros.derive._
+import play.api.libs.json.DefaultWrites
 import sangria.schema._
 
 /**

--- a/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
+++ b/app/org/maproulette/framework/graphql/schemas/UserSchema.scala
@@ -11,7 +11,7 @@ import org.maproulette.framework.graphql.UserContext
 import org.maproulette.framework.model._
 import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.service.UserService
-import play.api.libs.json.{DefaultWrites, Json, Reads, Writes}
+import play.api.libs.json.{DefaultWrites, Json, Reads}
 import sangria.macros.derive._
 import sangria.schema._
 

--- a/app/org/maproulette/framework/mixins/LeaderboardMixin.scala
+++ b/app/org/maproulette/framework/mixins/LeaderboardMixin.scala
@@ -4,8 +4,6 @@
  */
 package org.maproulette.framework.mixins
 
-import org.maproulette.framework.psql.filter._
-import org.maproulette.framework.psql.Query
 import org.maproulette.framework.model.Task
 import org.maproulette.Config
 

--- a/app/org/maproulette/framework/mixins/ReviewSearchMixin.scala
+++ b/app/org/maproulette/framework/mixins/ReviewSearchMixin.scala
@@ -5,7 +5,6 @@
 package org.maproulette.framework.mixins
 
 import org.maproulette.session.SearchParameters
-import org.maproulette.framework.psql.SQLUtils
 import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.{AND, OR}

--- a/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
+++ b/app/org/maproulette/framework/mixins/SearchParametersMixin.scala
@@ -4,7 +4,6 @@
  */
 package org.maproulette.framework.mixins
 
-import anorm.NamedParameter
 import org.maproulette.session.{SearchParameters, SearchLocation}
 import org.maproulette.framework.psql.SQLUtils
 import org.maproulette.framework.psql.filter._
@@ -13,7 +12,6 @@ import org.maproulette.framework.psql.{AND, OR}
 import org.maproulette.framework.model.{TaskReview, Project, Challenge, Task}
 import play.api.libs.json.JsDefined
 
-import scala.collection.mutable.ListBuffer
 
 trait SearchParametersMixin {
 

--- a/app/org/maproulette/framework/mixins/TaskFilterMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskFilterMixin.scala
@@ -4,15 +4,12 @@
  */
 package org.maproulette.framework.mixins
 
-import play.api.libs.json._
 
-import org.maproulette.framework.service.ServiceManager
-import org.maproulette.framework.model.{Task, User, Challenge, Project}
+import org.maproulette.framework.model.{User, Challenge, Project}
 import org.maproulette.framework.psql.{Query, _}
 import org.maproulette.framework.psql.filter._
 import org.maproulette.data.Actions
 
-import org.maproulette.utils.Utils
 
 /**
   * TaskFilterMixin provides task related methods

--- a/app/org/maproulette/framework/mixins/TaskParserMixin.scala
+++ b/app/org/maproulette/framework/mixins/TaskParserMixin.scala
@@ -4,15 +4,12 @@
  */
 package org.maproulette.framework.mixins
 
-import play.api.libs.json._
 import anorm.SqlParser.get
 import anorm.{RowParser, ~}
 import org.joda.time.DateTime
 
-import org.maproulette.framework.service.ServiceManager
-import org.maproulette.framework.model.{TaskReview, TaskReviewFields, TaskWithReview, User, Task}
+import org.maproulette.framework.model.{TaskReview, TaskReviewFields, TaskWithReview, Task}
 
-import org.maproulette.utils.Utils
 
 /**
   * TaskParserMixin provides task parsers

--- a/app/org/maproulette/framework/model/Grant.scala
+++ b/app/org/maproulette/framework/model/Grant.scala
@@ -4,7 +4,6 @@
  */
 package org.maproulette.framework.model
 
-import org.maproulette.cache.CacheObject
 import org.maproulette.data.{ItemType, UserType, ProjectType, GroupType, Actions}
 import org.maproulette.framework.psql.CommonField
 import play.api.libs.json._

--- a/app/org/maproulette/framework/model/Leaderboard.scala
+++ b/app/org/maproulette/framework/model/Leaderboard.scala
@@ -6,9 +6,8 @@ package org.maproulette.framework.model
 
 import org.joda.time.DateTime
 import org.maproulette.framework.psql.CommonField
-import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.{Json, Writes}
 import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
 
 case class LeaderboardChallenge(id: Long, name: String, activity: Int)
 object LeaderboardChallenge {

--- a/app/org/maproulette/framework/model/TaskLogEntry.scala
+++ b/app/org/maproulette/framework/model/TaskLogEntry.scala
@@ -5,7 +5,7 @@
 package org.maproulette.framework.model
 
 import org.joda.time.DateTime
-import play.api.libs.json.{DefaultWrites, Json, Reads, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 

--- a/app/org/maproulette/framework/model/Team.scala
+++ b/app/org/maproulette/framework/model/Team.scala
@@ -5,8 +5,6 @@
 package org.maproulette.framework.model
 
 import play.api.libs.json._
-import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
 
 /**
   * @author nrotstan

--- a/app/org/maproulette/framework/model/User.scala
+++ b/app/org/maproulette/framework/model/User.scala
@@ -13,11 +13,8 @@ import org.maproulette.Config
 import org.maproulette.cache.CacheObject
 import org.maproulette.framework.psql.CommonField
 import org.maproulette.utils.{Crypto, Utils}
-import org.maproulette.permissions.Permission
 import org.maproulette.data._
 import org.slf4j.LoggerFactory
-import play.api.data.Form
-import play.api.data.Forms._
 import play.api.libs.json._
 import play.api.libs.oauth.RequestToken
 import play.api.libs.json.JodaWrites._

--- a/app/org/maproulette/framework/model/UserNotification.scala
+++ b/app/org/maproulette/framework/model/UserNotification.scala
@@ -6,7 +6,7 @@ package org.maproulette.framework.model
 
 import org.joda.time.DateTime
 import org.maproulette.framework.psql.CommonField
-import play.api.libs.json.{DefaultWrites, Json, Reads, Writes}
+import play.api.libs.json.{Json, Reads, Writes}
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
 

--- a/app/org/maproulette/framework/psql/filter/Filter.scala
+++ b/app/org/maproulette/framework/psql/filter/Filter.scala
@@ -6,7 +6,7 @@
 package org.maproulette.framework.psql.filter
 
 import anorm.NamedParameter
-import org.maproulette.framework.psql.{OR, AND, Query, SQLKey}
+import org.maproulette.framework.psql.{OR, AND, SQLKey}
 
 /**
   * This class handles any filters that you want to add onto a query. Repositories only handle one

--- a/app/org/maproulette/framework/repository/ChallengeCommentRepository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeCommentRepository.scala
@@ -8,9 +8,7 @@ package org.maproulette.framework.repository
 import anorm.SqlParser.{get, long}
 import anorm._
 import org.joda.time.DateTime
-import org.maproulette.framework.model.{ChallengeComment, Comment, User}
-import org.maproulette.framework.psql.Query
-import org.maproulette.framework.psql.filter.BaseParameter
+import org.maproulette.framework.model.{ChallengeComment, User}
 import play.api.db.Database
 
 import java.sql.Connection

--- a/app/org/maproulette/framework/repository/ChallengeSnapshotRespository.scala
+++ b/app/org/maproulette/framework/repository/ChallengeSnapshotRespository.scala
@@ -5,18 +5,12 @@
 
 package org.maproulette.framework.repository
 
-import java.sql.Connection
-import scala.concurrent.duration.FiniteDuration
 
-import anorm.SqlParser.get
-import anorm.ToParameterValue
-import anorm.{RowParser, ~}
 import javax.inject.{Inject, Singleton}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
-import org.maproulette.framework.model.{User, ChallengeSnapshot}
+import org.maproulette.framework.model.ChallengeSnapshot
 import play.api.db.Database
-import play.api.libs.json.JsValue
 @Singleton
 class ChallengeSnapshotRepository @Inject() (override val db: Database) extends RepositoryMixin {
   implicit val baseTable: String = ChallengeSnapshot.TABLE

--- a/app/org/maproulette/framework/repository/GrantRepository.scala
+++ b/app/org/maproulette/framework/repository/GrantRepository.scala
@@ -7,7 +7,6 @@ package org.maproulette.framework.repository
 
 import java.sql.Connection
 
-import anorm.Macro.ColumnNaming
 import anorm._
 import anorm.SqlParser._
 import javax.inject.{Inject, Singleton}

--- a/app/org/maproulette/framework/repository/GroupMemberRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupMemberRepository.scala
@@ -11,7 +11,6 @@ import anorm.Macro.ColumnNaming
 import anorm._
 import javax.inject.{Inject, Singleton}
 import org.maproulette.framework.model.{Group, GroupMember, MemberObject}
-import org.maproulette.framework.repository.{UserRepository}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter._
 import play.api.db.Database

--- a/app/org/maproulette/framework/repository/GroupRepository.scala
+++ b/app/org/maproulette/framework/repository/GroupRepository.scala
@@ -7,13 +7,11 @@ package org.maproulette.framework.repository
 
 import java.sql.Connection
 
-import anorm.SqlParser.{get, long}
 import anorm._
 import javax.inject.Inject
-import org.joda.time.DateTime
-import org.maproulette.framework.model.{Group, GroupMember}
+import org.maproulette.framework.model.Group
 import org.maproulette.framework.repository.{GroupMemberRepository}
-import org.maproulette.framework.psql.{Query, Paging}
+import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.{BaseParameter, Operator, FilterGroup}
 import play.api.db.Database
 

--- a/app/org/maproulette/framework/repository/LeaderboardRepository.scala
+++ b/app/org/maproulette/framework/repository/LeaderboardRepository.scala
@@ -8,11 +8,10 @@ package org.maproulette.framework.repository
 import java.sql.Connection
 
 import anorm.SqlParser.get
-import anorm.ToParameterValue
 import anorm.{RowParser, ~}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
-import org.maproulette.framework.psql.{Query, Grouping, GroupField}
+import org.maproulette.framework.psql.Query
 import org.maproulette.framework.model.{LeaderboardUser, LeaderboardChallenge}
 import play.api.db.Database
 

--- a/app/org/maproulette/framework/repository/NotificationRepository.scala
+++ b/app/org/maproulette/framework/repository/NotificationRepository.scala
@@ -8,7 +8,7 @@ import java.sql.Connection
 import anorm.SqlParser._
 import anorm._
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
 import scala.collection.mutable.ListBuffer
 import org.joda.time.DateTime
 import org.maproulette.framework.model.{UserNotification, UserNotificationEmail, UserRevCount}

--- a/app/org/maproulette/framework/repository/NotificationSubscriptionRepository.scala
+++ b/app/org/maproulette/framework/repository/NotificationSubscriptionRepository.scala
@@ -8,7 +8,7 @@ import java.sql.Connection
 
 import anorm.SqlParser._
 import anorm._
-import javax.inject.{Inject, Singleton}
+import javax.inject.Inject
 import org.maproulette.framework.model.{NotificationSubscriptions}
 import org.maproulette.framework.psql._
 import org.maproulette.framework.psql.filter._

--- a/app/org/maproulette/framework/repository/TaskBundleRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskBundleRepository.scala
@@ -5,12 +5,9 @@
 
 package org.maproulette.framework.repository
 
-import java.sql.Connection
 import org.slf4j.LoggerFactory
 
-import anorm.SqlParser.{get, scalar, str}
 import anorm.ToParameterValue
-import anorm.{RowParser, ~}
 import anorm._, postgresql._
 import javax.inject.{Inject, Singleton}
 import org.maproulette.Config
@@ -20,7 +17,6 @@ import org.maproulette.framework.model.{Task, TaskBundle, User}
 import org.maproulette.framework.mixins.{TaskParserMixin, Locking}
 import org.maproulette.data.TaskType
 import play.api.db.Database
-import play.api.libs.json._
 
 // deprecated and to be removed after conversion
 import org.maproulette.models.dal.TaskDAL

--- a/app/org/maproulette/framework/repository/TaskClusterRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskClusterRepository.scala
@@ -6,19 +6,14 @@
 package org.maproulette.framework.repository
 
 import java.sql.Connection
-import scala.concurrent.duration.FiniteDuration
-import org.joda.time.DateTime
 
-import anorm.ToParameterValue
-import anorm.{RowParser, ~}
-import anorm._, postgresql._
-import anorm.SqlParser.{get, int, long, str}
+import anorm.~
+import anorm._
+import anorm.SqlParser.{get, int, str}
 import javax.inject.{Inject, Singleton}
-import org.maproulette.data.Actions
 import org.maproulette.session.SearchParameters
 import org.maproulette.framework.psql.{Query, Order, Paging}
-import org.maproulette.framework.psql.filter.{BaseParameter, CustomParameter, Parameter}
-import org.maproulette.framework.model.{User, ClusteredPoint, Point, PointReview, Task, TaskCluster}
+import org.maproulette.framework.model.{ClusteredPoint, Point, TaskCluster}
 import play.api.db.Database
 import play.api.libs.json._
 

--- a/app/org/maproulette/framework/repository/TaskHistoryRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskHistoryRepository.scala
@@ -5,14 +5,11 @@
 
 package org.maproulette.framework.repository
 
-import java.sql.Connection
 import org.joda.time.DateTime
 
 import anorm.SqlParser.get
-import anorm.ToParameterValue
 import anorm.{RowParser, ~, SQL}
 import javax.inject.{Inject, Singleton}
-import org.maproulette.framework.psql.{Query, Grouping, GroupField}
 import org.maproulette.framework.model.{TaskLogEntry, TaskReview}
 import play.api.db.Database
 

--- a/app/org/maproulette/framework/repository/TaskRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskRepository.scala
@@ -5,19 +5,16 @@
 
 package org.maproulette.framework.repository
 
-import java.sql.Connection
-import scala.concurrent.duration.FiniteDuration
 
 import anorm.SqlParser.{get, scalar, str}
 import anorm.ToParameterValue
-import anorm.{RowParser, ~}
 import anorm._, postgresql._
 import javax.inject.{Inject, Singleton}
 import org.maproulette.Config
 import org.maproulette.framework.mixins.TaskParserMixin
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.{BaseParameter, CustomParameter}
-import org.maproulette.framework.model.{User, Project, Task}
+import org.maproulette.framework.model.{User, Task}
 import org.maproulette.cache.CacheManager
 import play.api.db.Database
 import play.api.libs.json._

--- a/app/org/maproulette/framework/repository/TaskReviewMetricsRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewMetricsRepository.scala
@@ -6,10 +6,8 @@
 package org.maproulette.framework.repository
 
 import java.sql.Connection
-import scala.concurrent.duration.FiniteDuration
 
 import anorm.SqlParser.{get, long}
-import anorm.ToParameterValue
 import anorm.{RowParser, ~, SQL}
 import javax.inject.{Inject, Singleton}
 import org.maproulette.framework.model.{Task, TaskReview, ReviewMetrics}

--- a/app/org/maproulette/framework/repository/TaskReviewRepository.scala
+++ b/app/org/maproulette/framework/repository/TaskReviewRepository.scala
@@ -14,7 +14,7 @@ import anorm.{ToParameterValue, SimpleSql, Row, SqlParser, RowParser, ~, SQL}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.framework.model.{Task, TaskReview, TaskWithReview, User}
-import org.maproulette.framework.psql.{Query, Grouping, GroupField, Order, Paging}
+import org.maproulette.framework.psql.{Query, Grouping, Order, Paging}
 import org.maproulette.framework.mixins.{Locking, TaskParserMixin}
 import org.maproulette.framework.service.UserService
 import org.maproulette.session.SearchParameters

--- a/app/org/maproulette/framework/repository/UserRepository.scala
+++ b/app/org/maproulette/framework/repository/UserRepository.scala
@@ -14,11 +14,10 @@ import com.vividsolutions.jts.io.WKTReader
 import javax.inject.{Inject, Singleton}
 import org.joda.time.DateTime
 import org.maproulette.Config
-import org.maproulette.data._
 import org.maproulette.framework.model._
 import org.maproulette.framework.service.{ServiceManager, GrantService}
 import org.maproulette.framework.psql.filter._
-import org.maproulette.framework.psql.{Grouping, Query, SQLUtils}
+import org.maproulette.framework.psql.{Query, SQLUtils}
 import org.maproulette.models.dal.ChallengeDAL
 import play.api.db.Database
 import play.api.libs.oauth.RequestToken

--- a/app/org/maproulette/framework/repository/VirtualProjectRepository.scala
+++ b/app/org/maproulette/framework/repository/VirtualProjectRepository.scala
@@ -10,7 +10,7 @@ import java.sql.Connection
 import anorm.SQL
 import javax.inject.{Inject, Singleton}
 import org.maproulette.exception.InvalidException
-import org.maproulette.framework.model.{Project, VirtualProject}
+import org.maproulette.framework.model.VirtualProject
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
 import org.postgresql.util.PSQLException

--- a/app/org/maproulette/framework/service/ChallengeService.scala
+++ b/app/org/maproulette/framework/service/ChallengeService.scala
@@ -11,12 +11,9 @@ import org.maproulette.framework.model.{
   ArchivableChallenge,
   ArchivableTask,
   Challenge,
-  Grant,
   Project,
-  User,
-  UserRevCount
+  User
 }
-import org.maproulette.data.{ProjectType, UserType}
 import org.maproulette.framework.psql.{OR, Paging, Query}
 import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.repository.ChallengeRepository

--- a/app/org/maproulette/framework/service/ChallengeSnapshotService.scala
+++ b/app/org/maproulette/framework/service/ChallengeSnapshotService.scala
@@ -6,17 +6,11 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.FiniteDuration
-import play.api.libs.json.JsValue
 
-import org.maproulette.exception.NotFoundException
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, _}
-import org.maproulette.framework.psql.filter.{BaseParameter, _}
 import org.maproulette.framework.repository.ChallengeSnapshotRepository
-import org.maproulette.cache.CacheManager
 import org.maproulette.permissions.Permission
-import org.maproulette.data.{SnapshotManager, Snapshot}
+import org.maproulette.data.SnapshotManager
 import org.maproulette.models.dal.ChallengeDAL
 
 /**

--- a/app/org/maproulette/framework/service/DataService.scala
+++ b/app/org/maproulette/framework/service/DataService.scala
@@ -7,10 +7,10 @@ package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
 import org.maproulette.permissions.Permission
-import org.maproulette.framework.model.{ReviewMetrics, User}
+import org.maproulette.framework.model.ReviewMetrics
 import org.maproulette.framework.mixins.SearchParametersMixin
 import org.maproulette.framework.repository.TaskReviewMetricsRepository
-import org.maproulette.session.{SearchParameters, SessionManager}
+import org.maproulette.session.SearchParameters
 
 /**
   * Service layer for Data business logic

--- a/app/org/maproulette/framework/service/GrantService.scala
+++ b/app/org/maproulette/framework/service/GrantService.scala
@@ -5,15 +5,13 @@
 
 package org.maproulette.framework.service
 
-import java.sql.Connection
 
 import javax.inject.{Inject, Singleton}
 import org.maproulette.Config
-import org.maproulette.cache.{BasicCache, CacheManager, ListCacheObject}
 import org.maproulette.exception.InvalidException
 import org.maproulette.framework.model.{Grant, Grantee, GrantTarget, User}
 import org.maproulette.framework.psql.Query
-import org.maproulette.framework.psql.filter.{Parameter, BaseParameter, FilterParameter, Operator}
+import org.maproulette.framework.psql.filter.{Parameter, BaseParameter, Operator}
 import org.maproulette.framework.repository.{GrantRepository}
 import org.maproulette.data._
 import org.maproulette.permissions.Permission

--- a/app/org/maproulette/framework/service/GroupService.scala
+++ b/app/org/maproulette/framework/service/GroupService.scala
@@ -5,16 +5,13 @@
 
 package org.maproulette.framework.service
 
-import java.net.URLDecoder
 
 import javax.inject.{Inject, Singleton}
-import org.apache.commons.lang3.StringUtils
-import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.framework.model.{Group, GroupMember, MemberObject}
 import org.maproulette.data.{ItemType}
 import org.maproulette.framework.psql._
 import org.maproulette.framework.psql.filter._
-import org.maproulette.framework.psql.{OR, Order, Paging, Query}
+import org.maproulette.framework.psql.Query
 import org.maproulette.framework.repository.{GroupRepository, GroupMemberRepository}
 import org.maproulette.permissions.Permission
 

--- a/app/org/maproulette/framework/service/LeaderboardService.scala
+++ b/app/org/maproulette/framework/service/LeaderboardService.scala
@@ -13,7 +13,7 @@ import org.maproulette.framework.mixins.LeaderboardMixin
 import org.maproulette.framework.repository.{LeaderboardRepository, ChallengeRepository}
 import org.maproulette.framework.psql._
 import org.maproulette.framework.psql.filter._
-import org.maproulette.session.{SessionManager, SearchLeaderboardParameters}
+import org.maproulette.session.SearchLeaderboardParameters
 import org.maproulette.utils.BoundingBoxFinder
 
 /**

--- a/app/org/maproulette/framework/service/NotificationService.scala
+++ b/app/org/maproulette/framework/service/NotificationService.scala
@@ -5,16 +5,13 @@
 
 package org.maproulette.framework.service
 
-import java.net.URLDecoder
 
 import javax.inject.{Inject, Singleton}
-import org.apache.commons.lang3.StringUtils
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.data.{UserType}
 import org.maproulette.framework.model._
 import org.maproulette.framework.model.{UserRevCount}
 import org.maproulette.framework.psql._
-import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.repository.{
   NotificationRepository,
   NotificationSubscriptionRepository

--- a/app/org/maproulette/framework/service/ProjectService.scala
+++ b/app/org/maproulette/framework/service/ProjectService.scala
@@ -16,8 +16,6 @@ import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.repository.{ChallengeRepository, ProjectRepository}
 import org.maproulette.permissions.Permission
 import org.maproulette.session.SearchParameters
-import org.maproulette.exception.{InvalidException}
-import org.maproulette.data._
 import org.slf4j.LoggerFactory
 import play.api.libs.json.JsValue
 

--- a/app/org/maproulette/framework/service/TaskBundleService.scala
+++ b/app/org/maproulette/framework/service/TaskBundleService.scala
@@ -6,17 +6,13 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.FiniteDuration
-import play.api.libs.json._
 
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, _}
-import org.maproulette.framework.psql.filter.{BaseParameter, _}
+import org.maproulette.framework.psql.Query
+import org.maproulette.framework.psql.filter.BaseParameter
 import org.maproulette.framework.repository.TaskBundleRepository
 import org.maproulette.framework.service.TaskService
-import org.maproulette.framework.mixins.Locking
-import org.maproulette.cache.CacheManager
 import org.maproulette.permissions.Permission
 
 // deprecated and to be removed after conversion

--- a/app/org/maproulette/framework/service/TaskClusterService.scala
+++ b/app/org/maproulette/framework/service/TaskClusterService.scala
@@ -6,13 +6,11 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.FiniteDuration
-import play.api.libs.json._
 
 import org.maproulette.Config
 import org.maproulette.exception.InvalidException
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, _}
+import org.maproulette.framework.psql._
 import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.repository.TaskClusterRepository
 import org.maproulette.framework.mixins.{SearchParametersMixin, TaskFilterMixin}

--- a/app/org/maproulette/framework/service/TaskHistoryService.scala
+++ b/app/org/maproulette/framework/service/TaskHistoryService.scala
@@ -6,16 +6,11 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.FiniteDuration
-import org.joda.time.DateTime
 import org.maproulette.framework.model.{ArchivableTask, TaskLogEntry, TaskReview}
-import org.maproulette.framework.psql.{Query, _}
-import org.maproulette.framework.psql.filter.{BaseParameter, _}
 import org.maproulette.framework.repository.TaskHistoryRepository
-import org.maproulette.session.SearchParameters
 import org.maproulette.permissions.Permission
 import org.maproulette.data.Actions
-import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
+import org.maproulette.provider.websockets.WebSocketProvider
 
 /**
   * Service layer for TaskHistory

--- a/app/org/maproulette/framework/service/TaskReviewMetricsService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewMetricsService.scala
@@ -6,11 +6,9 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.FiniteDuration
 
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, _}
-import org.maproulette.framework.psql.filter.{BaseParameter, _}
+import org.maproulette.framework.psql.Query
 import org.maproulette.framework.repository.TaskReviewMetricsRepository
 import org.maproulette.framework.mixins.ReviewSearchMixin
 import org.maproulette.session.SearchParameters

--- a/app/org/maproulette/framework/service/TaskReviewService.scala
+++ b/app/org/maproulette/framework/service/TaskReviewService.scala
@@ -19,7 +19,7 @@ import org.maproulette.framework.repository.{
 }
 import org.maproulette.framework.mixins.ReviewSearchMixin
 import org.maproulette.exception.InvalidException
-import org.maproulette.session.{SearchParameters, SearchReviewParameters}
+import org.maproulette.session.SearchParameters
 import org.maproulette.permissions.Permission
 import org.maproulette.provider.websockets.{WebSocketMessages, WebSocketProvider}
 import org.maproulette.data.{ChallengeType, Actions}

--- a/app/org/maproulette/framework/service/TaskService.scala
+++ b/app/org/maproulette/framework/service/TaskService.scala
@@ -6,16 +6,13 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.FiniteDuration
 import play.api.libs.json._
 
 import org.maproulette.exception.NotFoundException
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, _}
-import org.maproulette.framework.psql.filter.{BaseParameter, _}
+import org.maproulette.framework.psql._
 import org.maproulette.framework.repository.TaskRepository
 import org.maproulette.models.dal.TaskDAL
-import org.maproulette.cache.CacheManager
 
 /**
   * Service layer for Task

--- a/app/org/maproulette/framework/service/TeamService.scala
+++ b/app/org/maproulette/framework/service/TeamService.scala
@@ -5,10 +5,8 @@
 
 package org.maproulette.framework.service
 
-import java.net.URLDecoder
 
 import javax.inject.{Inject, Singleton}
-import org.apache.commons.lang3.StringUtils
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.framework.model._
 import org.maproulette.data.{Actions, UserType, GroupType, ProjectType}

--- a/app/org/maproulette/framework/service/UserMetricService.scala
+++ b/app/org/maproulette/framework/service/UserMetricService.scala
@@ -6,7 +6,7 @@
 package org.maproulette.framework.service
 
 import javax.inject.{Inject, Singleton}
-import org.joda.time.{DateTime, Months}
+import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.framework.model.{StatusActions, TaskReview, User, UserMetrics, Task}

--- a/app/org/maproulette/jobs/Bootstrap.scala
+++ b/app/org/maproulette/jobs/Bootstrap.scala
@@ -4,7 +4,6 @@
  */
 package org.maproulette.jobs
 
-import anorm._
 import javax.inject.{Inject, Singleton}
 import org.maproulette.Config
 import org.slf4j.LoggerFactory

--- a/app/org/maproulette/jobs/Scheduler.scala
+++ b/app/org/maproulette/jobs/Scheduler.scala
@@ -11,7 +11,7 @@ import javax.inject.{Inject, Named}
 import org.maproulette.Config
 import org.maproulette.jobs.SchedulerActor.RunJob
 import org.slf4j.LoggerFactory
-import play.api.{Application, Logger}
+import play.api.Application
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory
 import play.api.Application
 import play.api.db.Database
 
-import java.time.Instant
 import scala.util.{Failure, Success}
 
 /**

--- a/app/org/maproulette/jobs/utils/LeaderboardHelper.scala
+++ b/app/org/maproulette/jobs/utils/LeaderboardHelper.scala
@@ -8,7 +8,6 @@ import java.time.{LocalDate, Period}
 import java.time.format.DateTimeFormatter
 
 import org.maproulette.Config
-import org.maproulette.framework.model.Task
 import org.maproulette.framework.mixins.LeaderboardMixin
 
 /**

--- a/app/org/maproulette/models/Changeset.scala
+++ b/app/org/maproulette/models/Changeset.scala
@@ -7,7 +7,6 @@ package org.maproulette.models
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
-import play.api.Logger
 
 import scala.xml._
 

--- a/app/org/maproulette/models/dal/ChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/ChallengeDAL.scala
@@ -8,12 +8,12 @@ import java.sql.Connection
 
 import anorm.SqlParser._
 import anorm._
-import javax.inject.{Inject, Provider, Singleton}
+import javax.inject.{Inject, Singleton}
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.DateTime
 import org.maproulette.Config
 import org.maproulette.cache.CacheManager
-import org.maproulette.data.{Actions, ChallengeType, ProjectType, TaskType}
+import org.maproulette.data.{Actions, ChallengeType, ProjectType}
 import org.maproulette.exception.{InvalidException, NotFoundException, UniqueViolationException}
 import org.maproulette.framework.model._
 import org.maproulette.framework.repository.{
@@ -22,7 +22,6 @@ import org.maproulette.framework.repository.{
   ChallengeListingRepository
 }
 import org.maproulette.framework.service.{ServiceManager, TagService}
-import org.maproulette.models._
 import org.maproulette.models.dal.mixin.{OwnerMixin, TagDALMixin}
 import org.maproulette.permissions.Permission
 import org.maproulette.session.SearchParameters

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -15,7 +15,6 @@ import org.apache.commons.lang3.StringUtils
 import org.joda.time.{DateTime, DateTimeZone}
 import org.locationtech.jts.geom.Envelope
 import org.maproulette.Config
-import org.maproulette.cache.CacheManager
 import org.maproulette.data._
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import org.maproulette.framework.model.{
@@ -24,8 +23,7 @@ import org.maproulette.framework.model.{
   StatusActions,
   User,
   GrantTarget,
-  Task,
-  Achievement
+  Task
 }
 import org.maproulette.framework.psql.filter.{BaseParameter, SubQueryFilter}
 import org.maproulette.framework.psql.{Order, Paging, Query}

--- a/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
+++ b/app/org/maproulette/models/dal/VirtualChallengeDAL.scala
@@ -19,7 +19,7 @@ import org.maproulette.framework.psql.Paging
 import org.maproulette.models._
 import org.maproulette.models.utils.DALHelper
 import org.maproulette.permissions.Permission
-import org.maproulette.session.{SearchChallengeParameters, SearchLocation, SearchParameters}
+import org.maproulette.session.{SearchLocation, SearchParameters}
 import play.api.db.Database
 import play.api.libs.json.JodaReads._
 import play.api.libs.json.{JsString, JsValue, Json}

--- a/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
+++ b/app/org/maproulette/models/dal/mixin/SearchParametersMixin.scala
@@ -7,8 +7,6 @@ package org.maproulette.models.dal.mixin
 import anorm.NamedParameter
 import org.maproulette.models.utils.DALHelper
 import org.maproulette.session.SearchParameters
-import org.maproulette.framework.psql.SQLUtils
-import play.api.libs.json.JsDefined
 
 import scala.collection.mutable.ListBuffer
 

--- a/app/org/maproulette/models/utils/ChallengeFormatters.scala
+++ b/app/org/maproulette/models/utils/ChallengeFormatters.scala
@@ -12,7 +12,6 @@ import org.maproulette.framework.model.{
   ChallengeGeneral,
   ChallengePriority
 }
-import org.maproulette.models._
 import org.maproulette.utils.Utils
 import org.maproulette.utils.Utils.{jsonReads, jsonWrites}
 import play.api.libs.functional.syntax._

--- a/app/org/maproulette/provider/ChallengeProvider.scala
+++ b/app/org/maproulette/provider/ChallengeProvider.scala
@@ -19,7 +19,6 @@ import play.api.http.Status
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 
-import scala.collection.View.Empty
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}

--- a/app/org/maproulette/provider/EmailProvider.scala
+++ b/app/org/maproulette/provider/EmailProvider.scala
@@ -5,12 +5,9 @@
 package org.maproulette.provider
 
 import play.api.libs.mailer._
-import java.io.File
-import org.apache.commons.mail.EmailAttachment
 import javax.inject.{Inject, Singleton}
 import org.maproulette.Config
 import org.maproulette.framework.model.{UserNotification, UserNotificationEmail}
-import scala.concurrent.{Future}
 
 /**
   * @author nrotstan
@@ -20,7 +17,6 @@ import scala.concurrent.{Future}
 @Singleton
 class EmailProvider @Inject() (mailerClient: MailerClient, config: Config) {
 
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   def emailNotification(toAddress: String, notification: UserNotificationEmail) = {
     val notificationName =

--- a/app/org/maproulette/provider/KeepRightProvider.scala
+++ b/app/org/maproulette/provider/KeepRightProvider.scala
@@ -13,7 +13,6 @@ import org.maproulette.Config
 import org.maproulette.framework.model._
 import org.maproulette.framework.psql.TransactionManager
 import org.maproulette.framework.service.ProjectService
-import org.maproulette.models._
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import org.maproulette.utils.Utils
 import org.slf4j.LoggerFactory

--- a/app/org/maproulette/provider/websockets/WebSocketMessages.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketMessages.scala
@@ -8,7 +8,6 @@ import org.joda.time.DateTime
 import org.maproulette.framework.model.{TaskWithReview, User, Challenge, Project, Task}
 import play.api.libs.json._
 import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
 
 /**
   * Defines case classes representing the various kinds of messages to be

--- a/app/org/maproulette/session/TaskPropertySearch.scala
+++ b/app/org/maproulette/session/TaskPropertySearch.scala
@@ -4,14 +4,7 @@
  */
 package org.maproulette.session
 
-import java.net.URLDecoder
 
-import org.maproulette.utils.Utils
-import play.api.mvc.{AnyContent, Request}
-import play.api.data.format.Formats
-import play.api.libs.json._
-import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
 import org.maproulette.exception.InvalidException
 
 /**

--- a/app/org/maproulette/utils/Readers.scala
+++ b/app/org/maproulette/utils/Readers.scala
@@ -6,7 +6,6 @@
 package org.maproulette.utils
 
 import org.maproulette.framework.model._
-import org.maproulette.models._
 import org.maproulette.models.utils.ChallengeReads
 import play.api.libs.json.Reads
 import play.api.libs.oauth.RequestToken

--- a/app/org/maproulette/utils/Writers.scala
+++ b/app/org/maproulette/utils/Writers.scala
@@ -6,7 +6,6 @@
 package org.maproulette.utils
 
 import org.maproulette.framework.model._
-import org.maproulette.models._
 import org.maproulette.models.utils.ChallengeWrites
 import play.api.libs.json.Writes
 import play.api.libs.oauth.RequestToken

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,14 @@ lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 compileScalastyle := scalastyle.in(Compile).toTask("").value
 (scalastyleConfig in Compile) := baseDirectory.value / "conf/scalastyle-config.xml"
 
+// Setup the scalafix plugin
+inThisBuild(List(
+  semanticdbEnabled := true,
+  semanticdbOptions += "-P:semanticdb:synthetics:on",
+  semanticdbVersion := scalafixSemanticdb.revision,
+  scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value),
+))
+
 lazy val `MapRouletteV2` = (project in file(".")).enablePlugins(PlayScala, SbtWeb, SwaggerPlugin)
 
 swaggerDomainNameSpaces := Seq(
@@ -85,7 +93,8 @@ scalacOptions ++= Seq(
   // Show warning feature details in the console
   "-feature",
   // Enable routes file splitting
-  "-language:reflectiveCalls"
+  "-language:reflectiveCalls",
+  "-Wunused:imports"
 )
 
 javaOptions in Test ++= Option(System.getProperty("config.file")).map("-Dconfig.file=" + _).toSeq

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.6-PLAY2.8")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.4.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")

--- a/test/org/maproulette/PermissionsSpec.scala
+++ b/test/org/maproulette/PermissionsSpec.scala
@@ -9,7 +9,6 @@ import org.maproulette.data._
 import org.maproulette.framework.model.User
 import org.maproulette.utils.TestSpec
 import org.scalatest.BeforeAndAfterAll
-import org.scalatestplus.play.PlaySpec
 
 /**
   * @author mcuthbert

--- a/test/org/maproulette/cache/CacheSpec.scala
+++ b/test/org/maproulette/cache/CacheSpec.scala
@@ -11,7 +11,7 @@ import org.maproulette.data.{ItemType, ProjectType}
 import org.maproulette.models.BaseObject
 import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
-import play.api.libs.json.{DefaultWrites, JodaReads, JodaWrites, Json, Reads, Writes}
+import play.api.libs.json.{JodaReads, JodaWrites, Json, Reads, Writes}
 
 /**
   * @author cuthbertm

--- a/test/org/maproulette/framework/repository/ChallengeRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/ChallengeRepositorySpec.scala
@@ -9,7 +9,6 @@ import org.maproulette.framework.model.{Project, User, Challenge}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
 import org.maproulette.framework.util.{ChallengeRepoTag, FrameworkHelper}
-import org.maproulette.framework.service.VirtualProjectService
 
 import play.api.Application
 

--- a/test/org/maproulette/framework/repository/CommentRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/CommentRepositorySpec.scala
@@ -9,7 +9,7 @@ import org.maproulette.framework.model.{Comment, User}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.{BaseParameter, Operator}
 import org.maproulette.framework.service.CommentService
-import org.maproulette.framework.util.{CommentRepoTag, CommentTag, FrameworkHelper}
+import org.maproulette.framework.util.{CommentRepoTag, FrameworkHelper}
 import play.api.Application
 
 /**

--- a/test/org/maproulette/framework/repository/GroupMemberRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/GroupMemberRepositorySpec.scala
@@ -9,7 +9,7 @@ import org.maproulette.framework.model.{Group, GroupMember, MemberObject, User}
 import org.maproulette.data.{UserType, GroupType}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
-import org.maproulette.framework.repository.{GroupRepository, GroupMemberRepository}
+import org.maproulette.framework.repository.GroupMemberRepository
 import org.maproulette.framework.service.GroupService
 import org.maproulette.framework.util.{FrameworkHelper, GroupTag}
 import play.api.Application

--- a/test/org/maproulette/framework/repository/GroupRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/GroupRepositorySpec.scala
@@ -5,7 +5,7 @@
 
 package org.maproulette.framework
 
-import org.maproulette.framework.model.{Group, Project, User}
+import org.maproulette.framework.model.{Group, User}
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.BaseParameter
 import org.maproulette.framework.repository.{GroupRepository}

--- a/test/org/maproulette/framework/repository/NotificationRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/NotificationRepositorySpec.scala
@@ -6,8 +6,6 @@
 package org.maproulette.framework
 
 import org.maproulette.framework.model.{User, UserNotification}
-import org.maproulette.framework.psql.Query
-import org.maproulette.framework.psql.filter.BaseParameter
 import org.maproulette.framework.repository.NotificationRepository
 import org.maproulette.framework.service.NotificationService
 import org.maproulette.framework.util.{FrameworkHelper, NotificationTag}

--- a/test/org/maproulette/framework/repository/TaskClusterRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/TaskClusterRepositorySpec.scala
@@ -5,7 +5,6 @@
 
 package org.maproulette.framework.repository
 
-import java.util.UUID
 
 import org.maproulette.framework.model.{User, Task}
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}

--- a/test/org/maproulette/framework/repository/TaskHistoryRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/TaskHistoryRepositorySpec.scala
@@ -5,9 +5,7 @@
 
 package org.maproulette.framework.repository
 
-import java.util.UUID
 
-import org.maproulette.data._
 import org.maproulette.data.{Actions, TaskItem, ActionManager, TaskStatusSet}
 import org.maproulette.framework.model.{User, TaskLogEntry, Task}
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}

--- a/test/org/maproulette/framework/repository/TaskReviewRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/TaskReviewRepositorySpec.scala
@@ -5,9 +5,8 @@
 
 package org.maproulette.framework.repository
 
-import java.util.UUID
 
-import org.maproulette.framework.model.{User, Task}
+import org.maproulette.framework.model.User
 import org.maproulette.framework.util.{TaskReviewTag, FrameworkHelper}
 import play.api.Application
 

--- a/test/org/maproulette/framework/repository/UserRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/UserRepositorySpec.scala
@@ -11,7 +11,7 @@ import org.maproulette.framework.model.{User, UserMetrics, UserSettings, CustomB
 import org.maproulette.framework.psql.Query
 import org.maproulette.framework.psql.filter.{BaseParameter, Operator}
 import org.maproulette.framework.service.UserService
-import org.maproulette.framework.util.{FrameworkHelper, UserRepoTag, UserTag}
+import org.maproulette.framework.util.{FrameworkHelper, UserRepoTag}
 import play.api.Application
 import play.api.libs.oauth.RequestToken
 

--- a/test/org/maproulette/framework/repository/UserSavedObjectsRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/UserSavedObjectsRepositorySpec.scala
@@ -8,8 +8,7 @@ package org.maproulette.framework.repository
 import org.maproulette.framework.model.User
 import org.maproulette.framework.util.{
   FrameworkHelper,
-  UserSavedObjectsRepoTag,
-  UserSavedObjectsTag
+  UserSavedObjectsRepoTag
 }
 import play.api.Application
 

--- a/test/org/maproulette/framework/repository/VirtualProjectRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/VirtualProjectRepositorySpec.scala
@@ -7,7 +7,7 @@ package org.maproulette.framework.repository
 
 import org.maproulette.framework.model.{Project, User}
 import org.maproulette.framework.service.VirtualProjectService
-import org.maproulette.framework.util.{FrameworkHelper, VirtualProjectRepoTag, VirtualProjectTag}
+import org.maproulette.framework.util.{FrameworkHelper, VirtualProjectRepoTag}
 import play.api.Application
 
 /**

--- a/test/org/maproulette/framework/service/AchievementServiceSpec.scala
+++ b/test/org/maproulette/framework/service/AchievementServiceSpec.scala
@@ -5,12 +5,10 @@
 
 package org.maproulette.framework.service
 
-import org.maproulette.framework.model.{Achievement, User, Task, Challenge}
-import org.maproulette.data.{UserType, ProjectType}
+import org.maproulette.framework.model.{Achievement, User, Task}
 import org.maproulette.framework.util.{FrameworkHelper, UserTag}
 import play.api.Application
 import org.scalatestplus.mockito.MockitoSugar
-import org.mockito.Mockito._
 
 /**
   * @author nrotstan

--- a/test/org/maproulette/framework/service/ChallengeSnapshotServiceSpec.scala
+++ b/test/org/maproulette/framework/service/ChallengeSnapshotServiceSpec.scala
@@ -5,12 +5,8 @@
 
 package org.maproulette.framework.service
 
-import java.util.UUID
 
-import org.maproulette.framework.model._
-import org.maproulette.framework.psql.Query
 import org.maproulette.framework.util.{ChallengeSnapshotTag, FrameworkHelper}
-import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import org.maproulette.data.SnapshotManager
 import play.api.Application
 

--- a/test/org/maproulette/framework/service/DataServiceSpec.scala
+++ b/test/org/maproulette/framework/service/DataServiceSpec.scala
@@ -6,12 +6,9 @@
 package org.maproulette.framework.service
 
 import java.util.UUID
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
 
-import org.maproulette.session.{SearchParameters, SearchChallengeParameters, SearchReviewParameters}
+import org.maproulette.session.SearchParameters
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{GroupField, Grouping, Query}
 import org.maproulette.framework.util.{DataTag, FrameworkHelper}
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import play.api.Application

--- a/test/org/maproulette/framework/service/GroupServiceSpec.scala
+++ b/test/org/maproulette/framework/service/GroupServiceSpec.scala
@@ -5,7 +5,7 @@
 
 package org.maproulette.framework.service
 
-import org.maproulette.framework.model.{Group, GroupMember, MemberObject, User}
+import org.maproulette.framework.model.{Group, MemberObject, User}
 import org.maproulette.data.{UserType}
 import org.maproulette.framework.util.{FrameworkHelper, GroupTag}
 import play.api.Application

--- a/test/org/maproulette/framework/service/LeaderboardServiceSpec.scala
+++ b/test/org/maproulette/framework/service/LeaderboardServiceSpec.scala
@@ -9,18 +9,15 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{GroupField, Grouping, Query}
 import org.maproulette.framework.util.{LeaderboardTag, FrameworkHelper}
 import org.maproulette.framework.repository.UserRepository
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
-import org.maproulette.session.{SearchParameters, SearchLeaderboardParameters}
+import org.maproulette.session.SearchLeaderboardParameters
 import play.api.Application
-import javax.inject.Inject
 import org.joda.time.DateTime
 
 import play.api.db.Database
 import org.maproulette.jobs.utils.LeaderboardHelper
-import anorm.SqlParser._
 import anorm._
 import org.maproulette.Config
 

--- a/test/org/maproulette/framework/service/NotificationServiceSpec.scala
+++ b/test/org/maproulette/framework/service/NotificationServiceSpec.scala
@@ -7,8 +7,6 @@ package org.maproulette.framework
 
 import org.joda.time.DateTime
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.Query
-import org.maproulette.framework.psql.filter.BaseParameter
 import org.maproulette.framework.repository.NotificationRepository
 import org.maproulette.framework.service.NotificationService
 import org.maproulette.framework.util.{FrameworkHelper, NotificationTag}

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -6,12 +6,8 @@
 package org.maproulette.framework.service
 
 import java.util.UUID
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
-import play.api.libs.json._
 
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, Paging}
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}
 import org.maproulette.exception.{InvalidException, NotFoundException}
 import play.api.Application

--- a/test/org/maproulette/framework/service/TaskClusterServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskClusterServiceSpec.scala
@@ -6,8 +6,6 @@
 package org.maproulette.framework.service
 
 import java.util.UUID
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
 import play.api.libs.json._
 
 import org.maproulette.session.{
@@ -17,9 +15,8 @@ import org.maproulette.session.{
   SearchLocation
 }
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, Paging}
+import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}
-import org.maproulette.exception.NotFoundException
 import play.api.Application
 
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}

--- a/test/org/maproulette/framework/service/TaskReviewMetricsServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewMetricsServiceSpec.scala
@@ -6,12 +6,9 @@
 package org.maproulette.framework.service
 
 import java.util.UUID
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
 
 import org.maproulette.session.{SearchParameters, SearchChallengeParameters, SearchReviewParameters}
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{GroupField, Grouping, Query}
 import org.maproulette.framework.util.{TaskReviewTag, FrameworkHelper}
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import play.api.Application

--- a/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskReviewServiceSpec.scala
@@ -12,12 +12,9 @@ import play.api.libs.json.Json
 
 import org.maproulette.session.{
   SearchParameters,
-  SearchChallengeParameters,
-  SearchReviewParameters,
   SearchTaskParameters
 }
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{GroupField, Grouping, Query}
 import org.maproulette.framework.util.{TaskReviewTag, FrameworkHelper}
 import org.maproulette.models.dal.{ChallengeDAL, TaskDAL}
 import play.api.Application

--- a/test/org/maproulette/framework/service/TaskServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskServiceSpec.scala
@@ -6,12 +6,10 @@
 package org.maproulette.framework.service
 
 import java.util.UUID
-import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.FiniteDuration
 import play.api.libs.json._
 
 import org.maproulette.framework.model._
-import org.maproulette.framework.psql.{Query, Paging}
+import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.util.{TaskTag, FrameworkHelper}
 import org.maproulette.exception.NotFoundException
 import play.api.Application

--- a/test/org/maproulette/framework/service/TeamServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TeamServiceSpec.scala
@@ -8,14 +8,13 @@ package org.maproulette.framework.service
 import org.maproulette.framework.model.{
   TeamMember,
   Group,
-  GroupMember,
   MemberObject,
   User,
   Grant,
   Grantee,
   GrantTarget
 }
-import org.maproulette.data.{UserType, ProjectType}
+import org.maproulette.data.UserType
 import org.maproulette.framework.util.{FrameworkHelper, TeamTag}
 import org.maproulette.framework.psql.{Paging}
 import play.api.Application

--- a/test/org/maproulette/framework/service/UserSavedObjectsServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserSavedObjectsServiceSpec.scala
@@ -6,7 +6,6 @@
 package org.maproulette.framework.service
 
 import org.maproulette.framework.model.User
-import org.maproulette.framework.repository.UserSavedObjectsRepository
 import org.maproulette.framework.util.{FrameworkHelper, UserSavedObjectsTag}
 import play.api.Application
 

--- a/test/org/maproulette/framework/service/UserServiceSpec.scala
+++ b/test/org/maproulette/framework/service/UserServiceSpec.scala
@@ -5,7 +5,6 @@
 
 package org.maproulette.framework.service
 
-import java.util.UUID
 import org.maproulette.framework.model._
 import org.maproulette.framework.psql.filter._
 import org.maproulette.framework.psql.{OR, Paging, Query}

--- a/test/org/maproulette/models/TaskSpec.scala
+++ b/test/org/maproulette/models/TaskSpec.scala
@@ -7,7 +7,6 @@ package org.maproulette.framework.model
 
 import org.maproulette.framework.model.Task
 import org.scalatestplus.play.PlaySpec
-import org.joda.time.DateTime
 
 class TaskSpec() extends PlaySpec {
   "isValidStatusProgression" should {


### PR DESCRIPTION
In the spirit of reducing bugs and improving code quality, this patch adds the `scalafix` plugin and applies a single rule to verify that all files have removed unused imports. The scalafix rule is called `RemovedUnused` and in future patches if a file has an unused import, it will fail the (CI) build.

Developers can auto-apply fixes locally by running `sbt scalafixAll` and committing the changes.

In the future, more rules can be enabled and additional files fixed; the list of built-in rules is located here https://scalacenter.github.io/scalafix/docs/rules/overview.html

