### PR TITLE
Fix typos in routes files

### DIFF
--- a/conf/v2_route/bundle.api
+++ b/conf/v2_route/bundle.api
@@ -25,7 +25,7 @@
 #       $ref: '#/definitions/TaskBundle'
 ###
 POST    /taskBundle                                 @org.maproulette.framework.controller.TaskBundleController.createTaskBundle
-##
+###
 # tags: [ Bundle ]
 # summary: Gets a Task Bundle
 # consumes: [ application/json ]
@@ -52,7 +52,7 @@ POST    /taskBundle                                 @org.maproulette.framework.c
 #     required: true
 ###
 GET     /taskBundle/:id                             @org.maproulette.framework.controller.TaskBundleController.getTaskBundle(id:Long)
-##
+###
 # tags: [ Bundle ]
 # summary: Deletes a Task Bundle
 # consumes: [ application/json ]
@@ -77,7 +77,7 @@ GET     /taskBundle/:id                             @org.maproulette.framework.c
 #     in: query
 ###
 DELETE     /taskBundle/:id                          @org.maproulette.framework.controller.TaskBundleController.deleteTaskBundle(id:Long, primaryId:Option[Long])
-##
+###
 # tags: [ Bundle ]
 # summary: Unbundles tasks from Task Bundle
 # consumes: [ application/json ]

--- a/conf/v2_route/leaderboard.api
+++ b/conf/v2_route/leaderboard.api
@@ -71,6 +71,7 @@ GET     /data/user/leaderboard                      @org.maproulette.framework.c
 #     description: How many results before and after the found user to return
 ###
 GET     /data/user/:userId/leaderboard              @org.maproulette.framework.controller.LeaderboardController.getLeaderboardForUser(userId:Long, bracket:Int ?= 0)
+###
 # tags: [ Leaderboard ]
 # summary: Gets the top challenges worked on by the user
 # produces: [ application/json ]

--- a/conf/v2_route/user.api
+++ b/conf/v2_route/user.api
@@ -214,6 +214,8 @@ PUT     /user/:userId/apikey                        @org.maproulette.framework.c
 #     description: Used in conjunction with the limit parameter to page through X number of responses.
 ###
 GET     /users/find/:username                          @org.maproulette.framework.controller.UserController.searchUserByOSMUsername(username:String, limit:Int ?= 10)
+# This one is documented by the above route
+### NoDocs ###
 GET     /users/find                                    @org.maproulette.framework.controller.UserController.searchUserByOSMUsername(username:String ?= "", limit:Int ?= 10)
 ###
 # tags: [ User ]


### PR DESCRIPTION
There were some routes with '##' for their documentation instead of '###' (2 vs 3 hashes), causing the docs to not be included in the swagger-ui and placing them in the 'generated' tag grouping.

The 'generated' tag is now empty :-)