### PR TITLE
modify bulk task status update into a build flow

### DIFF
--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -527,24 +527,39 @@ class TaskController @Inject() (
             params = p.copy(location = Some(SearchLocation(-180, -90, 180, 90)))
         }
         val (count, tasks) = this.taskClusterService.getTasksInBoundingBox(user, params, Paging(-1))
-        val challengeIds = params.challengeParams.challengeIds.getOrElse(List())
+        val challengeIds   = params.challengeParams.challengeIds.getOrElse(List())
 
         //update challenge status to building
         challengeIds.foreach(challengeId => {
-          this.dalManager.challenge.update(Json.obj("status" -> Challenge.STATUS_BUILDING, "statusMessage" -> Challenge.STATUS_MESSAGE_UPDATING_TASK_STATUSES), user)(challengeId)
+          this.dalManager.challenge.update(
+            Json.obj(
+              "status"        -> Challenge.STATUS_BUILDING,
+              "statusMessage" -> Challenge.STATUS_MESSAGE_UPDATING_TASK_STATUSES
+            ),
+            user
+          )(challengeId)
         })
 
         def resetStatuses(): Unit = {
-          challengeIds.foreach (challengeId => {
-            val challenge = this.serviceManager.challenge.retrieve (challengeId).get
+          challengeIds.foreach(challengeId => {
+            val challenge = this.serviceManager.challenge.retrieve(challengeId).get
 
             // We need to check if the Challenge status changed during the bulk task update
             // and ensure we don't overwrite it.
             // If it didn't get updated, change status to Ready.
             if (challenge.status.get == Challenge.STATUS_BUILDING) {
-              this.dalManager.challenge.update (Json.obj ("status" -> Challenge.STATUS_READY, "statusMessage" -> Challenge.STATUS_MESSAGE_NONE), user) (challengeId)
+              this.dalManager.challenge.update(
+                Json.obj(
+                  "status"        -> Challenge.STATUS_READY,
+                  "statusMessage" -> Challenge.STATUS_MESSAGE_NONE
+                ),
+                user
+              )(challengeId)
             } else {
-              this.dalManager.challenge.update (Json.obj ("statusMessage" -> Challenge.STATUS_MESSAGE_NONE), user) (challengeId)
+              this.dalManager.challenge.update(
+                Json.obj("statusMessage" -> Challenge.STATUS_MESSAGE_NONE),
+                user
+              )(challengeId)
             }
           })
         }

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -19,11 +19,12 @@ import org.maproulette.exception.{
   StatusMessage
 }
 import org.maproulette.framework.model._
-import org.maproulette.framework.model.{Challenge}
+import org.maproulette.framework.model.Challenge
 import org.maproulette.framework.psql.Paging
 import org.maproulette.framework.service.{ServiceManager, TagService, TaskClusterService}
 import org.maproulette.framework.mixins.TagsControllerMixin
 import org.maproulette.framework.repository.TaskRepository
+import org.maproulette.metrics.Metrics
 import org.maproulette.models.dal.mixin.TagDALMixin
 import org.maproulette.models.dal.{DALManager, TaskDAL}
 import org.maproulette.provider.osm._
@@ -527,9 +528,9 @@ class TaskController @Inject() (
             params = p.copy(location = Some(SearchLocation(-180, -90, 180, 90)))
         }
         val (count, tasks) = this.taskClusterService.getTasksInBoundingBox(user, params, Paging(-1))
-        val challengeIds   = params.challengeParams.challengeIds.getOrElse(List())
+        val challengeIds   = params.challengeParams.challengeIds.getOrElse(List()).distinct.sorted
 
-        //update challenge status to building
+        // Update challenge status to building
         challengeIds.foreach(challengeId => {
           this.dalManager.challenge.update(
             Json.obj(
@@ -564,19 +565,49 @@ class TaskController @Inject() (
           })
         }
 
-        Future(
-          try {
-            tasks.foreach(task => {
-              val taskJson = Json.obj("id" -> task.id, "status" -> newStatus)
-              this.dal.update(taskJson, user)(task.id)
-            })
+        val requestId     = request.id
+        val challengesStr = challengeIds.mkString(",")
 
+        Future {
+          logger.info(
+            "Starting bulkStatusChange for requestId={} challenges={} on {} tasks",
+            requestId,
+            challengesStr,
+            tasks.length
+          )
+          try {
+            Metrics.timer(s"bulkStatusChange_${requestId}_${challengesStr}") { () =>
+              tasks.foreach(task => {
+                val taskJson = Json.obj("id" -> task.id, "status" -> newStatus)
+                this.dal.update(taskJson, user)(task.id)
+              })
+            }
+          } finally {
+            logger.info(
+              "Finished running bulkStatusChange requestId={} challenges={} on {} tasks",
+              requestId,
+              challengesStr,
+              tasks.length
+            )
             resetStatuses()
-          } catch {
-            case e: Exception =>
-              resetStatuses()
           }
-        )
+        }.onComplete {
+          case Success(_) =>
+            logger.info(
+              "Successful bulkStatusChange update for requestId={} and challenges={} on {} tasks",
+              requestId,
+              challengesStr,
+              tasks.length
+            )
+          case Failure(e) =>
+            logger.warn(
+              "FAILED bulkStatusChange update for requestId={} and challenges={} on {} tasks",
+              requestId,
+              challengesStr,
+              tasks.length,
+              e
+            )
+        }
 
         Ok(Json.toJson(tasks.length))
       }

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -266,7 +266,7 @@ object Challenge extends CommonField {
   val STATUS_FINISHED         = 5
   val STATUS_DELETING_TASKS   = 6
 
-  val STATUS_MESSAGE_NONE     = ""
+  val STATUS_MESSAGE_NONE                   = ""
   val STATUS_MESSAGE_UPDATING_TASK_STATUSES = "Updating Task Statuses"
 
   // COOPERATIVE TYPES

--- a/app/org/maproulette/framework/model/Challenge.scala
+++ b/app/org/maproulette/framework/model/Challenge.scala
@@ -266,6 +266,9 @@ object Challenge extends CommonField {
   val STATUS_FINISHED         = 5
   val STATUS_DELETING_TASKS   = 6
 
+  val STATUS_MESSAGE_NONE     = ""
+  val STATUS_MESSAGE_UPDATING_TASK_STATUSES = "Updating Task Statuses"
+
   // COOPERATIVE TYPES
   val COOPERATIVE_NONE       = 0
   val COOPERATIVE_TAGS       = 1


### PR DESCRIPTION
Going to modify the bulk task status update endpoint to resolve immediately and allow tasks to be updated in a background process.  The challenge will be placed in a Building status until the process is complete.

Resolves https://github.com/osmlab/maproulette3/issues/1764, but the endpoint background process will still take the same amount of time.  This fix just allows the UI to respond to the process without throwing a frontend timeout error.

To be released with https://github.com/osmlab/maproulette3/pull/1812