### PR TITLE
Create the initial CaffeineCache implementation

### DIFF
--- a/app/org/maproulette/cache/BasicCache.scala
+++ b/app/org/maproulette/cache/BasicCache.scala
@@ -42,16 +42,7 @@ class BasicCache[Key, Value <: CacheObject[Key]](config: Config) extends Cache[K
     *
     * @return
     */
-  def size: Int = this.cache.size
-
-  /**
-    * True size is a little bit more accurate than size, however the performance will be a bit slower
-    * as this size will loop through all the objects in the cache and expire out any items that have
-    * expired. Thereby giving the true size at the end.
-    *
-    * @return
-    */
-  def trueSize: Int = this.cache.keysIterator.count(!isExpiredByKey(_))
+  def size(): Long = this.cache.size
 
   override protected def innerGet(key: Key): Option[BasicInnerValue[Key, Value]] =
     this.cache.get(key)

--- a/app/org/maproulette/cache/Cache.scala
+++ b/app/org/maproulette/cache/Cache.scala
@@ -48,20 +48,9 @@ trait Cache[Key, Value <: CacheObject[Key]] {
   def clear(): Unit
 
   /**
-    * The current size of the cache
-    *
-    * @return
+    * @return the current size of the cache
     */
-  def size: Int
-
-  /**
-    * True size is a little bit more accurate than size, however the performance will be a bit slower
-    * as this size will loop through all the objects in the cache and expire out any items that have
-    * expired. Thereby giving the true size at the end.
-    *
-    * @return
-    */
-  def trueSize: Int
+  def size(): Long
 
   /**
     * Adds an object to the cache, if cache limit has been reached, then will remove the oldest

--- a/app/org/maproulette/cache/CaffeineCache.scala
+++ b/app/org/maproulette/cache/CaffeineCache.scala
@@ -1,0 +1,92 @@
+package org.maproulette.cache
+
+import org.maproulette.Config
+import play.api.Logging
+
+class CaffeineCache[Key, Value <: CacheObject[Key]](config: Config)
+    extends Cache[Key, Value]
+    with Logging {
+  override implicit val cacheLimit: Int  = config.cacheLimit
+  override implicit val cacheExpiry: Int = config.cacheExpiry
+  val caffeineCache: com.github.blemale.scaffeine.Cache[Key, BasicInnerValue[Key, Value]] =
+    com.github.blemale.scaffeine.Scaffeine().build[Key, BasicInnerValue[Key, Value]]()
+
+  /**
+    * Checks if an item is cached or not
+    *
+    * @param key The id of the object to check to see if it is in the cache
+    * @return true if the item is found in the cache
+    */
+  override def isCached(key: Key): Boolean = caffeineCache.getIfPresent(key).nonEmpty
+
+  /**
+    * Fully clears the cache, this may not be applicable for non basic in memory caches
+    */
+  override def clear(): Unit = caffeineCache.invalidateAll()
+
+  /**
+    * @return the current size of the cache
+    */
+  override def size(): Long = caffeineCache.estimatedSize()
+
+  /**
+    * Adds an object to the cache, if cache limit has been reached, then will remove the oldest
+    * accessed item in the cache
+    *
+    * @param key   The object to add to the cache
+    * @param value You can add a custom expiry to a specific element in seconds
+    * @return The object put in the cache, or None if it could not be placed in the cache
+    */
+  override def add(key: Key, value: Value, localExpiry: Option[Int]): Option[Value] = {
+    if (localExpiry.nonEmpty) {
+      // NOTE: this code is a hot path and must log at debug to avoid filling the disk
+      logger.debug("CaffeineCache does not support localExpiry parameter")
+    }
+    caffeineCache.put(key, BasicInnerValue(key, value, null, null))
+    Some(value)
+  }
+
+  /**
+    * Finds an object from the cache based on the name instead of the id
+    *
+    * @param name The name of the object you wish to find
+    * @return The object from the cache, None if not found
+    */
+  override def find(name: String): Option[Value] = {
+    // This method intends to search the **entire cache** for a value with a specific name.
+    // It's extremely inefficient and for now it's unsupported, until we find exactly why this is needed.
+    throw new UnsupportedOperationException(
+      "CaffeineCache.find by string (not a key) is not supported"
+    )
+  }
+
+  /**
+    * Remove an object from the cache based on the name
+    *
+    * @param name The name of the object to be removed
+    * @return The object removed from the cache, or None if it could not be removed from the cache,
+    *         or was not originally in the cache
+    */
+  override def remove(name: String): Option[Value] = {
+    // This method intends to search the **entire cache** for a value with a specific name.
+    // It's extremely inefficient and for now it's unsupported, until we find exactly why this is needed.
+    throw new UnsupportedOperationException(
+      "CaffeineCache.remove by string (not a key) is not supported"
+    )
+  }
+
+  override def remove(id: Key): Option[Value] = {
+    caffeineCache.getIfPresent(id) match {
+      case Some(res) => {
+        caffeineCache.invalidate(id)
+        Some(res.value)
+      }
+      case _ => None
+    }
+  }
+
+  override protected def innerGet(key: Key): Option[BasicInnerValue[Key, Value]] = {
+    // If something calls this method we really need to throw an exception.
+    throw new UnsupportedOperationException("CaffeineCache innerGet is not supported")
+  }
+}

--- a/app/org/maproulette/cache/RedisCache.scala
+++ b/app/org/maproulette/cache/RedisCache.scala
@@ -49,18 +49,11 @@ class RedisCache[Key, Value <: CacheObject[Key]](config: Config, prefix: String)
   }
 
   /**
-    * In Redis true size and size would be the same
-    *
-    * @return
-    */
-  override def trueSize: Int = this.size
-
-  /**
     * Retrieve all the keys and then just count it
     *
     * @return
     */
-  override def size: Int = this.withClient { client =>
+  override def size(): Long = this.withClient { client =>
     client.keys[String]().get.size
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ libraryDependencies ++= Seq(
   filters,
   guice,
 
+
   // NOTE: Be careful upgrading sangria and play-json as binary incompatiblities can break graphql and the entire UI.
   //       See the compatibility matrix here https://github.com/sangria-graphql/sangria-play-json
   "org.sangria-graphql"     %% "sangria-play-json"  % "2.0.1",
@@ -84,7 +85,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"       %% "akka-cluster-tools" % "2.6.19",
   "com.typesafe.akka"       %% "akka-cluster-typed" % "2.6.19",
   "com.typesafe.akka"       %% "akka-slf4j"         % "2.6.19",
-  "net.debasishg"           %% "redisclient"        % "3.42"
+  "net.debasishg"           %% "redisclient"        % "3.42",
+  "com.github.blemale"      %% "scaffeine"          % "5.2.1"
 )
 
 resolvers ++= Seq(

--- a/test/org/maproulette/cache/CacheSpec.scala
+++ b/test/org/maproulette/cache/CacheSpec.scala
@@ -183,10 +183,13 @@ class CacheSpec extends PlaySpec with JodaWrites with JodaReads {
       theCache.clear()
       cacheObject(1L, "test1")
       theCache.addObject(TestBaseObject(2L, "test2"), Some(1))
-      Thread.sleep(2000)
-      theCache.trueSize mustEqual 1
-      Thread.sleep(5000)
-      theCache.trueSize mustEqual 0
+
+      // The overridden cache expiry is 5 seconds, sleep at least that long.
+      Thread.sleep(6000)
+
+      // The Cache.scala actually does a prune of the cache on EVERY GET...  so try to get the item
+      // in the cache expect None since it's past the expiry.
+      theCache.get(1L) mustBe None
     }
   }
 


### PR DESCRIPTION
This is the initial implementation of a `CaffeineCache` (caffeine is a highly performant in-memory cache) that will soon replace the `BasicCache`. The `BasicCache` was shown to be the limiter in several profiles and lacks a priority queue for items with expiry.

The new dependencies have been added and the code will compile, however, this is NOT REPLACING the `BasicCache` yet. More profiles and tweaks need to be done.