### PR TITLE
Create the CaffeineCache implementation

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -95,6 +95,7 @@ jobs:
         echo '}' >> ./conf/dev.conf
         echo 'maproulette {' >> ./conf/dev.conf
         echo '  debug=true' >> ./conf/dev.conf
+        echo '  caching.type="caffeine"' >> ./conf/dev.conf
         echo '  bootstrap=true' >> ./conf/dev.conf
         echo '  super.key="1234"' >> ./conf/dev.conf
         echo '  super.accounts=""' >> ./conf/dev.conf

--- a/app/org/maproulette/Config.scala
+++ b/app/org/maproulette/Config.scala
@@ -188,6 +188,7 @@ class Config @Inject() (implicit val configuration: Configuration) {
     this.config.getOptional[Boolean](Config.KEY_SIGNIN).getOrElse(Config.DEFAULT_SIGNIN)
 
   //caching properties
+  // TODO(ljdelight): After the caffeine cache is better tested, use it as the default cache.
   lazy val cacheType: String =
     this.config.getOptional[String](Config.KEY_CACHING_TYPE).getOrElse(CacheManager.BASIC_CACHE)
   lazy val cacheLimit: Int = this.config

--- a/app/org/maproulette/cache/BasicCache.scala
+++ b/app/org/maproulette/cache/BasicCache.scala
@@ -42,16 +42,7 @@ class BasicCache[Key, Value <: CacheObject[Key]](config: Config) extends Cache[K
     *
     * @return
     */
-  def size: Int = this.cache.size
-
-  /**
-    * True size is a little bit more accurate than size, however the performance will be a bit slower
-    * as this size will loop through all the objects in the cache and expire out any items that have
-    * expired. Thereby giving the true size at the end.
-    *
-    * @return
-    */
-  def trueSize: Int = this.cache.keysIterator.count(!isExpiredByKey(_))
+  def size(): Long = this.cache.size
 
   override protected def innerGet(key: Key): Option[BasicInnerValue[Key, Value]] =
     this.cache.get(key)

--- a/app/org/maproulette/cache/Cache.scala
+++ b/app/org/maproulette/cache/Cache.scala
@@ -48,20 +48,9 @@ trait Cache[Key, Value <: CacheObject[Key]] {
   def clear(): Unit
 
   /**
-    * The current size of the cache
-    *
-    * @return
+    * @return the current size of the cache
     */
-  def size: Int
-
-  /**
-    * True size is a little bit more accurate than size, however the performance will be a bit slower
-    * as this size will loop through all the objects in the cache and expire out any items that have
-    * expired. Thereby giving the true size at the end.
-    *
-    * @return
-    */
-  def trueSize: Int
+  def size(): Long
 
   /**
     * Adds an object to the cache, if cache limit has been reached, then will remove the oldest
@@ -113,13 +102,6 @@ trait Cache[Key, Value <: CacheObject[Key]] {
   def remove(id: Key): Option[Value]
 
   protected def innerGet(key: Key): Option[BasicInnerValue[Key, Value]]
-
-  protected def isExpiredByKey(key: Key): Boolean = synchronized {
-    this.innerGet(key) match {
-      case Some(value) => isExpired(value)
-      case None        => true
-    }
-  }
 
   /**
     * Checks to see if the item has expired and should be removed from the cache. If it finds the

--- a/app/org/maproulette/cache/CaffeineCache.scala
+++ b/app/org/maproulette/cache/CaffeineCache.scala
@@ -1,0 +1,139 @@
+package org.maproulette.cache
+
+import com.github.blemale.scaffeine.Scaffeine
+import org.maproulette.Config
+import play.api.Logging
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+
+class CaffeineCache[Key, Value <: CacheObject[Key]](config: Config)
+    extends Cache[Key, Value]
+    with Logging {
+  override implicit val cacheLimit: Int  = config.cacheLimit
+  override implicit val cacheExpiry: Int = config.cacheExpiry
+  val caffeineCache: com.github.blemale.scaffeine.Cache[Key, BasicInnerValue[Key, Value]] =
+    Scaffeine()
+      .recordStats()
+      .expireAfterAccess(FiniteDuration(config.cacheExpiry, TimeUnit.SECONDS))
+      .maximumSize(config.cacheLimit)
+      .build[Key, BasicInnerValue[Key, Value]]()
+
+  /**
+    * Checks if an item is cached or not
+    *
+    * @param key The id of the object to check to see if it is in the cache
+    * @return true if the item is found in the cache
+    */
+  override def isCached(key: Key): Boolean = caffeineCache.getIfPresent(key).nonEmpty
+
+  /**
+    * Fully clears the cache, this may not be applicable for non basic in memory caches
+    */
+  override def clear(): Unit = caffeineCache.invalidateAll()
+
+  /**
+    * @return the current size of the cache
+    */
+  override def size(): Long = caffeineCache.estimatedSize()
+
+  /**
+    * Adds an object to the cache, if cache limit has been reached, then will remove the oldest
+    * accessed item in the cache
+    *
+    * @param key   The object to add to the cache
+    * @param value You can add a custom expiry to a specific element in seconds
+    * @return The object put in the cache, or None if it could not be placed in the cache
+    */
+  override def add(key: Key, value: Value, localExpiry: Option[Int]): Option[Value] = {
+    if (localExpiry.nonEmpty) {
+      // NOTE: this code is a hot path and must log at debug to avoid filling the disk
+      logger.debug("CaffeineCache does not support localExpiry parameter")
+    }
+    caffeineCache.put(key, BasicInnerValue(key, value, null, null))
+    Some(value)
+  }
+
+  /**
+    * Search the cache's values and find the first based on the name.
+    * IMPORTANT NOTE: There may be multiple values in the cache that match, and only the FIRST is returned.
+    *
+    * @param name The name of the object you wish to find
+    * @return The object from the cache, None if not found
+    */
+  override def find(name: String): Option[Value] = {
+    // This method searches the **entire cache** for a value with a specific name.
+    logger.debug(s"INEFFICIENT SEARCH: Checking entire cache values for one matching '$name'")
+    this.caffeineCache
+      .asMap()
+      .values
+      .find(it => {
+        name.equals(it.value.name)
+      }) match {
+      case Some(it) => Some(it.value)
+      case None     => None
+    }
+  }
+
+  /**
+    * Search the cache's values and remove the first that matches the name.
+    * IMPORTANT NOTE: There may be multiple values in the cache that match, and only the FIRST is removed.
+    *
+    * @param name The name of the object to be removed
+    * @return The object removed from the cache, or None if it could not be removed from the cache,
+    *         or was not originally in the cache
+    */
+  override def remove(name: String): Option[Value] = {
+    // This method intends to search the **entire cache** for a value with a specific name.
+    logger.debug(
+      s"INEFFICIENT SEARCH: Checking entire cache values for one matching '$name' to remove"
+    )
+    this.caffeineCache
+      .asMap()
+      .values
+      .find(it => {
+        name.equals(it.value.name)
+      }) match {
+      case Some(it) => {
+        this.caffeineCache.invalidate(it.key)
+        Some(it.value)
+      }
+      case None => None
+    }
+  }
+
+  override def remove(id: Key): Option[Value] = {
+    caffeineCache.getIfPresent(id) match {
+      case Some(res) =>
+        caffeineCache.invalidate(id)
+        Some(res.value)
+      case _ => None
+    }
+  }
+
+  override def get(key: Key): Option[Value] = {
+    caffeineCache.getIfPresent(key) match {
+      case Some(res) => Some(res.value)
+      case _         => None
+    }
+  }
+
+  /**
+    * Unsupported for the CaffeineCache and this will raise an exception. The only caller of 'innerGet' is in the
+    * base Cache interface, and the CaffeineCache overrides that method.
+    */
+  override protected def innerGet(key: Key): Option[BasicInnerValue[Key, Value]] = {
+    throw new UnsupportedOperationException("CaffeineCache innerGet is not supported")
+  }
+
+  /**
+    * Unsupported for the CaffeineCache and this will raise an exception. The only caller of 'isExpired' is in the
+    * base Cache interface, and the CaffeineCache overrides that method.
+    */
+  override protected def isExpired(value: BasicInnerValue[Key, Value]): Boolean = {
+    // The expiry is internal to caffeine and the value is not exposed.
+    throw new UnsupportedOperationException(
+      "CaffeineCache.isExpired is not supported"
+    )
+  }
+}

--- a/app/org/maproulette/cache/RedisCache.scala
+++ b/app/org/maproulette/cache/RedisCache.scala
@@ -49,18 +49,11 @@ class RedisCache[Key, Value <: CacheObject[Key]](config: Config, prefix: String)
   }
 
   /**
-    * In Redis true size and size would be the same
-    *
-    * @return
-    */
-  override def trueSize: Int = this.size
-
-  /**
     * Retrieve all the keys and then just count it
     *
     * @return
     */
-  override def size: Int = this.withClient { client =>
+  override def size(): Long = this.withClient { client =>
     client.keys[String]().get.size
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ libraryDependencies ++= Seq(
   filters,
   guice,
 
+
   // NOTE: Be careful upgrading sangria and play-json as binary incompatiblities can break graphql and the entire UI.
   //       See the compatibility matrix here https://github.com/sangria-graphql/sangria-play-json
   "org.sangria-graphql"     %% "sangria-play-json"  % "2.0.1",
@@ -84,7 +85,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"       %% "akka-cluster-tools" % "2.6.19",
   "com.typesafe.akka"       %% "akka-cluster-typed" % "2.6.19",
   "com.typesafe.akka"       %% "akka-slf4j"         % "2.6.19",
-  "net.debasishg"           %% "redisclient"        % "3.42"
+  "net.debasishg"           %% "redisclient"        % "3.42",
+  "com.github.blemale"      %% "scaffeine"          % "5.2.1"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
This is the implementation of a `CaffeineCache` (caffeine is a highly performant in-memory cache) that can be used based on the conf. The `BasicCache` was shown to be a limiter in several profiles and lacks a priority queue for item expiry.

Use the more performant cache by setting `maproulette.caching.type = "caffeine"` in the conf file. At this time the default will remain the BasicCache until this gets more testing.