### PR TITLE
scalastyle: Switch to com.beautiful-scala:sbt-scalastyle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,9 @@ scalaVersion := "2.13.9"
 
 packageName in Universal := "MapRouletteAPI"
 
-lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
-
-compileScalastyle := scalastyle.in(Compile).toTask("").value
-(scalastyleConfig in Compile) := baseDirectory.value / "conf/scalastyle-config.xml"
+// Configure scalastyle. This does not run during compile, run it with 'sbt scalastyle' or 'sbt test:scalastyle'.
+Compile / scalastyleConfig := baseDirectory.value / "conf/scalastyle-config.xml"
+Test / scalastyleConfig := baseDirectory.value / "conf/scalastyle-config.xml"
 
 // Setup the scalafix plugin
 inThisBuild(List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.beautiful-scala" %% "sbt-scalastyle" % "1.5.1")
 
 addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.6-PLAY2.8")
 


### PR DESCRIPTION
The sbt plugin org.scalastyle:scalastyle-sbt-plugin is deprecated and replaced by [com.beautiful-scala:sbt-scalastyle](https://github.com/beautiful-scala/scalastyle).