### PR TITLE
Use only sonatypeOss releases resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,11 +89,7 @@ libraryDependencies ++= Seq(
   "com.github.blemale"      %% "scaffeine"          % "5.2.1"
 )
 
-resolvers ++= Seq(
-  Resolver.bintrayRepo("scalaz", "releases"),
-  "Atlassian Releases" at "https://maven.atlassian.com/public/",
-  Resolver.sonatypeRepo("snapshots")
-)
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 scalacOptions ++= Seq(
   // Show warning feature details in the console

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,5 @@
 logLevel := Level.Warn
 
-// The Typesafe repository
-resolvers ++= Seq(
-  Resolver.bintrayRepo("scalaz", "releases"),
-  Resolver.bintrayIvyRepo("iheartradio", "sbt-plugins")
-)
-
 addDependencyTreePlugin
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")


### PR DESCRIPTION
Bintray and atlassian are not needed, and snapshot jars should be avoided.