### PR TITLE
Fix warnings for "Auto-application to `()` is deprecated"

### DIFF
--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -47,7 +47,7 @@ class AuthController @Inject() (
     */
   def authenticate(): Action[AnyContent] = Action.async { implicit request =>
     MPExceptionUtil.internalAsyncExceptionCatcher { () =>
-      val p        = Promise[Result]
+      val p        = Promise[Result]()
       val redirect = request.getQueryString("redirect").getOrElse("")
       request.getQueryString("oauth_verifier") match {
         case Some(verifier) =>
@@ -119,7 +119,7 @@ class AuthController @Inject() (
 
   def signIn(redirect: String): Action[AnyContent] = Action.async { implicit request =>
     MPExceptionUtil.internalAsyncExceptionCatcher { () =>
-      val p = Promise[Result]
+      val p = Promise[Result]()
       request.body.asFormUrlEncoded match {
         case Some(data) =>
           val username = data.getOrElse("signInUsername", ArrayBuffer("")).mkString

--- a/app/org/maproulette/controllers/OSMChangesetController.scala
+++ b/app/org/maproulette/controllers/OSMChangesetController.scala
@@ -51,7 +51,7 @@ class OSMChangesetController @Inject() (
             }
           },
           element => {
-            val p = Promise[Result]
+            val p = Promise[Result]()
             val future = changeType match {
               case OSMChangesetController.CHANGETYPE_OSMCHANGE =>
                 val updates = element.map(tagChange => {
@@ -97,7 +97,7 @@ class OSMChangesetController @Inject() (
           }
         },
         element => {
-          val p = Promise[Result]
+          val p = Promise[Result]()
           // For now just support creation of new geometries
           changeService.getOsmChange(element, None) onComplete {
             case Success(res) =>

--- a/app/org/maproulette/controllers/api/ChallengeController.scala
+++ b/app/org/maproulette/controllers/api/ChallengeController.scala
@@ -1071,9 +1071,9 @@ class ChallengeController @Inject() (
       rebuild: Boolean
   ): Action[AnyContent] = Action.async { implicit request =>
     this.sessionManager.authenticatedFutureRequest { implicit user =>
-      val result  = Promise[Result]
+      val result  = Promise[Result]()
       val baseURL = s"https://raw.githubusercontent.com/$username/$repo/master/${name}_";
-      this.wsClient.url(s"${baseURL}create.json").get onComplete {
+      this.wsClient.url(s"${baseURL}create.json").get() onComplete {
         case Success(response) =>
           try {
             // inject the info link into the challenge

--- a/app/org/maproulette/controllers/api/TaskController.scala
+++ b/app/org/maproulette/controllers/api/TaskController.scala
@@ -624,7 +624,7 @@ class TaskController @Inject() (
     this.sessionManager.authenticatedFutureRequest { implicit user =>
       this.dal.retrieveById(taskId) match {
         case Some(t) =>
-          val promise = Promise[Result]
+          val promise = Promise[Result]()
           this.dal.matchToOSMChangeSet(t, user, false) onComplete {
             case Success(response) => promise success Ok(Json.toJson(t))
             case Failure(error)    => promise failure error
@@ -646,7 +646,7 @@ class TaskController @Inject() (
             }
           },
           element => {
-            val p = Promise[Result]
+            val p = Promise[Result]()
 
             val requestReview = request.getQueryString("requestReview") match {
               case Some(v) => Some(v.toBoolean)

--- a/app/org/maproulette/exception/MPExceptionUtil.scala
+++ b/app/org/maproulette/exception/MPExceptionUtil.scala
@@ -57,7 +57,7 @@ object MPExceptionUtil {
     * @return Future[Result]
     */
   def internalAsyncExceptionCatcher(block: () => Future[Result]): Future[Result] = {
-    val p = Promise[Result]
+    val p = Promise[Result]()
     Try(block()) match {
       case Success(f) =>
         f onComplete {

--- a/app/org/maproulette/framework/controller/ChallengeSnapshotController.scala
+++ b/app/org/maproulette/framework/controller/ChallengeSnapshotController.scala
@@ -140,10 +140,10 @@ class ChallengeSnapshotController @Inject() (
       val priorityActions = snapshot.priorityActions.get
 
       s"${snapshot.created},${snapshot.id},${snapshot.itemId},${snapshot.name},${snapshot.status.getOrElse("")}," +
-        snapshot.actions.get.values.mkString(",") + "," +
-        priorityActions(Challenge.PRIORITY_HIGH.toString).values.mkString(",") + "," +
-        priorityActions(Challenge.PRIORITY_MEDIUM.toString).values.mkString(",") + "," +
-        priorityActions(Challenge.PRIORITY_LOW.toString).values.mkString(",")
+        snapshot.actions.get.values().mkString(",") + "," +
+        priorityActions(Challenge.PRIORITY_HIGH.toString).values().mkString(",") + "," +
+        priorityActions(Challenge.PRIORITY_MEDIUM.toString).values().mkString(",") + "," +
+        priorityActions(Challenge.PRIORITY_LOW.toString).values().mkString(",")
     })
   }
 }

--- a/app/org/maproulette/framework/controller/UserController.scala
+++ b/app/org/maproulette/framework/controller/UserController.scala
@@ -185,7 +185,7 @@ class UserController @Inject() (
     */
   def refreshProfile(osmUserId: Long): Action[AnyContent] = Action.async { implicit request =>
     sessionManager.authenticatedFutureRequest { implicit user =>
-      val p = Promise[Result]
+      val p = Promise[Result]()
       this.serviceManager.user.retrieveByOSMId(osmUserId) match {
         case Some(u) =>
           sessionManager.refreshProfile(u.osmProfile.requestToken, user) onComplete {

--- a/app/org/maproulette/framework/psql/filter/Parameter.scala
+++ b/app/org/maproulette/framework/psql/filter/Parameter.scala
@@ -230,7 +230,7 @@ case class FuzzySearchParameter(
       )"""
   }
 
-  override def parameters(): List[NamedParameter] = List(Symbol(getKey) -> value)
+  override def parameters(): List[NamedParameter] = List(Symbol(getKey()) -> value)
 }
 
 object FilterParameter {

--- a/app/org/maproulette/framework/service/ChallengeService.scala
+++ b/app/org/maproulette/framework/service/ChallengeService.scala
@@ -79,7 +79,7 @@ class ChallengeService @Inject() (
         ),
         BaseParameter(
           Challenge.FIELD_PARENT_ID,
-          user.managedProjectIds,
+          user.managedProjectIds(),
           Operator.IN,
           table = Some(Challenge.TABLE)
         )

--- a/app/org/maproulette/jobs/SchedulerActor.scala
+++ b/app/org/maproulette/jobs/SchedulerActor.scala
@@ -841,7 +841,7 @@ object SchedulerActor {
   private val TWELVE_MONTHS = 12
   private val ALL_TIME      = -1
 
-  def props = Props[SchedulerActor]
+  def props = Props[SchedulerActor]()
 
   case class RunJob(name: String, action: String = "")
 

--- a/app/org/maproulette/models/dal/TaskDAL.scala
+++ b/app/org/maproulette/models/dal/TaskDAL.scala
@@ -858,7 +858,7 @@ class TaskDAL @Inject() (
   def matchToOSMChangeSet(task: Task, user: User, immediate: Boolean = true)(
       implicit c: Option[Connection] = None
   ): Future[Boolean] = {
-    val result = Promise[Boolean]
+    val result = Promise[Boolean]()
     if (config.allowMatchOSM) {
       task.status match {
         case Some(Task.STATUS_FIXED) =>
@@ -930,7 +930,7 @@ class TaskDAL @Inject() (
     * @return A list of sorted changesets
     */
   private def getSortedChangeList(statusAction: StatusActionItem): Future[Seq[Changeset]] = {
-    val result        = Promise[Seq[Changeset]]
+    val result        = Promise[Seq[Changeset]]()
     val format        = "YYYY-MM-dd'T'HH:mm:ss'Z'"
     val fixedTimeDiff = statusAction.created.getMillis
     val prevHours =

--- a/app/org/maproulette/provider/KeepRightProvider.scala
+++ b/app/org/maproulette/provider/KeepRightProvider.scala
@@ -130,7 +130,7 @@ class KeepRightProvider @Inject() (
 
   // This will create a challenge for each KeepRight Check and each country
   def integrate(checkIDs: List[Int] = List.empty, bounding: KeepRightBox): Future[Boolean] = {
-    val p = Promise[Boolean]
+    val p = Promise[Boolean]()
     val cidList = URLEncoder.encode(
       this.errorList
         .filter(cid => checkIDs.isEmpty || checkIDs.contains(cid.id))

--- a/app/org/maproulette/provider/osm/ChangesetProvider.scala
+++ b/app/org/maproulette/provider/osm/ChangesetProvider.scala
@@ -40,7 +40,7 @@ class ChangesetProvider @Inject() (
   import scala.concurrent.ExecutionContext.Implicits.global
 
   def getVersionedChange(tagChanges: List[TagChange]): Future[List[VersionedObject]] = {
-    val p = Promise[List[VersionedObject]]
+    val p = Promise[List[VersionedObject]]()
     this.conflateTagChanges(tagChanges) onComplete {
       case Success(res) => p success res.map(_._1)
       case Failure(f)   => p failure f
@@ -56,7 +56,7 @@ class ChangesetProvider @Inject() (
     * @return
     */
   def testTagChange(tagChanges: List[TagChange]): Future[List[TagChangeResult]] = {
-    val p = Promise[List[TagChangeResult]]
+    val p = Promise[List[TagChangeResult]]()
     this.conflateTagChanges(tagChanges) onComplete {
       case Success(res) => p success res.map(_._2)
       case Failure(f)   => p failure f
@@ -77,7 +77,7 @@ class ChangesetProvider @Inject() (
       accessToken: RequestToken,
       taskId: Option[Long] = None
   )(implicit c: Option[Connection] = None): Future[Elem] = {
-    val p = Promise[Elem]
+    val p = Promise[Elem]()
     // create the new changeset
     this.createChangeset(changeSetComment, accessToken) onComplete {
       case Success(changesetId) =>
@@ -137,7 +137,7 @@ class ChangesetProvider @Inject() (
     * @return The osmChange XML
     */
   def getOsmChange(change: OSMChange, changeSetId: Option[Int]): Future[Elem] = {
-    val changePromise = Promise[Elem]
+    val changePromise = Promise[Elem]()
     val osmCreates = change.creates match {
       case Some(creates) =>
         <create>
@@ -146,7 +146,7 @@ class ChangesetProvider @Inject() (
       case None => NodeSeq.Empty
     }
 
-    val updatesPromise = Promise[NodeSeq]
+    val updatesPromise = Promise[NodeSeq]()
     val osmUpdates = change.updates match {
       case Some(updates) =>
         // Only support tag changes for now
@@ -198,7 +198,7 @@ class ChangesetProvider @Inject() (
       relations <- relationService.get(relations.map(_.osmId))
     } yield (nodes, ways, relations)
 
-    val p = Promise[List[(VersionedObject, TagChangeResult)]]
+    val p = Promise[List[(VersionedObject, TagChangeResult)]]()
     results onComplete {
       case Success(r) =>
         val changes = (r._1 ++ r._2 ++ r._3).flatMap(feature => {
@@ -271,7 +271,7 @@ class ChangesetProvider @Inject() (
   private def checkResult[T](
       block: WSResponse => T
   )(implicit req: Future[WSResponse], url: String): Future[T] = {
-    val p = Promise[T]
+    val p = Promise[T]()
     req onComplete {
       case Success(res) =>
         res.status match {

--- a/app/org/maproulette/provider/osm/objects/ObjectProvider.scala
+++ b/app/org/maproulette/provider/osm/objects/ObjectProvider.scala
@@ -37,7 +37,7 @@ trait ObjectProvider[T <: VersionedObject] {
     * @return A list of VersionedObjects that is basically every version of the object
     */
   def getObjectHistory(id: Long, osmType: OSMType): Future[List[T]] = {
-    val p = Promise[List[T]]
+    val p = Promise[List[T]]()
     if (id < 0) {
       p success List.empty
     } else {
@@ -61,7 +61,7 @@ trait ObjectProvider[T <: VersionedObject] {
     * @return
     */
   protected def getFromType(ids: List[Long], osmType: OSMType): Future[List[T]] = {
-    val p = Promise[List[T]]
+    val p = Promise[List[T]]()
     if (ids.isEmpty) {
       p success List.empty
     } else {

--- a/app/org/maproulette/provider/websockets/WebSocketProvider.scala
+++ b/app/org/maproulette/provider/websockets/WebSocketProvider.scala
@@ -27,7 +27,7 @@ import akka.actor._
   */
 @Singleton
 class WebSocketProvider @Inject() (implicit system: ActorSystem) {
-  val publisher = system.actorOf(Props[WebSocketPublisher], "publisher")
+  val publisher = system.actorOf(Props[WebSocketPublisher](), "publisher")
 
   def sendMessage(message: WebSocketMessages.ServerMessage): Unit = {
     publisher ! message

--- a/app/org/maproulette/session/SessionManager.scala
+++ b/app/org/maproulette/session/SessionManager.scala
@@ -69,7 +69,7 @@ class SessionManager @Inject() (
     * @return A Future which will contain the user
     */
   def retrieveUser(verifier: String)(implicit request: Request[AnyContent]): Future[User] = {
-    val p = Promise[User]
+    val p = Promise[User]()
     this.sessionTokenPair match {
       case Some(pair) =>
         this.oauth.retrieveAccessToken(pair, verifier) match {
@@ -137,7 +137,7 @@ class SessionManager @Inject() (
   protected def userAware(
       block: Option[User] => Result
   )(implicit request: Request[Any]): Future[Result] = {
-    val p = Promise[Result]
+    val p = Promise[Result]()
     this.sessionUser(sessionTokenPair) onComplete {
       case Success(result) =>
         Try(block(result)) match {
@@ -169,7 +169,7 @@ class SessionManager @Inject() (
   protected def authenticated(
       execute: Either[User => Result, User => Future[Result]]
   )(implicit request: Request[Any], requireSuperUser: Boolean = false): Future[Result] = {
-    val p = Promise[Result]
+    val p = Promise[Result]()
     try {
       this.sessionUser(sessionTokenPair) onComplete {
         case Success(result) =>
@@ -246,7 +246,7 @@ class SessionManager @Inject() (
   def sessionUser(tokenPair: Option[RequestToken], create: Boolean = false)(
       implicit request: RequestHeader
   ): Future[Option[User]] = {
-    val p      = Promise[Option[User]]
+    val p      = Promise[Option[User]]()
     val userId = request.session.get(SessionManager.KEY_USER_ID)
     val osmId  = request.session.get(SessionManager.KEY_OSM_ID)
     // if in dev mode we just default every request to super user request
@@ -375,7 +375,7 @@ class SessionManager @Inject() (
     *         None.
     */
   def refreshProfile(accessToken: RequestToken, user: User): Future[Option[User]] = {
-    val p = Promise[Option[User]]
+    val p = Promise[Option[User]]()
     // if no user is matched, then lets create a new user
     val details = this.ws
       .url(this.osmOAuth.userDetailsURL)

--- a/test/org/maproulette/cache/CacheSpec.scala
+++ b/test/org/maproulette/cache/CacheSpec.scala
@@ -110,7 +110,7 @@ class CacheSpec extends PlaySpec with JodaWrites with JodaReads {
       manager.withOptionCaching { () =>
         Some(TestBaseObject(1, "name1"))
       }
-      theCache.size mustEqual 0
+      theCache.size() mustEqual 0
     }
 
     "cache only the elements that are not already cached withIDListCaching" in {
@@ -123,7 +123,7 @@ class CacheSpec extends PlaySpec with JodaWrites with JodaReads {
         uncachedList.size mustEqual 2
         uncachedList.map(id => TestBaseObject(id, s"name$id"))
       }
-      theCache.size mustEqual 5
+      theCache.size() mustEqual 5
       theCache.get(5).isDefined mustEqual true
       theCache.get(6).isDefined mustEqual true
     }
@@ -168,7 +168,7 @@ class CacheSpec extends PlaySpec with JodaWrites with JodaReads {
 
       // The cache may have a thread managing the evictions, so we can't expect an exact size.
       // Since we inserted far more items than the capacity, check that some items were evicted.
-      theCache.size must be < 15L
+      theCache.size() must be < 15L
 
       // Add a handful of new objects to the cache, and keep fetching one to keep it from being evicted
       for (id <- 0L until insertN) {

--- a/test/org/maproulette/framework/psql/FilterParameterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterParameterSpec.scala
@@ -23,20 +23,20 @@ class FilterParameterSpec extends PlaySpec {
   "BaseParameter" should {
     "set correctly" in {
       val parameter = BaseParameter(KEY, VALUE)
-      parameter.sql() mustEqual s"$KEY = {${parameter.getKey}}"
+      parameter.sql() mustEqual s"$KEY = {${parameter.getKey()}}"
       val params = parameter.parameters()
       params.size mustEqual 1
-      params.head mustEqual NamedParameter(s"${parameter.getKey}", VALUE)
+      params.head mustEqual NamedParameter(s"${parameter.getKey()}", VALUE)
     }
 
     "set operator correctly" in {
       val parameter = BaseParameter(KEY, VALUE, Operator.GT)
-      parameter.sql() mustEqual s"$KEY > {${parameter.getKey}}"
+      parameter.sql() mustEqual s"$KEY > {${parameter.getKey()}}"
     }
 
     "set negation correctly" in {
       val parameter = BaseParameter(KEY, VALUE, negate = true)
-      parameter.sql() mustEqual s"NOT $KEY = {${parameter.getKey}}"
+      parameter.sql() mustEqual s"NOT $KEY = {${parameter.getKey()}}"
     }
 
     "set negation correctly on Custom operator" in {
@@ -56,7 +56,7 @@ class FilterParameterSpec extends PlaySpec {
 
     "set list correctly using IN operator" in {
       val parameter = BaseParameter(KEY, List(1, 2, 3), Operator.IN)
-      parameter.sql() mustEqual s"$KEY IN ({${parameter.getKey}})"
+      parameter.sql() mustEqual s"$KEY IN ({${parameter.getKey()}})"
     }
 
     "do not set empty list" in {
@@ -67,17 +67,17 @@ class FilterParameterSpec extends PlaySpec {
 
     "set implicit table" in {
       val parameter = BaseParameter(KEY, VALUE, table = Some("TEST"))
-      parameter.sql() mustEqual s"TEST.$KEY = {${parameter.getKey}}"
+      parameter.sql() mustEqual s"TEST.$KEY = {${parameter.getKey()}}"
     }
   }
 
   "ConditionalFilter" should {
     "set correctly if condition true" in {
       val filter = FilterParameter.conditional(KEY, VALUE, includeOnlyIfTrue = true)
-      filter.sql() mustEqual s"$KEY = {${filter.filter.getKey}}"
+      filter.sql() mustEqual s"$KEY = {${filter.filter.getKey()}}"
       val params = filter.parameters()
       params.size mustEqual 1
-      params.head mustEqual NamedParameter(filter.filter.getKey, VALUE)
+      params.head mustEqual NamedParameter(filter.filter.getKey(), VALUE)
     }
 
     "not set if condition is false" in {
@@ -86,13 +86,13 @@ class FilterParameterSpec extends PlaySpec {
 
     "set operator correctly" in {
       val parameter = FilterParameter.conditional(KEY, VALUE, Operator.LT, includeOnlyIfTrue = true)
-      parameter.sql() mustEqual s"$KEY < {${parameter.filter.getKey}}"
+      parameter.sql() mustEqual s"$KEY < {${parameter.filter.getKey()}}"
     }
 
     "set negation correctly" in {
       val parameter =
         FilterParameter.conditional(KEY, VALUE, negate = true, includeOnlyIfTrue = true)
-      parameter.sql() mustEqual s"NOT $KEY = {${parameter.filter.getKey}}"
+      parameter.sql() mustEqual s"NOT $KEY = {${parameter.filter.getKey()}}"
     }
 
     "set value directly correctly" in {
@@ -112,10 +112,10 @@ class FilterParameterSpec extends PlaySpec {
     "set single start date correctly" in {
       val startDate = DateTime.now()
       val filter    = DateParameter(KEY, startDate, null)
-      filter.sql() mustEqual s"$KEY = {${filter.getKey}}"
+      filter.sql() mustEqual s"$KEY = {${filter.getKey()}}"
       val params = filter.parameters()
       params.size mustEqual 1
-      params.head mustEqual SQLUtils.buildNamedParameter(filter.getKey, startDate)
+      params.head mustEqual SQLUtils.buildNamedParameter(filter.getKey(), startDate)
     }
 
     "set two dates correctly" in {
@@ -123,11 +123,11 @@ class FilterParameterSpec extends PlaySpec {
       val startDate = endDate.minus(Months.ONE)
       val filter    = DateParameter(KEY, startDate, endDate, Operator.BETWEEN)
       filter
-        .sql() mustEqual s"$KEY::DATE BETWEEN {${filter.getKey}_date1} AND {${filter.getKey}_date2}"
+        .sql() mustEqual s"$KEY::DATE BETWEEN {${filter.getKey()}_date1} AND {${filter.getKey()}_date2}"
       val params = filter.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(s"${filter.getKey}_date1", startDate)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(s"${filter.getKey}_date2", endDate)
+      params.head mustEqual SQLUtils.buildNamedParameter(s"${filter.getKey()}_date1", startDate)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(s"${filter.getKey()}_date2", endDate)
     }
 
     "set negate correctly on two dates" in {
@@ -139,7 +139,7 @@ class FilterParameterSpec extends PlaySpec {
         negate = true
       )
       parameter
-        .sql() mustEqual s"$KEY::DATE NOT BETWEEN {${parameter.getKey}_date1} AND {${parameter.getKey}_date2}"
+        .sql() mustEqual s"$KEY::DATE NOT BETWEEN {${parameter.getKey()}_date1} AND {${parameter.getKey()}_date2}"
     }
 
     "fail on invalid provided column" in {
@@ -166,11 +166,11 @@ class FilterParameterSpec extends PlaySpec {
         Query.simple(List(parameter), "SELECT * FROM table")
       )
       filter
-        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE Key2 = {${parameter.getKey}})"
+        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE Key2 = {${parameter.getKey()}})"
       val params = filter.parameters()
       params.size mustEqual 1
       params.head mustEqual SQLUtils.buildNamedParameter(
-        s"${parameter.getKey}",
+        s"${parameter.getKey()}",
         "value2"
       )
     }
@@ -181,15 +181,16 @@ class FilterParameterSpec extends PlaySpec {
       val filter =
         SubQueryFilter(KEY, Query.simple(List(parameter1, parameter2), "SELECT * FROM table", OR()))
       filter
-        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE (key2 = {${parameter1.getKey}} OR key3 <= {${parameter2.getKey}}))"
+        .sql() mustEqual s"$KEY IN (SELECT * FROM table WHERE (key2 = {${parameter1
+        .getKey()}} OR key3 <= {${parameter2.getKey()}}))"
       val params = filter.parameters()
       params.size mustEqual 2
       params.head mustEqual SQLUtils.buildNamedParameter(
-        s"${parameter1.getKey}",
+        s"${parameter1.getKey()}",
         "value2"
       )
       params.tail.head mustEqual SQLUtils.buildNamedParameter(
-        s"${parameter2.getKey}",
+        s"${parameter2.getKey()}",
         "value3"
       )
     }
@@ -202,7 +203,7 @@ class FilterParameterSpec extends PlaySpec {
         operator = Operator.EXISTS
       )
       filter
-        .sql() mustEqual s"EXISTS (SELECT * FROM table WHERE key2 = {${parameter.getKey}})"
+        .sql() mustEqual s"EXISTS (SELECT * FROM table WHERE key2 = {${parameter.getKey()}})"
     }
 
     "Set equals subquery filter" in {
@@ -213,7 +214,7 @@ class FilterParameterSpec extends PlaySpec {
         operator = Operator.EQ
       )
       filter
-        .sql() mustEqual s"$KEY = (SELECT * FROM table WHERE key2 = {${parameter.getKey}})"
+        .sql() mustEqual s"$KEY = (SELECT * FROM table WHERE key2 = {${parameter.getKey()}})"
     }
 
     "fail on invalid provided column" in {
@@ -253,7 +254,7 @@ class FilterParameterSpec extends PlaySpec {
         .sql() mustEqual FilterParameterSpec.DEFAULT_FUZZY_SQL(KEY, keyPrefix = filter.randomPrefix)
       val params = filter.parameters()
       params.size mustEqual 1
-      params.head mustEqual SQLUtils.buildNamedParameter(filter.getKey, VALUE)
+      params.head mustEqual SQLUtils.buildNamedParameter(filter.getKey(), VALUE)
     }
 
     "sets fuzzy search with default levenshstein score if less than 1" in {

--- a/test/org/maproulette/framework/psql/FilterSpec.scala
+++ b/test/org/maproulette/framework/psql/FilterSpec.scala
@@ -25,59 +25,61 @@ class FilterSpec extends PlaySpec {
   "FilterGroup" should {
     "Create a group of AND filters parameters" in {
       val group = FilterGroup(List(parameter1, parameter2))
-      group.sql() mustEqual s"KEY = {${parameter1.getKey}} AND KEY2 = {${parameter2.getKey}}"
+      group.sql() mustEqual s"KEY = {${parameter1.getKey()}} AND KEY2 = {${parameter2.getKey()}}"
       val params = group.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey(), VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), VALUE2)
     }
 
     "Create a group of OR filter parameters" in {
       val group =
         FilterGroup(List(parameter1, parameter2), OR())
-      group.sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}})"
+      group.sql() mustEqual s"(KEY = {${parameter1.getKey()}} OR KEY2 = {${parameter2.getKey()}})"
       val params = group.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey(), VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), VALUE2)
     }
   }
 
   "Filter" should {
     "generate standard sql for AND parameters" in {
       val filter = Filter.simple(List(parameter1, parameter2), AND())
-      filter.sql() mustEqual s"KEY = {${parameter1.getKey}} AND KEY2 = {${parameter2.getKey}}"
+      filter.sql() mustEqual s"KEY = {${parameter1.getKey()}} AND KEY2 = {${parameter2.getKey()}}"
       val params = filter.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey(), VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), VALUE2)
     }
 
     "generate standard sql for OR parameters" in {
       val filter = Filter.simple(List(parameter1, parameter2), OR())
-      filter.sql() mustEqual s"(KEY = {${parameter1.getKey}} OR KEY2 = {${parameter2.getKey}})"
+      filter.sql() mustEqual s"(KEY = {${parameter1.getKey()}} OR KEY2 = {${parameter2.getKey()}})"
       val params = filter.parameters()
       params.size mustEqual 2
-      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
-      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey(), VALUE)
+      params.tail.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), VALUE2)
     }
 
     "generate filter groups for AND parameters" in {
       val filter = this.genericFilter(AND(), AND(), AND())
       filter
-        .sql() mustEqual s"(KEY = {${parameter1.getKey}} AND KEY_1 = {${parameter3.getKey}}) AND (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
+        .sql() mustEqual s"(KEY = {${parameter1.getKey()}} AND KEY_1 = {${parameter3
+        .getKey()}}) AND (KEY2 = {${parameter2.getKey()}} AND KEY2_2 = {${parameter4.getKey()}})"
       val params = filter.parameters()
       params.size mustEqual 4
-      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey, VALUE)
-      params(1) mustEqual SQLUtils.buildNamedParameter(parameter3.getKey, VALUE)
-      params(2) mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, VALUE2)
-      params(3) mustEqual SQLUtils.buildNamedParameter(parameter4.getKey, VALUE2)
+      params.head mustEqual SQLUtils.buildNamedParameter(parameter1.getKey(), VALUE)
+      params(1) mustEqual SQLUtils.buildNamedParameter(parameter3.getKey(), VALUE)
+      params(2) mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), VALUE2)
+      params(3) mustEqual SQLUtils.buildNamedParameter(parameter4.getKey(), VALUE2)
     }
 
     "generate filter groups for OR parameters" in {
       val filter = this.genericFilter(OR(), OR(), OR())
       filter
-        .sql() mustEqual s"((KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}})) OR ((KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}}))"
+        .sql() mustEqual s"((KEY = {${parameter1.getKey()}} OR KEY_1 = {${parameter3
+        .getKey()}})) OR ((KEY2 = {${parameter2.getKey()}} OR KEY2_2 = {${parameter4.getKey()}}))"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -85,7 +87,8 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for AND/OR/AND parameters" in {
       val filter = this.genericFilter(OR(), AND(), AND())
       filter
-        .sql() mustEqual s"(KEY = {${parameter1.getKey}} AND KEY_1 = {${parameter3.getKey}}) OR (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
+        .sql() mustEqual s"(KEY = {${parameter1.getKey()}} AND KEY_1 = {${parameter3
+        .getKey()}}) OR (KEY2 = {${parameter2.getKey()}} AND KEY2_2 = {${parameter4.getKey()}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -93,7 +96,8 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR/AND/OR parameters" in {
       val filter = this.genericFilter(AND(), OR(), OR())
       filter
-        .sql() mustEqual s"((KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}})) AND ((KEY2 = {${parameter2.getKey}} OR KEY2_2 = {${parameter4.getKey}}))"
+        .sql() mustEqual s"((KEY = {${parameter1.getKey()}} OR KEY_1 = {${parameter3
+        .getKey()}})) AND ((KEY2 = {${parameter2.getKey()}} OR KEY2_2 = {${parameter4.getKey()}}))"
       val params = filter.parameters()
       params.size mustEqual 4
     }
@@ -101,7 +105,8 @@ class FilterSpec extends PlaySpec {
     "generate filter groups for OR/OR/AND parameters" in {
       val filter = this.genericFilter(OR(), OR(), AND())
       filter
-        .sql() mustEqual s"((KEY = {${parameter1.getKey}} OR KEY_1 = {${parameter3.getKey}})) OR (KEY2 = {${parameter2.getKey}} AND KEY2_2 = {${parameter4.getKey}})"
+        .sql() mustEqual s"((KEY = {${parameter1.getKey()}} OR KEY_1 = {${parameter3
+        .getKey()}})) OR (KEY2 = {${parameter2.getKey()}} AND KEY2_2 = {${parameter4.getKey()}})"
       val params = filter.parameters()
       params.size mustEqual 4
     }

--- a/test/org/maproulette/framework/psql/QuerySpec.scala
+++ b/test/org/maproulette/framework/psql/QuerySpec.scala
@@ -139,23 +139,26 @@ class QuerySpec extends PlaySpec {
     )
 
     query
-      .sql() mustEqual s"""SELECT * FROM table WHERE ((KEY = {$setKey} OR key2 = {${parameter2.getKey}})) AND ((a.g = g.a OR dateField::DATE BETWEEN {${parameter4.getKey}_date1} AND {${parameter4.getKey}_date2})) AND (${FilterParameterSpec
+      .sql() mustEqual s"""SELECT * FROM table WHERE ((KEY = {$setKey} OR key2 = {${parameter2
+      .getKey()}})) AND ((a.g = g.a OR dateField::DATE BETWEEN {${parameter4
+      .getKey()}_date1} AND {${parameter4.getKey()}_date2})) AND (${FilterParameterSpec
       .DEFAULT_FUZZY_SQL(
         "fuzzy",
         keyPrefix = parameter5.randomPrefix
-      )} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {${parameter6.getKey}} LIMIT {${paging1.randomPrefix}limit} OFFSET {${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"""
+      )} AND subQueryKey IN (SELECT * FROM subTable WHERE subsubKey = {${parameter6
+      .getKey()}} LIMIT {${paging1.randomPrefix}limit} OFFSET {${paging1.randomPrefix}offset})) ORDER BY oField DESC LIMIT {${paging2.randomPrefix}limit} OFFSET {${paging2.randomPrefix}offset}"""
     val params = query.parameters()
     params.size mustEqual 10
     params.head mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
-    params(1) mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, "value2")
-    params(2) mustEqual SQLUtils.buildNamedParameter(s"${parameter4.getKey}_date1", firstDate)
-    params(3) mustEqual SQLUtils.buildNamedParameter(s"${parameter4.getKey}_date2", secondDate)
+    params(1) mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), "value2")
+    params(2) mustEqual SQLUtils.buildNamedParameter(s"${parameter4.getKey()}_date1", firstDate)
+    params(3) mustEqual SQLUtils.buildNamedParameter(s"${parameter4.getKey()}_date2", secondDate)
     params(4) mustEqual SQLUtils.buildNamedParameter(
       s"${parameter5.randomPrefix}fuzzy",
       "fuzzyValue"
     )
     params(5) mustEqual SQLUtils.buildNamedParameter(
-      s"${parameter6.getKey}",
+      s"${parameter6.getKey()}",
       "subsubValue"
     )
     params(6) mustEqual SQLUtils.buildNamedParameter(s"${paging1.randomPrefix}limit", 10)
@@ -193,7 +196,7 @@ class QuerySpec extends PlaySpec {
     // Augmented query gets additional parameters
     val params = augmentedQuery.parameters()
     params.size mustEqual 2
-    params.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey, "value2")
+    params.head mustEqual SQLUtils.buildNamedParameter(parameter2.getKey(), "value2")
     params(1) mustEqual SQLUtils.buildNamedParameter(setKey, VALUE)
   }
 

--- a/test/org/maproulette/framework/repository/CommentRepositorySpec.scala
+++ b/test/org/maproulette/framework/repository/CommentRepositorySpec.scala
@@ -22,7 +22,7 @@ class CommentRepositorySpec(implicit val application: Application) extends Frame
 
   "CommentRepository" should {
     "add comment into database" taggedAs CommentRepoTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       val comment =
         this.commentRepository.create(
           User.superUser,
@@ -42,7 +42,7 @@ class CommentRepositorySpec(implicit val application: Application) extends Frame
     }
 
     "update comment in the database" taggedAs CommentRepoTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       val comment = this.commentRepository.create(
         User.superUser,
         defaultTask.id,
@@ -57,7 +57,7 @@ class CommentRepositorySpec(implicit val application: Application) extends Frame
     }
 
     "delete a comment in the database" taggedAs CommentRepoTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       val comment = this.commentRepository.create(
         User.superUser,
         defaultTask.id,
@@ -72,7 +72,7 @@ class CommentRepositorySpec(implicit val application: Application) extends Frame
     }
 
     "find a specific comment" taggedAs CommentRepoTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       this.commentRepository.create(User.superUser, defaultTask.id, "find a specific comment", None)
       val comment =
         this.commentRepository.create(

--- a/test/org/maproulette/framework/service/CommentServiceSpec.scala
+++ b/test/org/maproulette/framework/service/CommentServiceSpec.scala
@@ -18,14 +18,14 @@ class CommentServiceSpec(implicit val application: Application) extends Framewor
 
   "CommentService" should {
     "add comment into database" taggedAs CommentTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       val comment          = this.commentService.create(User.superUser, defaultTask.id, "GP Add", None)
       val retrievedComment = this.commentService.retrieve(comment.id)
       retrievedComment.get mustEqual comment
     }
 
     "update a comment in the database" taggedAs CommentTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       val comment = this.commentService.create(User.superUser, defaultTask.id, "GP update", None)
       this.commentService.update(comment.id, "GP update Test", User.superUser)
       val retrievedComment = this.commentService.retrieve(comment.id)
@@ -65,7 +65,7 @@ class CommentServiceSpec(implicit val application: Application) extends Framewor
     }
 
     "Only super user or original user can update comment" taggedAs CommentTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       intercept[IllegalAccessException] {
         val comment =
           this.commentService.create(User.superUser, defaultTask.id, "Default comment", None)
@@ -74,7 +74,7 @@ class CommentServiceSpec(implicit val application: Application) extends Framewor
     }
 
     "Find comments for a specific project, challenge and task" taggedAs CommentTag in {
-      cancel // TODO(ljdelight): This test needs to be fixed.
+      cancel() // TODO(ljdelight): This test needs to be fixed.
       val comment =
         this.commentService.create(User.superUser, defaultTask.id, "Default Comment", None)
       val projectComments =

--- a/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
+++ b/test/org/maproulette/framework/service/TaskBundleServiceSpec.scala
@@ -219,7 +219,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
         primaryTaskId = Some(task1.id)
       )
 
-      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id))
+      this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id))()
       val response = this.service.getTaskBundle(User.superUser, bundle.bundleId)
       response.taskIds.length mustEqual 1
       response.taskIds.head mustEqual task1.id
@@ -256,7 +256,7 @@ class TaskBundleServiceSpec(implicit val application: Application) extends Frame
 
       // Random user is not allowed to delete this bundle
       an[IllegalAccessException] should be thrownBy
-        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id))
+        this.service.unbundleTasks(randomUser, bundle.bundleId, List(task2.id))()
     }
 
   }


### PR DESCRIPTION
In the spirit of reducing compile warnings to see actual issues, this patch resolves many issues with the "Auto-application to `()` is deprecated" warning. These fixes were auto-applied by using the `scala-rewrites` plugins for `sbt-scalafix` and, for now, scalafix won't be configured to check for this issue during CI.

The full warning looks like this:

    Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method unbundleTasks,
    [warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
    [warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
    [warn]       this.service.unbundleTasks(User.superUser, bundle.bundleId, List(task2.id))

There were some version issues with the plugin were resolved with these steps:

- build.sbt:
  - Set `scalaVersion := "2.13.8"`
  - Add `ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)`
- project/plugins.sbt:
  - Change sbt-scalafix to `addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")`

Now run `scalafixAll dependency:fix.scala213.ExplicitNonNullaryApply@org.scala-lang:scala-rewrites:0.1.3`