### PR TITLE
Support setting cache type based on env MR_CACHING_TYPE

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -278,6 +278,7 @@ maproulette {
   }
   caching {
     type="Basic"
+    type=${?MR_CACHING_TYPE}
     cacheLimit=10000
     cacheExpiry=900
     redis.resetOnStart=false

--- a/conf/dev.conf.example
+++ b/conf/dev.conf.example
@@ -13,7 +13,7 @@ akka {
   # Refer to the manual for akka logging options
   # https://doc.akka.io/docs/akka/current/logging.html
   loggers = ["akka.event.slf4j.Slf4jLogger"]
-  loglevel = "WARN"
+  loglevel = "WARNING"
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   actor {
     debug {


### PR DESCRIPTION
The `maproulette.caching.type` can be set via conf changes or by setting MR_CACHING_TYPE=<cacheType> env variable.